### PR TITLE
add t0/t1 temporal segmentation controls to parser config

### DIFF
--- a/ncpi/EphysDatasetParser.py
+++ b/ncpi/EphysDatasetParser.py
@@ -318,6 +318,12 @@ class ParseConfig:
     epoch_length_s: Optional[float] = None
     epoch_step_s: Optional[float] = None
 
+    # Optional temporal segmentation (applied before epoching), in seconds.
+    # Example:
+    #   segment_t0_s=10.0, segment_t1_s=60.0 -> keep only [10, 60]s from each row.
+    segment_t0_s: Optional[float] = None
+    segment_t1_s: Optional[float] = None
+
     # MNE-specific operational options (only used if input is MNE or you load with MNE)
     preload: bool = True
     pick_types: Optional[Dict[str, bool]] = None
@@ -383,6 +389,10 @@ class EphysDatasetParser:
 
         # 1) Parse raw rows (one row per sensor / epoch)
         rows = self._parse_object(obj, source_file=source_file)
+
+        # 1b) Optional temporal segmentation BEFORE z-score/aggregation/epoching
+        rows = self._apply_time_segment_rows(rows)
+
         df = self._rows_to_df(rows)
 
         # 2) Optional z-scoring BEFORE epoching (default behavior)
@@ -1461,6 +1471,11 @@ class EphysDatasetParser:
             )
 
             # Use a string epoch id if base_epoch already exists
+            base_t0 = row.get("t0")
+            try:
+                base_t0 = float(base_t0) if base_t0 is not None else 0.0
+            except Exception:
+                base_t0 = 0.0
             for k, start in enumerate(range(0, x.shape[0] - win + 1, step)):
                 seg = x[start: start + win]
 
@@ -1474,10 +1489,124 @@ class EphysDatasetParser:
                     r["epoch"] = f"{base_epoch}:{k}"
 
                 # time bounds for this epoch
-                r["t0"] = float(start / fs)
-                r["t1"] = float((start + win - 1) / fs)
+                r["t0"] = float(base_t0 + (start / fs))
+                r["t1"] = float(base_t0 + ((start + win - 1) / fs))
 
                 out.append(r)
+
+        return out
+
+    def _apply_time_segment_rows(self, rows: list[dict]) -> list[dict]:
+        """Crop each time-domain row to [segment_t0_s, segment_t1_s] before epoching."""
+        t0_cfg = self.config.segment_t0_s
+        t1_cfg = self.config.segment_t1_s
+        if t0_cfg is None and t1_cfg is None:
+            return rows
+
+        if t0_cfg is not None:
+            t0_cfg = float(t0_cfg)
+        if t1_cfg is not None:
+            t1_cfg = float(t1_cfg)
+        if t0_cfg is not None and t1_cfg is not None and t1_cfg <= t0_cfg:
+            raise ValueError("Temporal segmentation requires segment_t1_s > segment_t0_s.")
+
+        out: list[dict] = []
+        eps = 1e-12
+        for row in rows:
+            data_domain = row.get("data_domain") or "time"
+            if data_domain != "time":
+                out.append(row)
+                continue
+
+            x = row.get("data")
+            if x is None:
+                out.append(row)
+                continue
+            x = np.asarray(x)
+            if x.ndim != 1 or x.size == 0:
+                out.append(row)
+                continue
+
+            n = int(x.shape[0])
+            fs = row.get("fs", None)
+            fs_val: Optional[float] = None
+            try:
+                fs_float = float(fs)
+                if np.isfinite(fs_float) and fs_float > 0:
+                    fs_val = fs_float
+            except Exception:
+                fs_val = None
+
+            row_t0 = row.get("t0", None)
+            row_t1 = row.get("t1", None)
+            try:
+                row_t0_val = float(row_t0) if row_t0 is not None else 0.0
+            except Exception:
+                row_t0_val = 0.0
+            try:
+                row_t1_val = float(row_t1) if row_t1 is not None else None
+            except Exception:
+                row_t1_val = None
+
+            if row_t1_val is None:
+                if fs_val is not None and n > 0:
+                    row_t1_val = float(row_t0_val + (n - 1) / fs_val)
+                else:
+                    # Cannot infer temporal support: keep as-is.
+                    out.append(row)
+                    continue
+
+            seg_t0 = t0_cfg if t0_cfg is not None else row_t0_val
+            seg_t1 = t1_cfg if t1_cfg is not None else row_t1_val
+            # Clip requested interval to this row's support.
+            clip_t0 = max(float(seg_t0), float(row_t0_val))
+            clip_t1 = min(float(seg_t1), float(row_t1_val))
+            if clip_t1 <= clip_t0:
+                # No overlap for this row: drop it.
+                continue
+
+            if fs_val is not None:
+                i0 = int(np.ceil(((clip_t0 - row_t0_val) * fs_val) - eps))
+                i1 = int(np.floor(((clip_t1 - row_t0_val) * fs_val) + eps))
+                i0 = max(0, min(i0, n - 1))
+                i1 = max(0, min(i1, n - 1))
+                if i1 < i0:
+                    continue
+                y = x[i0:i1 + 1]
+                r = dict(row)
+                r["data"] = np.asarray(y)
+                r["t0"] = float(row_t0_val + (i0 / fs_val))
+                r["t1"] = float(row_t0_val + (i1 / fs_val))
+                out.append(r)
+                continue
+
+            # Fallback when fs is missing: infer dt from row t0/t1 and array length.
+            if n <= 1:
+                if clip_t0 <= row_t0_val <= clip_t1:
+                    r = dict(row)
+                    r["data"] = np.asarray(x[:1])
+                    r["t0"] = float(row_t0_val)
+                    r["t1"] = float(row_t0_val)
+                    out.append(r)
+                continue
+
+            dt = (row_t1_val - row_t0_val) / float(n - 1)
+            if not np.isfinite(dt) or dt <= 0:
+                out.append(row)
+                continue
+
+            i0 = int(np.ceil(((clip_t0 - row_t0_val) / dt) - eps))
+            i1 = int(np.floor(((clip_t1 - row_t0_val) / dt) + eps))
+            i0 = max(0, min(i0, n - 1))
+            i1 = max(0, min(i1, n - 1))
+            if i1 < i0:
+                continue
+            y = x[i0:i1 + 1]
+            r = dict(row)
+            r["data"] = np.asarray(y)
+            r["t0"] = float(row_t0_val + i0 * dt)
+            r["t1"] = float(row_t0_val + i1 * dt)
+            out.append(r)
 
         return out
 

--- a/webui/app.py
+++ b/webui/app.py
@@ -3368,6 +3368,8 @@ def _copy_parse_config(base_cfg, *, fields):
         fields=fields,
         epoch_length_s=base_cfg.epoch_length_s,
         epoch_step_s=base_cfg.epoch_step_s,
+        segment_t0_s=base_cfg.segment_t0_s,
+        segment_t1_s=base_cfg.segment_t1_s,
         preload=base_cfg.preload,
         pick_types=base_cfg.pick_types,
         max_seconds=base_cfg.max_seconds,
@@ -3731,8 +3733,16 @@ def _build_parse_config_from_form(form):
     aggregate_enabled = str(form.get("parser_enable_aggregate", "")).lower() in {"1", "true", "on", "yes"}
     epoch_length_s = _optional_float(form.get("parser_epoch_length_s")) if epoching_enabled else None
     epoch_step_s = _optional_float(form.get("parser_epoch_step_s")) if epoching_enabled else None
+    segment_t0_s = _optional_float(form.get("parser_segment_t0_s"))
+    segment_t1_s = _optional_float(form.get("parser_segment_t1_s"))
     if epoching_enabled and (epoch_length_s is None or epoch_step_s is None):
         raise ValueError("Epoching is enabled. Provide both epoch length and epoch step in seconds.")
+    if (
+        segment_t0_s is not None
+        and segment_t1_s is not None
+        and float(segment_t1_s) <= float(segment_t0_s)
+    ):
+        raise ValueError("Temporal segmentation requires end time > start time.")
 
     aggregate_over = None
     aggregate_method = "sum"
@@ -3914,6 +3924,8 @@ def _build_parse_config_from_form(form):
             fields=fields,
             epoch_length_s=epoch_length_s,
             epoch_step_s=epoch_step_s,
+            segment_t0_s=segment_t0_s,
+            segment_t1_s=segment_t1_s,
             zscore=zscore,
             aggregate_over=aggregate_over,
             aggregate_method=aggregate_method,
@@ -3950,6 +3962,8 @@ def _build_parse_config_from_form(form):
         fields=fields,
         epoch_length_s=epoch_length_s,
         epoch_step_s=epoch_step_s,
+        segment_t0_s=segment_t0_s,
+        segment_t1_s=segment_t1_s,
         zscore=zscore,
         aggregate_over=aggregate_over,
         aggregate_method=aggregate_method,
@@ -9949,6 +9963,15 @@ def start_computation_redirect(computation_type):
             if _optional_float(request.form.get("parser_epoch_step_s")) is None:
                 flash('Set an epoch step in seconds.', 'error')
                 return redirect(request.referrer or url_for('features_methods'))
+        seg_t0 = _optional_float(request.form.get("parser_segment_t0_s"))
+        seg_t1 = _optional_float(request.form.get("parser_segment_t1_s"))
+        if (
+            seg_t0 is not None
+            and seg_t1 is not None
+            and float(seg_t1) <= float(seg_t0)
+        ):
+            flash('Temporal segmentation requires end time greater than start time.', 'error')
+            return redirect(request.referrer or url_for('features_methods'))
 
         if data_source_kind == "pipeline":
             if uploaded_files:

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -133,6 +133,8 @@
             parserEnableEpoching: false,
             parserEpochLengthS: '5.0',
             parserEpochStepS: '5.0',
+            parserSegmentT0S: '',
+            parserSegmentT1S: '',
             parserZscore: false,
             parserEnableAggregate: false,
             parserAggregateOverSelected: ['sensor'],
@@ -276,6 +278,8 @@
                     'parserEnableEpoching',
                     'parserEpochLengthS',
                     'parserEpochStepS',
+                    'parserSegmentT0S',
+                    'parserSegmentT1S',
                     'parserZscore',
                     'parserEnableAggregate',
                     'parserAggregateOverSelected',
@@ -1257,6 +1261,7 @@
                 const kind = this.resolvedDataSourceKind();
                 if (!this.selectedMethod) return false;
                 if (!this.parserDataLocator) return false;
+                if (this.segmentBoundsInvalid()) return false;
                 if (this.parserEnableAggregate && (!Array.isArray(this.parserAggregateOverSelected) || this.parserAggregateOverSelected.length === 0)) return false;
                 const fsSource = String(this.parserFsSource || '').trim();
                 if (!fsSource) return false;
@@ -1282,6 +1287,17 @@
                     return true;
                 }
                 return false;
+            },
+            optionalFiniteNumber(value) {
+                const raw = String(value ?? '').trim();
+                if (!raw) return null;
+                const num = Number.parseFloat(raw);
+                return Number.isFinite(num) ? num : null;
+            },
+            segmentBoundsInvalid() {
+                const t0 = this.optionalFiniteNumber(this.parserSegmentT0S);
+                const t1 = this.optionalFiniteNumber(this.parserSegmentT1S);
+                return t0 !== null && t1 !== null && t1 <= t0;
             },
             epochsDefinedByAxes() {
                 return this.parserArrayAxesEnabled && String(this.parserAxisEpochs) !== '-1';
@@ -1375,6 +1391,8 @@
                 this.parserEnableEpoching = false;
                 this.parserEpochLengthS = '5.0';
                 this.parserEpochStepS = '5.0';
+                this.parserSegmentT0S = '';
+                this.parserSegmentT1S = '';
                 this.parserZscore = false;
                 this.parserEnableAggregate = false;
                 this.parserAggregateOverSelected = ['sensor'];
@@ -2092,6 +2110,8 @@
                 const epochEnabled = !!this.parserEnableEpoching;
                 const epochLength = this.parserEpochLengthS || '5.0';
                 const epochStep = this.parserEpochStepS || '5.0';
+                const segmentT0 = String(this.parserSegmentT0S || '').trim();
+                const segmentT1 = String(this.parserSegmentT1S || '').trim();
                 const toPyString = (value) => "'" + String(value || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'";
                 const chSource = String(this.parserChNamesSource || '').trim();
                 let chNamesExpr = 'None';
@@ -2183,6 +2203,12 @@
                         lines.push('        },');
                     }
                     lines.push('    ),');
+                    if (segmentT0) {
+                        lines.push(`    segment_t0_s=${segmentT0},`);
+                    }
+                    if (segmentT1) {
+                        lines.push(`    segment_t1_s=${segmentT1},`);
+                    }
                     if (epochEnabled) {
                         lines.push(`    epoch_length_s=${epochLength},`);
                         lines.push(`    epoch_step_s=${epochStep},`);
@@ -2267,6 +2293,12 @@
                     lines.push('        },');
                 }
                 lines.push('    ),');
+                if (segmentT0) {
+                    lines.push(`    segment_t0_s=${segmentT0},`);
+                }
+                if (segmentT1) {
+                    lines.push(`    segment_t1_s=${segmentT1},`);
+                }
                 if (epochEnabled) {
                     lines.push(`    epoch_length_s=${epochLength},`);
                     lines.push(`    epoch_step_s=${epochStep},`);
@@ -3523,6 +3555,29 @@
                                         Apply z-score normalization
                                     </label>
 
+                                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                        <label class="text-sm">
+                                            <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Segment start time (s)</span>
+                                            <input type="number" step="any" name="parser_segment_t0_s" x-model="parserSegmentT0S"
+                                                placeholder="Optional (e.g., 10)"
+                                                class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm"
+                                                :class="segmentBoundsInvalid() ? 'border-red-400 dark:border-red-500' : ''">
+                                        </label>
+                                        <label class="text-sm">
+                                            <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Segment end time (s)</span>
+                                            <input type="number" step="any" name="parser_segment_t1_s" x-model="parserSegmentT1S"
+                                                placeholder="Optional (e.g., 60)"
+                                                class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm"
+                                                :class="segmentBoundsInvalid() ? 'border-red-400 dark:border-red-500' : ''">
+                                        </label>
+                                    </div>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                                        Optional temporal segmentation applied before epoching. Leave empty to use the full signal.
+                                    </p>
+                                    <p x-show="segmentBoundsInvalid()" x-cloak class="text-xs text-red-600 dark:text-red-400">
+                                        End time must be greater than start time.
+                                    </p>
+
                                 </div>
 
                                 <div x-show="resolvedDataSourceKind() === 'new-empirical'" class="space-y-4">
@@ -3744,11 +3799,34 @@
                                         </label>
                                     </div>
 
-                                    <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-300">
-                                        <input type="checkbox" x-model="parserZscore"
+                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-300">
+                                    <input type="checkbox" x-model="parserZscore"
                                         class="rounded border-gray-300 text-primary focus:ring-primary/50">
-                                        Apply z-score normalization
+                                    Apply z-score normalization
+                                </label>
+
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Segment start time (s)</span>
+                                        <input type="number" step="any" name="parser_segment_t0_s" x-model="parserSegmentT0S"
+                                            placeholder="Optional (e.g., 10)"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm"
+                                            :class="segmentBoundsInvalid() ? 'border-red-400 dark:border-red-500' : ''">
                                     </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Segment end time (s)</span>
+                                        <input type="number" step="any" name="parser_segment_t1_s" x-model="parserSegmentT1S"
+                                            placeholder="Optional (e.g., 60)"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm"
+                                            :class="segmentBoundsInvalid() ? 'border-red-400 dark:border-red-500' : ''">
+                                    </label>
+                                </div>
+                                <p class="text-xs text-gray-500 dark:text-gray-400">
+                                    Optional temporal segmentation applied before epoching. Leave empty to use the full signal.
+                                </p>
+                                <p x-show="segmentBoundsInvalid()" x-cloak class="text-xs text-red-600 dark:text-red-400">
+                                    End time must be greater than start time.
+                                </p>
 
                                 </div>
 


### PR DESCRIPTION
This PR implements temporal segmentation (`t0` / `t1`) in the Features WebUI parser flow, so users can crop each signal to a selected time window **before** epoching.  
It also fixes the UI placement so these controls are available in the flows used for feature computation (`Continue simulation pipeline` and `New data`).

## What Changed

### 1. Parser support for temporal segmentation
- Added optional `ParseConfig` fields:
  - `segment_t0_s`
  - `segment_t1_s`
- Applied segmentation at row level before z-score, aggregation, and epoching.
- Segmentation behavior:
  - Works on time-domain rows.
  - Clips to row support.
  - Drops rows with no overlap.
  - Supports both:
    - explicit `fs` (sample-accurate crop)
    - fallback using `t0/t1` when `fs` is missing.
- Updated epoching time bounds to preserve absolute time reference (`base_t0`) after segmentation.

### 2. Backend form-to-parser wiring (WebUI)
- Read new form fields:
  - `parser_segment_t0_s`
  - `parser_segment_t1_s`
- Added validation for invalid ranges (`t1 <= t0`) in:
  - parse-config builder
  - feature compute route pre-check (flash error)
- Ensured these fields are preserved when parse configs are copied internally.

### 3. Frontend UI + UX updates
- Added parser controls:
  - `Segment start time (s)`
  - `Segment end time (s)`
- Added helper text clarifying segmentation is optional and applied before epoching.
- Added inline visual validation when `t1 <= t0`.
- Disabled compute submission when bounds are invalid.
- Included these values in parser debug preview output.
- Fixed placement so controls appear in the relevant `Compute new features` flows (not only in empirical-specific block).
