### PR TITLE
feat: unify channel-name autocomplete with Channels axis, improve config validation feedback, and add paginated sortable dataframe explorer

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -3851,11 +3851,14 @@ def _build_parse_config_from_form(form):
     sensor_names = _parse_sensor_names(form.get("parser_sensor_names"))
     ch_names_source = (form.get("parser_ch_names_source") or "").strip()
     ch_names_locator = (form.get("parser_ch_names_locator") or "").strip() or None
-    ch_names_autocomplete_axis = _parse_nonnegative_int(
-        form.get("parser_ch_names_autocomplete_axis"),
-        default=0,
-        field_name="Autocomplete channel axis",
-    )
+    if array_axes is not None and "channels" in array_axes:
+        ch_names_autocomplete_axis = int(array_axes.get("channels", 0))
+    else:
+        ch_names_autocomplete_axis = _parse_nonnegative_int(
+            form.get("parser_ch_names_autocomplete_axis"),
+            default=0,
+            field_name="Autocomplete channel axis",
+        )
     if ch_names_source == "__manual__":
         if sensor_names is None:
             raise ValueError("Provide manual channel names when channel names source is set to manual.")
@@ -10141,11 +10144,19 @@ def start_computation_redirect(computation_type):
                     return redirect(request.referrer or url_for('features_methods'))
             elif ch_names_source == "__autocomplete__":
                 try:
-                    _parse_nonnegative_int(
-                        request.form.get("parser_ch_names_autocomplete_axis"),
-                        default=0,
-                        field_name="Autocomplete channel axis",
-                    )
+                    array_axes_enabled = str(request.form.get("parser_array_axes_enabled", "")).lower() in {"1", "on", "true", "yes"}
+                    if array_axes_enabled:
+                        _parse_nonnegative_int(
+                            request.form.get("parser_axis_channels"),
+                            default=0,
+                            field_name="Channels axis",
+                        )
+                    else:
+                        _parse_nonnegative_int(
+                            request.form.get("parser_ch_names_autocomplete_axis"),
+                            default=0,
+                            field_name="Autocomplete channel axis",
+                        )
                 except Exception as exc:
                     flash(str(exc), 'error')
                     return redirect(request.referrer or url_for('features_methods'))
@@ -11391,7 +11402,7 @@ def get_status(job_id):
 
 @app.route("/preview_results/<job_id>")
 def preview_results(job_id):
-    """Returns the first rows of the result DataFrame as JSON for in-UI preview."""
+    """Returns paginated rows of the result DataFrame for in-UI exploration."""
     status = job_status.get(job_id)
     if not status or status.get("status") != "finished" or not status.get("results"):
         return jsonify({"error": "Results not available"}), 404
@@ -11408,6 +11419,25 @@ def preview_results(job_id):
             df = pd.read_pickle(path)
         if not isinstance(df, pd.DataFrame):
             return jsonify({"error": "Result is not a DataFrame"}), 400
+
+        # Query controls
+        page_raw = request.args.get("page", 1)
+        page_size_raw = request.args.get("page_size", 20)
+        search_query = (request.args.get("search") or "").strip()
+        sort_col = (request.args.get("sort_col") or "").strip()
+        sort_dir = (request.args.get("sort_dir") or "asc").strip().lower()
+        if sort_dir not in {"asc", "desc"}:
+            sort_dir = "asc"
+        try:
+            page = int(page_raw)
+        except Exception:
+            page = 1
+        try:
+            page_size = int(page_size_raw)
+        except Exception:
+            page_size = 20
+        page = max(1, page)
+        page_size = max(5, min(200, page_size))
 
         def _format_preview_value(value):
             if isinstance(value, np.ndarray):
@@ -11436,14 +11466,56 @@ def preview_results(job_id):
                 pass
             return str(value)
 
-        preview = df.head(20).copy()
+        # Optional full-text filter across all columns
+        filtered_df = df
+        if search_query:
+            search_lower = search_query.lower()
+            mask = pd.Series(False, index=df.index)
+            for col in df.columns:
+                series = df[col]
+                try:
+                    col_mask = series.astype(str).str.contains(search_query, case=False, na=False, regex=False)
+                except Exception:
+                    col_mask = series.map(lambda value: search_lower in str(value).lower() if value is not None else False)
+                mask = mask | col_mask
+            filtered_df = df.loc[mask]
+
+        # Optional sorting
+        sort_applied = ""
+        if sort_col and sort_col in filtered_df.columns:
+            try:
+                filtered_df = filtered_df.sort_values(
+                    by=sort_col,
+                    ascending=(sort_dir != "desc"),
+                    kind="mergesort",
+                    na_position="last",
+                )
+                sort_applied = sort_col
+            except Exception:
+                sort_applied = ""
+
+        total_rows = len(df)
+        filtered_rows = len(filtered_df)
+        total_pages = max(1, (filtered_rows + page_size - 1) // page_size)
+        if page > total_pages:
+            page = total_pages
+        start = (page - 1) * page_size
+        stop = start + page_size
+        preview = filtered_df.iloc[start:stop].copy()
         for col in preview.columns:
             preview[col] = preview[col].map(_format_preview_value)
         return jsonify({
             "columns": list(preview.columns),
             "rows": preview.values.tolist(),
-            "total_rows": len(df),
+            "total_rows": total_rows,
+            "filtered_rows": filtered_rows,
             "total_cols": len(df.columns),
+            "page": page,
+            "page_size": page_size,
+            "total_pages": total_pages,
+            "search": search_query,
+            "sort_col": sort_applied,
+            "sort_dir": sort_dir if sort_applied else "asc",
             "dropped_cols": [],
         })
     except Exception as exc:

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -2141,7 +2141,9 @@
                         ? `[${sensors.map((s) => toPyString(s)).join(', ')}]`
                         : '[]';
                 } else if (chSource === '__autocomplete__') {
-                    const axis = Number.parseInt(String(this.parserChNamesAutocompleteAxis || '0'), 10);
+                    const axis = this.parserArrayAxesEnabled
+                        ? Number.parseInt(String(this.parserAxisChannels || '0'), 10)
+                        : 0;
                     const axisValue = Number.isFinite(axis) && axis >= 0 ? axis : 0;
                     const locatorExpr = dataLocator === '__self__' ? 'data' : `data.${dataLocator}`;
                     chNamesExpr = `[f"ch{i}" for i in range(${locatorExpr}.shape[${axisValue}])]`;
@@ -3400,7 +3402,7 @@
                                         </label>
                                     </div>
 
-                                    <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_8rem] gap-4 items-end">
+                                    <div class="grid grid-cols-1 gap-4 items-end">
                                         <label class="text-sm">
                                             <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Channel names source *</span>
                                             <select name="parser_ch_names_source" x-model="parserChNamesSource" @change="onParserChNamesSourceChange()"
@@ -3411,14 +3413,9 @@
                                                 </template>
                                                 <option value="__manual__" :style="parserManualOptionStyle()">Manual list</option>
                                             </select>
-                                        </label>
-                                        <label class="text-sm">
-                                            <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Autocomplete channel axis</span>
-                                            <input type="number" name="parser_ch_names_autocomplete_axis" x-model="parserChNamesAutocompleteAxis"
-                                                min="0" max="4" step="1" inputmode="numeric"
-                                                :disabled="parserChNamesSource !== '__autocomplete__'"
-                                                class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm disabled:opacity-50"
-                                                placeholder="0-4">
+                                            <span class="block text-[11px] text-gray-400 mt-1">
+                                                Autocomplete uses Channels axis from "Specify array dimension mapping" (defaults to Dim 0 if mapping is off).
+                                            </span>
                                         </label>
                                     </div>
                                     <input type="hidden" name="parser_fs_locator"
@@ -3589,7 +3586,8 @@
                                         </label>
                                     </div>
                                     <p class="text-xs text-gray-500 dark:text-gray-400">
-                                        Optional temporal segmentation applied before epoching. Leave empty to use the full signal.
+                                        Optional temporal segmentation applied before epoching. Leave both empty to use the full signal.
+                                        Set only start time (t0) to keep data from t0 to the end, or only end time (t1) to keep data from the beginning to t1.
                                     </p>
                                     <p x-show="segmentBoundsInvalid()" x-cloak class="text-xs text-red-600 dark:text-red-400" x-text="segmentValidationError()"></p>
 
@@ -3705,7 +3703,7 @@
                                         </label>
                                     </div>
 
-                                    <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_8rem] gap-4 items-end">
+                                    <div class="grid grid-cols-1 gap-4 items-end">
                                         <label class="text-sm">
                                             <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Channel names source *</span>
                                             <select name="parser_ch_names_source" x-model="parserChNamesSource" @change="onParserChNamesSourceChange()"
@@ -3716,14 +3714,9 @@
                                                 </template>
                                                 <option value="__manual__" :style="parserManualOptionStyle()">Manual list</option>
                                             </select>
-                                        </label>
-                                        <label class="text-sm">
-                                            <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Autocomplete channel axis</span>
-                                            <input type="number" name="parser_ch_names_autocomplete_axis" x-model="parserChNamesAutocompleteAxis"
-                                                min="0" max="4" step="1" inputmode="numeric"
-                                                :disabled="parserChNamesSource !== '__autocomplete__'"
-                                                class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm disabled:opacity-50"
-                                                placeholder="0-4">
+                                            <span class="block text-[11px] text-gray-400 mt-1">
+                                                Autocomplete uses Channels axis from "Specify array dimension mapping" (defaults to Dim 0 if mapping is off).
+                                            </span>
                                         </label>
                                     </div>
                                     <input type="hidden" name="parser_fs_locator"
@@ -3837,7 +3830,8 @@
                                     </label>
                                 </div>
                                 <p class="text-xs text-gray-500 dark:text-gray-400">
-                                    Optional temporal segmentation applied before epoching. Leave empty to use the full signal.
+                                    Optional temporal segmentation applied before epoching. Leave both empty to use the full signal.
+                                    Set only start time (t0) to keep data from t0 to the end, or only end time (t1) to keep data from the beginning to t1.
                                 </p>
                                 <p x-show="segmentBoundsInvalid()" x-cloak class="text-xs text-red-600 dark:text-red-400" x-text="segmentValidationError()"></p>
 

--- a/webui/templates/loading_page.html
+++ b/webui/templates/loading_page.html
@@ -77,38 +77,79 @@
     </div>
     {% endif %}
 
-    <!-- DataFrame preview (shown when finished and preview data is available) -->
+    <!-- DataFrame explorer (shown when finished and preview data is available) -->
     <div x-show="computationType !== 'simulation' && status === 'finished' && (previewColumns.length > 0 || previewError)"
-         class="w-full mt-6 space-y-2">
-        <div class="flex items-center justify-between text-xs text-text-light-secondary dark:text-[#929bc9]">
-            <span class="font-semibold lowercase tracking-wide">result preview</span>
-            <span x-show="previewTotalRows !== null"
-                  class="text-[11px]"
-                  x-text="`showing up to 20 of ${previewTotalRows} rows · ${previewTotalCols} columns`"></span>
+         class="w-full mt-6 space-y-3">
+        <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between text-xs text-text-light-secondary dark:text-[#929bc9]">
+            <span class="font-semibold lowercase tracking-wide">result explorer</span>
+            <span x-show="previewTotalRows !== null" class="text-[11px]" x-text="previewSummaryText()"></span>
         </div>
+
+        <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div class="text-xs text-slate-500 dark:text-slate-400">
+                Click a column name to sort ascending/descending.
+            </div>
+            <div class="flex items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                <span>Rows/page</span>
+                <select x-model="previewPageSize" @change="onPreviewPageSizeChange()"
+                    class="h-9 px-2 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-xs">
+                    <option value="20">20</option>
+                    <option value="50">50</option>
+                    <option value="100">100</option>
+                </select>
+            </div>
+        </div>
+
+        <div x-show="previewLoading" class="text-xs text-slate-500 dark:text-slate-400">Loading table...</div>
         <div x-show="previewError" class="text-xs text-red-500 dark:text-red-400" x-text="previewError"></div>
-        <div x-show="previewColumns.length > 0"
-             class="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
+
+        <div x-show="previewColumns.length > 0" class="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
             <table class="min-w-full text-xs font-mono">
                 <thead class="bg-slate-100 dark:bg-slate-800 sticky top-0">
                     <tr>
                         <template x-for="col in previewColumns" :key="'th-'+col">
-                            <th class="px-3 py-1.5 text-left text-[11px] font-semibold text-slate-600 dark:text-slate-300 whitespace-nowrap border-b border-slate-200 dark:border-slate-700"
-                                x-text="col"></th>
+                            <th class="px-3 py-1.5 text-left text-[11px] font-semibold text-slate-600 dark:text-slate-300 whitespace-nowrap border-b border-slate-200 dark:border-slate-700">
+                                <button type="button" @click="togglePreviewSort(col)"
+                                    class="inline-flex items-center gap-1 hover:text-primary">
+                                    <span x-text="col"></span>
+                                    <span class="text-[10px]" x-show="previewSortCol === col" x-text="previewSortDir === 'desc' ? '▼' : '▲'"></span>
+                                </button>
+                            </th>
                         </template>
                     </tr>
                 </thead>
                 <tbody>
+                    <template x-if="previewRows.length === 0">
+                        <tr>
+                            <td :colspan="previewColumns.length || 1" class="px-3 py-3 text-xs text-slate-500 dark:text-slate-400">
+                                No rows available.
+                            </td>
+                        </tr>
+                    </template>
                     <template x-for="(row, ri) in previewRows" :key="'tr-'+ri">
                         <tr :class="ri % 2 === 0 ? 'bg-white dark:bg-slate-900' : 'bg-slate-50 dark:bg-slate-800/50'">
                             <template x-for="(cell, ci) in row" :key="'td-'+ri+'-'+ci">
-                                <td class="px-3 py-1 text-slate-700 dark:text-slate-300 whitespace-nowrap max-w-[200px] truncate border-b border-slate-100 dark:border-slate-800"
+                                <td class="px-3 py-1 text-slate-700 dark:text-slate-300 whitespace-nowrap max-w-[240px] truncate border-b border-slate-100 dark:border-slate-800"
                                     x-text="cell"></td>
                             </template>
                         </tr>
                     </template>
                 </tbody>
             </table>
+        </div>
+
+        <div x-show="previewColumns.length > 0" class="flex items-center justify-between gap-3 text-xs text-slate-600 dark:text-slate-300">
+            <span x-text="previewPageLabel()"></span>
+            <div class="flex items-center gap-2">
+                <button type="button" @click="changePreviewPage(-1)" :disabled="previewPage <= 1 || previewLoading"
+                    class="h-8 px-3 rounded-lg border border-slate-300 dark:border-slate-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-slate-100 dark:hover:bg-slate-800">
+                    Previous
+                </button>
+                <button type="button" @click="changePreviewPage(1)" :disabled="previewPage >= previewTotalPages || previewLoading"
+                    class="h-8 px-3 rounded-lg border border-slate-300 dark:border-slate-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-slate-100 dark:hover:bg-slate-800">
+                    Next
+                </button>
+            </div>
         </div>
     </div>
 
@@ -211,7 +252,14 @@ document.addEventListener('alpine:init', () => {
         previewRows: [],
         previewTotalRows: null,
         previewTotalCols: null,
+        previewPage: 1,
+        previewPageSize: '20',
+        previewTotalPages: 1,
+        previewSortCol: '',
+        previewSortDir: 'asc',
+        previewLoading: false,
         previewError: null,
+        previewRequestId: 0,
         
         init() {
             this.startTime = Date.now();
@@ -287,6 +335,11 @@ document.addEventListener('alpine:init', () => {
                             this.previewRows = [];
                             this.previewTotalRows = null;
                             this.previewTotalCols = null;
+                            this.previewPage = 1;
+                            this.previewTotalPages = 1;
+                            this.previewSortCol = '';
+                            this.previewSortDir = 'asc';
+                            this.previewLoading = false;
                             this.previewError = null;
                         }
                         // Polling stops automatically here as it doesn't set a new timeout
@@ -325,21 +378,85 @@ document.addEventListener('alpine:init', () => {
             const encodedType = encodeURIComponent(this.computationType || '');
             window.location.href = `/download_results/${encodedJobId}?computation_type=${encodedType}`;
         },
+        previewSummaryText() {
+            if (this.previewTotalRows === null) return '';
+            return `${this.previewTotalRows} rows · ${this.previewTotalCols} columns`;
+        },
+        previewPageLabel() {
+            const total = Number(this.previewTotalPages || 1);
+            const page = Number(this.previewPage || 1);
+            return `Page ${page} of ${Math.max(1, total)}`;
+        },
+        onPreviewPageSizeChange() {
+            const parsed = Number.parseInt(String(this.previewPageSize || '20'), 10);
+            const clamped = Number.isFinite(parsed) ? Math.max(5, Math.min(200, parsed)) : 20;
+            this.previewPageSize = String(clamped);
+            this.previewPage = 1;
+            this.fetchPreview();
+        },
+        togglePreviewSort(col) {
+            const column = String(col || '').trim();
+            if (!column) return;
+            if (this.previewSortCol === column) {
+                this.previewSortDir = this.previewSortDir === 'asc' ? 'desc' : 'asc';
+            } else {
+                this.previewSortCol = column;
+                this.previewSortDir = 'asc';
+            }
+            this.previewPage = 1;
+            this.fetchPreview();
+        },
+        changePreviewPage(delta) {
+            if (this.previewLoading) return;
+            const step = Number.parseInt(String(delta || 0), 10);
+            if (!Number.isFinite(step) || step === 0) return;
+            const nextPage = Number(this.previewPage || 1) + step;
+            const minPage = 1;
+            const maxPage = Math.max(1, Number(this.previewTotalPages || 1));
+            if (nextPage < minPage || nextPage > maxPage) return;
+            this.previewPage = nextPage;
+            this.fetchPreview();
+        },
         async fetchPreview() {
             if (!this.jobId) return;
+            const requestId = (this.previewRequestId || 0) + 1;
+            this.previewRequestId = requestId;
+            this.previewLoading = true;
+            this.previewError = null;
             try {
-                const resp = await fetch(`/preview_results/${encodeURIComponent(this.jobId)}`, {
+                const params = new URLSearchParams();
+                params.set('page', String(this.previewPage || 1));
+                params.set('page_size', String(this.previewPageSize || '20'));
+                if (this.previewSortCol) {
+                    params.set('sort_col', this.previewSortCol);
+                    params.set('sort_dir', this.previewSortDir || 'asc');
+                }
+                const resp = await fetch(`/preview_results/${encodeURIComponent(this.jobId)}?${params.toString()}`, {
                     cache: 'no-store',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 });
                 const data = await resp.json();
-                if (data.error) { this.previewError = data.error; return; }
+                if (requestId !== this.previewRequestId) return;
+                if (data.error) {
+                    this.previewError = data.error;
+                    return;
+                }
                 this.previewColumns = data.columns || [];
                 this.previewRows = data.rows || [];
                 this.previewTotalRows = data.total_rows;
                 this.previewTotalCols = data.total_cols;
+                this.previewPage = Number(data.page || 1);
+                this.previewPageSize = String(data.page_size || this.previewPageSize || '20');
+                this.previewTotalPages = Number(data.total_pages || 1);
+                this.previewSortCol = data.sort_col || '';
+                this.previewSortDir = data.sort_dir || 'asc';
             } catch (e) {
+                if (requestId !== this.previewRequestId) return;
                 this.previewError = e && e.message ? e.message : 'Could not load preview.';
+            } finally {
+                if (requestId === this.previewRequestId) {
+                    this.previewLoading = false;
+                }
             }
         },
         async cancelComputation() {


### PR DESCRIPTION
This PR bundles the UX and validation improvements introduced after the channel-axis discussion, plus the result-table exploration upgrade.

Main outcomes:
- Channel-name autocomplete now follows the parser's `Channels axis` mapping.
- Parser configuration errors are shown explicitly to users before compute.
- Temporal segmentation validation is stricter and clearer.
- Result preview is upgraded to a paginated, sortable DataFrame explorer.
- Search bar was intentionally removed from the explorer per final UX decision.

## Changes Included

### 1. Channel axis / channel-name autocomplete cleanup
- Removed the redundant `Autocomplete channel axis` input from `Channel names source` in New data parser configuration.
- `Autocomplete` now uses `Channels axis` from `Specify array dimension mapping`.
- If axis mapping is disabled, autocomplete defaults to axis `0` (Dim 0).
- Added explanatory helper text in UI so users understand where autocomplete axis comes from.

## 2. Results table exploration upgrade
- Replaced fixed `head(20)`-style display with a server-driven explorer:
  - pagination
  - selectable rows/page
  - sortable columns (click header to toggle asc/desc)
- API endpoint `/preview_results/<job_id>` now supports page/sort parameters.
- Final UX decision applied: removed search bar from explorer.
- Existing `.pkl` result download flow remains unchanged.

## Files Updated

- `webui/templates/3.1.features_methods.html`
- `webui/app.py`
- `ncpi/EphysDatasetParser.py`
- `webui/templates/loading_page.html`