### PR TITLE
lmer changes

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.12 (pymc_env)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (pymc_env)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ncpi.iml" filepath="$PROJECT_DIR$/.idea/ncpi.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/ncpi.iml
+++ b/.idea/ncpi.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.12 (pymc_env)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="NUMPY" />
+    <option name="myDocStringFormat" value="NumPy" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/examples/analysis_example.py
+++ b/examples/analysis_example.py
@@ -1,0 +1,73 @@
+
+import numpy as np
+import pandas as pd
+
+from ncpi import Analysis
+
+####################################################################
+# Generate toy data
+
+nsubj, nsensors, nepochs = 10, 3, 5
+id = np.repeat(np.arange(nsubj), 3*5)
+sensor = np.tile(np.repeat(np.arange(3), 5), 10)
+epoch = np.tile(np.arange(5), 3*10)
+data = pd.DataFrame([id, epoch, sensor], index=['id', 'epoch', 'sensor']).T
+data['gr'] = 'HC'
+data.loc[data['id'].isin((4, 5, 6)), 'gr'] = 'g1'
+data.loc[data['id'].isin((7, 8, 9)), 'gr'] = 'g2'
+data['Y'] = np.random.normal(size=10*3*5)
+# Make Y vary with epoch for HC and g1 but not for g2
+data.loc[data['gr']=='g1','Y'] = data.loc[data['gr']=='g1','Y'] + np.random.normal(
+                    loc=1, scale=.5, size = len(data.loc[data['gr']=='g1','Y']))
+data.loc[data['gr']=='g2','Y'] = data.loc[data['gr']=='g2','Y'] + np.random.normal(
+                    loc=3, scale=.5, size = len(data.loc[data['gr']=='g2','Y']))
+data.loc[data['gr']!='g2', 'Y'] = data.loc[data['gr']!='g2', 'Y'] + np.random.normal(
+                                loc=data.loc[data['gr']!='g2', 'epoch'], scale=.5)
+# Include subject-level deviations
+raneff = pd.DataFrame(np.random.normal(loc=0, scale=3, size=nsubj), index=range(nsubj), columns=['raneff'])
+data = data.join(raneff, on='id')
+data['Y'] = data['Y'] + np.random.normal(loc=data['raneff'], scale=.1)
+data.drop(columns='raneff', inplace=True)
+
+####################################################################
+# Run analyses
+
+# Initialise class
+analysis = Analysis(data)
+
+# 1.
+# Reduce random effect structure with BIC
+opt_f = analysis.lmer_selection(data_col='Y', group_col='gr', id_col='id', numeric=['epoch'],
+             full_model='Y~gr*epoch + sensor + (1|id)', random_crit='BIC', fixed_crit=None)
+# Run post-hoc analyses using selected model
+results = analysis.lmer_tests(data_col='Y', group_col='gr', control_group='HC', id_col='id', numeric=['epoch'],
+                                models=opt_f, specs=['gr', 'gr:epoch'])
+
+
+# 2.
+# Reduce random effect structure with BIC and fixed effect structure with LRT (anova)
+opt_f = analysis.lmer_selection(data_col='Y', group_col='gr', id_col='id', numeric=['epoch'],
+             full_model='Y~gr*epoch + sensor + (1|id)', random_crit='BIC', fixed_crit='LRT')
+# Run post-hoc analyses using selected model
+results = analysis.lmer_tests(data_col='Y', group_col='gr', control_group='HC', id_col='id', numeric=['epoch'],
+                                models=opt_f, specs=['gr', 'gr:epoch'])
+
+
+# 3.
+# Reduce random effect structure with BIC and fixed effect structure with LRT (anova),
+# but always keeping the sensor term in the model
+opt_f = analysis.lmer_selection(data_col='Y', group_col='gr', id_col='id', numeric=['epoch'],
+             full_model='Y~gr*epoch + sensor + (1|id)', random_crit='BIC', fixed_crit='LRT', include=['sensor'])
+# Run post-hoc analyses using selected model
+results = analysis.lmer_tests(data_col='Y', group_col='gr', control_group='HC', id_col='id', numeric=['epoch'],
+                                models=opt_f, specs=['gr', 'gr:epoch'])
+
+
+# 4.
+# Use BIC to compare only a specified set of possible models
+# (i.e., without exploring all their subsets via backward selection),
+# then run post-hoc analyses
+results = analysis.lmer_tests(data_col='Y', group_col='gr', control_group='HC', id_col='id', numeric=['epoch'],
+                models=['Y~ gr*epoch + (1|sensor) + (1|id)',
+                        'Y~ gr*epoch + sensor + (1|id)'],  # Best model is selected using BIC
+                specs=['gr', 'gr:epoch'])

--- a/examples/analysis_example.py
+++ b/examples/analysis_example.py
@@ -29,6 +29,8 @@ data = data.join(raneff, on='id')
 data['Y'] = data['Y'] + np.random.normal(loc=data['raneff'], scale=.1)
 data.drop(columns='raneff', inplace=True)
 
+print(data.head())
+
 ####################################################################
 # Run analyses
 
@@ -37,37 +39,40 @@ analysis = Analysis(data)
 
 # 1.
 # Reduce random effect structure with BIC
-opt_f = analysis.lmer_selection(data_col='Y', group_col='gr', id_col='id', numeric=['epoch'],
-             full_model='Y~gr*epoch + sensor + (1|id)', random_crit='BIC', fixed_crit=None)
+opt_f = analysis.lmer_selection(full_model='Y ~ gr*epoch + sensor + (1|id)',
+                                numeric=['epoch'],
+                                random_crit='BIC', fixed_crit=None)
 # Run post-hoc analyses using selected model
-results = analysis.lmer_tests(data_col='Y', group_col='gr', control_group='HC', id_col='id', numeric=['epoch'],
-                                models=opt_f, specs=['gr', 'gr:epoch'])
+results = analysis.lmer_tests(models=opt_f, group_col='gr', control_group='HC',
+                              numeric=['epoch'], specs=['gr', 'gr:epoch'])
 
 
 # 2.
 # Reduce random effect structure with BIC and fixed effect structure with LRT (anova)
-opt_f = analysis.lmer_selection(data_col='Y', group_col='gr', id_col='id', numeric=['epoch'],
-             full_model='Y~gr*epoch + sensor + (1|id)', random_crit='BIC', fixed_crit='LRT')
+opt_f = analysis.lmer_selection(full_model='Y~gr*epoch + sensor + (1|id)',
+                                numeric=['epoch'],
+                                random_crit='BIC', fixed_crit='LRT')
 # Run post-hoc analyses using selected model
-results = analysis.lmer_tests(data_col='Y', group_col='gr', control_group='HC', id_col='id', numeric=['epoch'],
-                                models=opt_f, specs=['gr', 'gr:epoch'])
+results = analysis.lmer_tests(models=opt_f, group_col='gr', control_group='HC',
+                              numeric=['epoch'], specs=['gr', 'gr:epoch'])
 
 
 # 3.
 # Reduce random effect structure with BIC and fixed effect structure with LRT (anova),
 # but always keeping the sensor term in the model
-opt_f = analysis.lmer_selection(data_col='Y', group_col='gr', id_col='id', numeric=['epoch'],
-             full_model='Y~gr*epoch + sensor + (1|id)', random_crit='BIC', fixed_crit='LRT', include=['sensor'])
+opt_f = analysis.lmer_selection(full_model='Y~gr*epoch + sensor + (1|id)',
+                                numeric=['epoch'],
+                                random_crit='BIC', fixed_crit='LRT', include=['sensor'])
 # Run post-hoc analyses using selected model
-results = analysis.lmer_tests(data_col='Y', group_col='gr', control_group='HC', id_col='id', numeric=['epoch'],
-                                models=opt_f, specs=['gr', 'gr:epoch'])
+results = analysis.lmer_tests(models=opt_f, group_col='gr', control_group='HC',
+                              numeric=['epoch'], specs=['gr', 'gr:epoch'])
 
 
 # 4.
 # Use BIC to compare only a specified set of possible models
 # (i.e., without exploring all their subsets via backward selection),
 # then run post-hoc analyses
-results = analysis.lmer_tests(data_col='Y', group_col='gr', control_group='HC', id_col='id', numeric=['epoch'],
-                models=['Y~ gr*epoch + (1|sensor) + (1|id)',
-                        'Y~ gr*epoch + sensor + (1|id)'],  # Best model is selected using BIC
+results = analysis.lmer_tests(models=['Y~ gr*epoch + (1|sensor) + (1|id)',
+                                      'Y~ gr*epoch + sensor + (1|id)'],  # Best model is selected using BIC
+                group_col='gr', control_group='HC', numeric=['epoch'],
                 specs=['gr', 'gr:epoch'])


### PR DESCRIPTION
**Main changes**

- Model selection: as discussed (**see below***). I split the `lmer` function into a `lmer_selection` function and a `lmer_tests` function. The `lmer_selection` function implements model selection in the “old way” (BIC for random effects + LRT backward selection for fixed effects) but can be customised to only do the BIC part (or the LRT part, or some different methods). I used existing R library `buildmer` - the backward selection process is super annoying to implement, no need to do it from scratch…I didn’t keep the code from the original `lmer` function as it required the user to specify all anova comparisons in advance, which is not what is normally done when using LRT model selection (i.e., anovas).
The `lmer_tests` function runs some `emmeans` and `emtrends` comparisons using the provided model. If more than one model is provided, it chooses which one to use based on BIC and then runs the tests on the selected model.
Several possible modelling strategies can be implemented using these two functions - it’s best explained by examples, see **examples/analysis_example.py** (I put the script there for now, feel free to move it / remove it).

- Fitting a new model for each pairwise comparison (group1 vs. HC, group2 vs. HC, ...) is not good practice. Better to fit a single model with the group as a multilevel factor, and then implement pairwise comparisons as a post-hoc analysis.

- The output of `lmer_tests` is now a dictionary where the keys are the different specs required by the user.

- I removed `other_col`. The code gets the variables from formulas directly, so the user doesn't have to specify things twice -- they just give the formulas they need and the data gets checked for those variables. Names for group and ID variables can be specified by the user  through `group_col` and `id_col` (instead of requiring them to be 'Group' and 'ID', so they don't have to rename them in their data). Also no need to rename `data_col` to `'Y'`.


**Questions**

- I don't get what `data_index` does. I left it as it was in the code.

- force categorical data type for `'Sensor`': is it necessary? It's a bit artificial, and very specific…if necessary, then we may add a `sensor_col` argument where the user can specify the name they used (if any) for the sensor?

- remove rows where `data_col` is zero - why?

---


**(*) Model selection strategy:**
**Old:**
- create full model with all possible predictors you can think of
- select random effect structure with BIC
- starting from selected model, recursively apply likelihood ratio tests to reduce fixed effect structure and only keep significant predictors
- do your post hoc stats on final model. Non-significant predictors have been removed from the model so we already know that the effect of those remaining is significant - we only need to quantify it.

**New:**
- create full model with all predictors that you can reasonably expect to have an effect on the dependent variable
- select random effect structure with BIC
- do your post hoc stats on that model. Fixed effect structure still includes all predictors, and the significance of the effects is established via post hoc tests.

**Motivation:** 
iterative use of statistical inference for selection of variables is a flawed approach to design multivariable models, as it invalidates the assumptions of inference (which assume a fixed model, not one selected based on the data) and it induces selection bias. Also, with this approach, variables that are not “significantly” associated with the outcome (albeit the model would be underpowered for at least some of them) are not accounted for even if they are true confounders of the relationship of interest. Instead, a multivariable model should be built based on the known and anticipated causal relationships. 