### PR TITLE
rename "Epochs axis" to "Trials/Epochs axis" and allow epoching even when trials axis is defined

### DIFF
--- a/ncpi/EphysDatasetParser.py
+++ b/ncpi/EphysDatasetParser.py
@@ -385,6 +385,17 @@ class EphysDatasetParser:
         Parse a source (path or in-memory object) into a pandas DataFrame
         with DEFAULT_COLUMNS.
         """
+        if (
+            self.config.epoch_length_s is not None
+            and self.config.segment_t0_s is not None
+            and self.config.segment_t1_s is not None
+        ):
+            seg_len = float(self.config.segment_t1_s) - float(self.config.segment_t0_s)
+            if seg_len < float(self.config.epoch_length_s):
+                raise ValueError(
+                    "Temporal segmentation window must be at least as long as epoch_length_s when epoching is enabled."
+                )
+
         obj, source_file = self._load_source(source)
 
         # 1) Parse raw rows (one row per sensor / epoch)
@@ -1507,10 +1518,16 @@ class EphysDatasetParser:
             t0_cfg = float(t0_cfg)
         if t1_cfg is not None:
             t1_cfg = float(t1_cfg)
+        if t0_cfg is not None and t0_cfg < 0:
+            raise ValueError("Temporal segmentation requires non-negative segment_t0_s.")
+        if t1_cfg is not None and t1_cfg < 0:
+            raise ValueError("Temporal segmentation requires non-negative segment_t1_s.")
         if t0_cfg is not None and t1_cfg is not None and t1_cfg <= t0_cfg:
             raise ValueError("Temporal segmentation requires segment_t1_s > segment_t0_s.")
 
         out: list[dict] = []
+        has_segmentable_time_row = False
+        has_overlapping_time_row = False
         eps = 1e-12
         for row in rows:
             data_domain = row.get("data_domain") or "time"
@@ -1556,6 +1573,7 @@ class EphysDatasetParser:
                     out.append(row)
                     continue
 
+            has_segmentable_time_row = True
             seg_t0 = t0_cfg if t0_cfg is not None else row_t0_val
             seg_t1 = t1_cfg if t1_cfg is not None else row_t1_val
             # Clip requested interval to this row's support.
@@ -1578,6 +1596,7 @@ class EphysDatasetParser:
                 r["t0"] = float(row_t0_val + (i0 / fs_val))
                 r["t1"] = float(row_t0_val + (i1 / fs_val))
                 out.append(r)
+                has_overlapping_time_row = True
                 continue
 
             # Fallback when fs is missing: infer dt from row t0/t1 and array length.
@@ -1588,6 +1607,7 @@ class EphysDatasetParser:
                     r["t0"] = float(row_t0_val)
                     r["t1"] = float(row_t0_val)
                     out.append(r)
+                    has_overlapping_time_row = True
                 continue
 
             dt = (row_t1_val - row_t0_val) / float(n - 1)
@@ -1607,6 +1627,12 @@ class EphysDatasetParser:
             r["t0"] = float(row_t0_val + i0 * dt)
             r["t1"] = float(row_t0_val + i1 * dt)
             out.append(r)
+            has_overlapping_time_row = True
+
+        if has_segmentable_time_row and not has_overlapping_time_row:
+            raise ValueError(
+                "Temporal segmentation window does not overlap with any time-domain samples in the loaded data."
+            )
 
         return out
 

--- a/webui/app.py
+++ b/webui/app.py
@@ -3738,12 +3738,26 @@ def _build_parse_config_from_form(form):
     segment_t1_s = _optional_float(form.get("parser_segment_t1_s"))
     if epoching_enabled and (epoch_length_s is None or epoch_step_s is None):
         raise ValueError("Epoching is enabled. Provide both epoch length and epoch step in seconds.")
+    if segment_t0_s is not None and float(segment_t0_s) < 0:
+        raise ValueError("Temporal segmentation start time must be non-negative.")
+    if segment_t1_s is not None and float(segment_t1_s) < 0:
+        raise ValueError("Temporal segmentation end time must be non-negative.")
     if (
         segment_t0_s is not None
         and segment_t1_s is not None
         and float(segment_t1_s) <= float(segment_t0_s)
     ):
         raise ValueError("Temporal segmentation requires end time > start time.")
+    if (
+        epoching_enabled
+        and epoch_length_s is not None
+        and segment_t0_s is not None
+        and segment_t1_s is not None
+        and (float(segment_t1_s) - float(segment_t0_s)) < float(epoch_length_s)
+    ):
+        raise ValueError(
+            "When epoching is enabled, temporal segmentation window must be at least as long as epoch length."
+        )
 
     aggregate_over = None
     aggregate_method = "sum"
@@ -3832,11 +3846,6 @@ def _build_parse_config_from_form(form):
             array_axes["epochs"] = axis_epochs
         if axis_ids >= 0:
             array_axes["ids"] = axis_ids
-            # Data is already pre-epoched: disable parser-level epoching
-        if axis_epochs >= 0:
-            epoching_enabled = False
-            epoch_length_s = None
-            epoch_step_s = None
 
     sensor_names = _parse_sensor_names(form.get("parser_sensor_names"))
     ch_names_source = (form.get("parser_ch_names_source") or "").strip()
@@ -9957,8 +9966,10 @@ def start_computation_redirect(computation_type):
             flash('Select the data locator for EphysDatasetParser.', 'error')
             return redirect(request.referrer or url_for('features_methods'))
         epoching_enabled = str(request.form.get("parser_enable_epoching", "")).lower() in {"1", "true", "on", "yes"}
+        epoch_length_value = None
         if epoching_enabled:
-            if _optional_float(request.form.get("parser_epoch_length_s")) is None:
+            epoch_length_value = _optional_float(request.form.get("parser_epoch_length_s"))
+            if epoch_length_value is None:
                 flash('Set an epoch length in seconds.', 'error')
                 return redirect(request.referrer or url_for('features_methods'))
             if _optional_float(request.form.get("parser_epoch_step_s")) is None:
@@ -9966,12 +9977,27 @@ def start_computation_redirect(computation_type):
                 return redirect(request.referrer or url_for('features_methods'))
         seg_t0 = _optional_float(request.form.get("parser_segment_t0_s"))
         seg_t1 = _optional_float(request.form.get("parser_segment_t1_s"))
+        if seg_t0 is not None and float(seg_t0) < 0:
+            flash('Temporal segmentation start time must be non-negative.', 'error')
+            return redirect(request.referrer or url_for('features_methods'))
+        if seg_t1 is not None and float(seg_t1) < 0:
+            flash('Temporal segmentation end time must be non-negative.', 'error')
+            return redirect(request.referrer or url_for('features_methods'))
         if (
             seg_t0 is not None
             and seg_t1 is not None
             and float(seg_t1) <= float(seg_t0)
         ):
             flash('Temporal segmentation requires end time greater than start time.', 'error')
+            return redirect(request.referrer or url_for('features_methods'))
+        if (
+            epoching_enabled
+            and epoch_length_value is not None
+            and seg_t0 is not None
+            and seg_t1 is not None
+            and (float(seg_t1) - float(seg_t0)) < float(epoch_length_value)
+        ):
+            flash('Segment duration must be at least as long as epoch length when epoching is enabled.', 'error')
             return redirect(request.referrer or url_for('features_methods'))
 
         if data_source_kind == "pipeline":

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -1257,36 +1257,41 @@
                 this.parserDataLocator = preferred || allowed[0] || '';
             },
             canSubmitFeatures() {
-                if (this.submitInProgress) return false;
+                return !this.computeSubmitBlockReason();
+            },
+            computeSubmitBlockReason() {
+                if (this.submitInProgress) return '';
                 const kind = this.resolvedDataSourceKind();
-                if (!this.selectedMethod) return false;
-                if (!this.parserDataLocator) return false;
-                if (this.segmentBoundsInvalid()) return false;
-                if (this.parserEnableAggregate && (!Array.isArray(this.parserAggregateOverSelected) || this.parserAggregateOverSelected.length === 0)) return false;
+                if (!this.selectedMethod) return 'Select a feature method in "Select Method".';
+                if (!this.parserDataLocator) return 'Select a Data locator in EphysDatasetParser configuration.';
+                if (this.segmentBoundsInvalid()) return this.segmentValidationError();
+                if (this.parserEnableAggregate && (!Array.isArray(this.parserAggregateOverSelected) || this.parserAggregateOverSelected.length === 0)) {
+                    return 'Aggregation is enabled but no aggregate-over field is selected.';
+                }
                 const fsSource = String(this.parserFsSource || '').trim();
-                if (!fsSource) return false;
-                if (fsSource === '__numeric__' && !String(this.parserFsManual || '').trim()) return false;
+                if (!fsSource) return 'Select a sampling frequency source.';
+                if (fsSource === '__numeric__' && !String(this.parserFsManual || '').trim()) return 'Provide a numeric sampling frequency value.';
                 const recSource = String(this.parserRecordingTypeSource || '').trim();
-                if (!recSource) return false;
-                if (recSource === '__value__' && !String(this.parserRecordingType || '').trim()) return false;
+                if (!recSource) return 'Select a recording type source.';
+                if (recSource === '__value__' && !String(this.parserRecordingType || '').trim()) return 'Select a recording type value.';
                 const chSource = String(this.parserChNamesSource || '').trim();
-                if (!chSource) return false;
-                if (chSource === '__manual__' && !String(this.parserSensorNames || '').trim()) return false;
-                if (this.parserFolderSelectionCount() > 1 && this.parserSelectedFolderCount() !== 1) return false;
+                if (!chSource) return 'Select a channel names source.';
+                if (chSource === '__manual__' && !String(this.parserSensorNames || '').trim()) return 'Provide manual channel names (comma-separated).';
+                if (this.parserFolderSelectionCount() > 1 && this.parserSelectedFolderCount() !== 1) return 'Select exactly one folder for parser analysis.';
 
                 if (kind === 'pipeline') {
-                    if (!this.epochsDefinedByAxes() && this.parserEnableEpoching && (!this.parserEpochLengthS || !this.parserEpochStepS)) return false;
-                    return true;
+                    if (this.parserEnableEpoching && (!this.parserEpochLengthS || !this.parserEpochStepS)) return 'Epoching is enabled. Set both epoch length and epoch step.';
+                    return '';
                 }
                 if (kind === 'new-simulation') {
                     const folderPaths = Array.isArray(this.simulationFolderPaths) ? this.simulationFolderPaths : [];
                     const hasSimulationPath = (folderPaths.length > 0 || String(this.simulationFolderPath || '').trim().length > 0)
                         && this.simulationFileCount > 0;
-                    if (!this.isUploaded('data-file') && !hasSimulationPath) return false;
-                    if (!this.epochsDefinedByAxes() && this.parserEnableEpoching && (!this.parserEpochLengthS || !this.parserEpochStepS)) return false;
-                    return true;
+                    if (!this.isUploaded('data-file') && !hasSimulationPath) return 'Load a data folder/file in New data before computing features.';
+                    if (this.parserEnableEpoching && (!this.parserEpochLengthS || !this.parserEpochStepS)) return 'Epoching is enabled. Set both epoch length and epoch step.';
+                    return '';
                 }
-                return false;
+                return 'Data source configuration is incomplete.';
             },
             optionalFiniteNumber(value) {
                 const raw = String(value ?? '').trim();
@@ -1294,10 +1299,22 @@
                 const num = Number.parseFloat(raw);
                 return Number.isFinite(num) ? num : null;
             },
-            segmentBoundsInvalid() {
+            segmentValidationError() {
                 const t0 = this.optionalFiniteNumber(this.parserSegmentT0S);
                 const t1 = this.optionalFiniteNumber(this.parserSegmentT1S);
-                return t0 !== null && t1 !== null && t1 <= t0;
+                if (t0 !== null && t0 < 0) return 'Start time must be non-negative.';
+                if (t1 !== null && t1 < 0) return 'End time must be non-negative.';
+                if (t0 !== null && t1 !== null && t1 <= t0) return 'End time must be greater than start time.';
+                if (this.parserEnableEpoching && t0 !== null && t1 !== null) {
+                    const epochLength = this.optionalFiniteNumber(this.parserEpochLengthS);
+                    if (epochLength !== null && (t1 - t0) < epochLength) {
+                        return 'Segment duration must be at least as long as epoch length when epoching is enabled.';
+                    }
+                }
+                return '';
+            },
+            segmentBoundsInvalid() {
+                return this.segmentValidationError().length > 0;
             },
             epochsDefinedByAxes() {
                 return this.parserArrayAxesEnabled && String(this.parserAxisEpochs) !== '-1';
@@ -3397,7 +3414,7 @@
                                                     </select>
                                                 </label>
                                                 <label class="text-sm">
-                                                    <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Epochs axis</span>
+                                                    <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Trials/Epochs axis</span>
                                                     <select name="parser_axis_epochs" x-model="parserAxisEpochs"
                                                         class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm">
                                                         <option value="-1">None</option>
@@ -3411,7 +3428,7 @@
                                                 </label>
                                             </div>
                                             <p class="text-[11px] text-amber-700 dark:text-amber-400" x-show="epochsDefinedByAxes()">
-                                                The data already contains epochs — parser-level epoching is disabled.
+                                                Trials/Epochs axis is defined. Enable epoching below to further divide samples within each trial.
                                             </p>
                                         </div>
                                     </div>
@@ -3558,14 +3575,14 @@
                                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                         <label class="text-sm">
                                             <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Segment start time (s)</span>
-                                            <input type="number" step="any" name="parser_segment_t0_s" x-model="parserSegmentT0S"
+                                            <input type="number" step="any" min="0" name="parser_segment_t0_s" x-model="parserSegmentT0S"
                                                 placeholder="Optional (e.g., 10)"
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm"
                                                 :class="segmentBoundsInvalid() ? 'border-red-400 dark:border-red-500' : ''">
                                         </label>
                                         <label class="text-sm">
                                             <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Segment end time (s)</span>
-                                            <input type="number" step="any" name="parser_segment_t1_s" x-model="parserSegmentT1S"
+                                            <input type="number" step="any" min="0" name="parser_segment_t1_s" x-model="parserSegmentT1S"
                                                 placeholder="Optional (e.g., 60)"
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm"
                                                 :class="segmentBoundsInvalid() ? 'border-red-400 dark:border-red-500' : ''">
@@ -3574,9 +3591,7 @@
                                     <p class="text-xs text-gray-500 dark:text-gray-400">
                                         Optional temporal segmentation applied before epoching. Leave empty to use the full signal.
                                     </p>
-                                    <p x-show="segmentBoundsInvalid()" x-cloak class="text-xs text-red-600 dark:text-red-400">
-                                        End time must be greater than start time.
-                                    </p>
+                                    <p x-show="segmentBoundsInvalid()" x-cloak class="text-xs text-red-600 dark:text-red-400" x-text="segmentValidationError()"></p>
 
                                 </div>
 
@@ -3704,7 +3719,7 @@
                                                     </select>
                                                 </label>
                                                 <label class="text-sm">
-                                                    <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Epochs axis</span>
+                                                    <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Trials/Epochs axis</span>
                                                     <select name="parser_axis_epochs" x-model="parserAxisEpochs"
                                                         class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm">
                                                         <option value="-1">None</option>
@@ -3718,7 +3733,7 @@
                                                 </label>
                                             </div>
                                             <p class="text-[11px] text-amber-700 dark:text-amber-400" x-show="epochsDefinedByAxes()">
-                                                The data already contains epochs — parser-level epoching is disabled.
+                                                Trials/Epochs axis is defined. Enable epoching below to further divide samples within each trial.
                                             </p>
                                         </div>
                                     </div>
@@ -3808,14 +3823,14 @@
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                     <label class="text-sm">
                                         <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Segment start time (s)</span>
-                                        <input type="number" step="any" name="parser_segment_t0_s" x-model="parserSegmentT0S"
+                                        <input type="number" step="any" min="0" name="parser_segment_t0_s" x-model="parserSegmentT0S"
                                             placeholder="Optional (e.g., 10)"
                                             class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm"
                                             :class="segmentBoundsInvalid() ? 'border-red-400 dark:border-red-500' : ''">
                                     </label>
                                     <label class="text-sm">
                                         <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Segment end time (s)</span>
-                                        <input type="number" step="any" name="parser_segment_t1_s" x-model="parserSegmentT1S"
+                                        <input type="number" step="any" min="0" name="parser_segment_t1_s" x-model="parserSegmentT1S"
                                             placeholder="Optional (e.g., 60)"
                                             class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm"
                                             :class="segmentBoundsInvalid() ? 'border-red-400 dark:border-red-500' : ''">
@@ -3824,9 +3839,7 @@
                                 <p class="text-xs text-gray-500 dark:text-gray-400">
                                     Optional temporal segmentation applied before epoching. Leave empty to use the full signal.
                                 </p>
-                                <p x-show="segmentBoundsInvalid()" x-cloak class="text-xs text-red-600 dark:text-red-400">
-                                    End time must be greater than start time.
-                                </p>
+                                <p x-show="segmentBoundsInvalid()" x-cloak class="text-xs text-red-600 dark:text-red-400" x-text="segmentValidationError()"></p>
 
                                 </div>
 
@@ -3860,15 +3873,12 @@
                                         :value="JSON.stringify(metadataInfo ? (metadataInfo.candidate_fields || []) : [])">
                                 </div>
 
-                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-300"
-                                    :class="epochsDefinedByAxes() ? 'opacity-40 cursor-not-allowed' : ''">
+                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-300">
                                     <input type="checkbox" x-model="parserEnableEpoching"
-                                        :disabled="epochsDefinedByAxes()"
                                         class="rounded border-gray-300 text-primary focus:ring-primary/50">
                                     Enable epoching
-                                    <span x-show="epochsDefinedByAxes()" class="text-[11px] text-amber-600 dark:text-amber-400 font-normal">(disabled — epochs defined by array axis)</span>
                                 </label>
-                                <input type="hidden" name="parser_enable_epoching" :value="(parserEnableEpoching && !epochsDefinedByAxes()) ? '1' : '0'">
+                                <input type="hidden" name="parser_enable_epoching" :value="parserEnableEpoching ? '1' : '0'">
 
                                 <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-300">
                                     <input type="checkbox" x-model="parserEnableAggregate"
@@ -3906,7 +3916,7 @@
                                     </label>
                                 </div>
 
-                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4" x-show="parserEnableEpoching && !epochsDefinedByAxes()">
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4" x-show="parserEnableEpoching">
                                     <label class="text-sm">
                                         <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Epoch length (s)</span>
                                         <input type="number" step="any" name="parser_epoch_length_s" x-model="parserEpochLengthS"
@@ -4447,6 +4457,14 @@
                     x-text="`${formatBytes(uploadBytesLoaded)} / ${formatBytes(uploadBytesTotal)}`"></p>
                 <p x-show="submitError" class="text-xs text-red-600 dark:text-red-400" x-text="submitError"></p>
             </div>
+
+            <template x-if="activeTab === 'configure-method' && !submitInProgress && computeSubmitBlockReason()">
+                <div class="mt-6 w-full p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700/40 rounded-xl">
+                    <p class="text-sm text-amber-800 dark:text-amber-200">
+                        Configuration issue: <span class="font-semibold" x-text="computeSubmitBlockReason()"></span>
+                    </p>
+                </div>
+            </template>
 
             <div class="mt-10 flex flex-col sm:flex-row justify-between items-center gap-4">
                 <template x-if="activeTab === 'load-data'">


### PR DESCRIPTION
This PR improves the Features workflow by adding robust temporal segmentation controls, clarifying array-axis terminology, and making configuration errors explicit before compute.

Main outcomes:
- Users can define `t0`/`t1` temporal segmentation in WebUI and apply it before epoching.
- `Epochs axis` is renamed to `Trials/Epochs axis`.
- Parser-level epoching is now allowed even when trials are already defined by array axis.
- The UI now shows explicit “Configuration issue” messages when compute is blocked.
- Validation was hardened to prevent invalid segmentation/epoching setups.

## Changes Included

### 1. Temporal segmentation (`t0` / `t1`) in parser + WebUI
- Added optional parser config fields:
  - `segment_t0_s`
  - `segment_t1_s`
- Applied segmentation before z-score/aggregation/epoching.
- Added row-level cropping for time-domain data with:
  - sample-accurate slicing when `fs` is available
  - fallback using `t0/t1` when `fs` is missing
  - clipping to valid signal support
- Preserved absolute time reference in epoching (`t0/t1` now offset by base segment start).

### 2. Validation hardening for segmentation and epoching
Implemented in frontend, backend form parsing, and parser runtime:
- `segment_t0_s >= 0`
- `segment_t1_s >= 0`
- `segment_t1_s > segment_t0_s` when both are set
- If epoching is enabled and both segment bounds are set:
  - `(segment_t1_s - segment_t0_s) >= epoch_length_s`
- Added explicit parser error when segmentation window has no overlap with any time-domain sample (instead of silently proceeding with empty overlap).

### 3. Array mapping UX changes
- Renamed label:
  - `Epochs axis` → `Trials/Epochs axis`
- Updated helper message accordingly.
- Removed behavior that disabled parser-level epoching when trials axis is defined.
- Users can now further epoch within each trial if desired.

### 4. Explicit pre-compute configuration errors in UI
- Added `computeSubmitBlockReason()` in the Features Alpine state.
- Reused it for submit gating and displayed it in a visible warning box in `configure-method`.
- This avoids the previous “button disappears with no explanation” behavior.

## Files Updated

- `ncpi/EphysDatasetParser.py`
- `webui/app.py`
- `webui/templates/3.1.features_methods.html`