### PR TITLE
Webui dataload

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -5572,6 +5572,11 @@ def field_potential_load_precomputed():
     }
 
     inputs = []
+    if source_mode == "auto-detected":
+        if not _list_field_potential_detected_files():
+            flash("No detected field potential files are available from previous steps.", "error")
+            return redirect(request.referrer or url_for("field_potential_load"))
+        return redirect(request.referrer or url_for("field_potential_load"))
     if source_mode == "server-path":
         if not server_file_paths:
             flash("Select at least one server field potential file (.pkl/.pickle).", "error")
@@ -10451,13 +10456,25 @@ def start_computation_redirect(computation_type):
 
         has_uploaded_features = _has_upload("features_predict_file", "features_predict", "file-upload-features")
         has_server_features_path = bool(features_server_file_path)
-        if inference_features_source_mode not in {"upload", "server-path"}:
-            inference_features_source_mode = "server-path" if has_server_features_path else "upload"
-        # Fallback: infer source mode from provided fields when UI mode sync fails.
-        if inference_features_source_mode == "upload" and not has_uploaded_features and has_server_features_path:
+        if inference_features_source_mode not in {"upload", "server-path", "auto-detected"}:
+            if has_existing_features:
+                inference_features_source_mode = "auto-detected"
+            elif has_server_features_path:
+                inference_features_source_mode = "server-path"
+            else:
+                inference_features_source_mode = "upload"
+        # Compatibility fallback when old UI states are posted.
+        if inference_features_source_mode == "upload" and not has_uploaded_features and has_existing_features and not has_server_features_path:
+            inference_features_source_mode = "auto-detected"
+        if inference_features_source_mode == "upload" and not has_uploaded_features and has_server_features_path and not has_existing_features:
             inference_features_source_mode = "server-path"
-        if inference_features_source_mode == "server-path" and not has_server_features_path and has_uploaded_features:
-            inference_features_source_mode = "upload"
+        if inference_features_source_mode == "server-path" and not has_server_features_path and has_existing_features and not has_uploaded_features:
+            inference_features_source_mode = "auto-detected"
+        if inference_features_source_mode == "auto-detected" and not has_existing_features:
+            if has_server_features_path and not has_uploaded_features:
+                inference_features_source_mode = "server-path"
+            elif has_uploaded_features:
+                inference_features_source_mode = "upload"
 
         if inference_features_source_mode == "server-path":
             try:
@@ -10468,9 +10485,13 @@ def start_computation_redirect(computation_type):
             except Exception as exc:
                 flash(str(exc), 'error')
                 return redirect(request.referrer or url_for('inference'))
+        elif inference_features_source_mode == "auto-detected":
+            if not has_existing_features:
+                flash('No auto-detected features dataframe is available from previous steps.', 'error')
+                return redirect(request.referrer or url_for('inference'))
         else:
-            if not has_uploaded_features and not has_existing_features:
-                flash('Upload features data or use an auto-loaded features file.', 'error')
+            if not has_uploaded_features:
+                flash('Upload features data or switch to Server file / Pipeline detection.', 'error')
                 return redirect(request.referrer or url_for('inference'))
 
         has_uploaded_model = _has_upload("model_file", "model-file", "file-upload-model")

--- a/webui/app.py
+++ b/webui/app.py
@@ -3835,14 +3835,27 @@ def _build_parse_config_from_form(form):
             axis_ids = int(axis_ids_raw)
         except (ValueError, TypeError):
             raise ValueError("Invalid array axis mapping values. Axes must be integers.")
-        all_axes = [axis_channels, axis_samples]
+        if axis_channels < -1:
+            raise ValueError("Channels axis must be greater than or equal to -1 (None).")
+        if axis_samples < 0:
+            raise ValueError("Samples axis must be greater than or equal to 0.")
+        if axis_epochs < -1:
+            raise ValueError("Trials/Epochs axis must be greater than or equal to -1 (None).")
+        if axis_ids < -1:
+            raise ValueError("IDs axis must be greater than or equal to -1 (None).")
+
+        all_axes = [axis_samples]
+        if axis_channels >= 0:
+            all_axes.append(axis_channels)
         if axis_epochs >= 0:
             all_axes.append(axis_epochs)
         if axis_ids >= 0:
             all_axes.append(axis_ids)
         if len(set(all_axes)) != len(all_axes):
             raise ValueError("Array axis mapping: each dimension can only be assigned to one role.")
-        array_axes = {"channels": axis_channels, "samples": axis_samples}
+        array_axes = {"samples": axis_samples}
+        if axis_channels >= 0:
+            array_axes["channels"] = axis_channels
         if axis_epochs >= 0:
             array_axes["epochs"] = axis_epochs
         if axis_ids >= 0:
@@ -10151,11 +10164,9 @@ def start_computation_redirect(computation_type):
                 try:
                     array_axes_enabled = str(request.form.get("parser_array_axes_enabled", "")).lower() in {"1", "on", "true", "yes"}
                     if array_axes_enabled:
-                        _parse_nonnegative_int(
-                            request.form.get("parser_axis_channels"),
-                            default=0,
-                            field_name="Channels axis",
-                        )
+                        axis_channels_value = int(request.form.get("parser_axis_channels") or 0)
+                        if axis_channels_value < -1:
+                            raise ValueError("Channels axis must be greater than or equal to -1 (None).")
                     else:
                         _parse_nonnegative_int(
                             request.form.get("parser_ch_names_autocomplete_axis"),

--- a/webui/static/js/field_potential_proxy.js
+++ b/webui/static/js/field_potential_proxy.js
@@ -504,10 +504,22 @@ function setupUploadZones() {
             }
         };
 
+        const hideUploadedBox = () => {
+            if (!uploadedBox || !uploadedName) return;
+            uploadedName.textContent = '';
+            uploadedBox.classList.add('hidden');
+            if (clearSelectionBtn) clearSelectionBtn.classList.add('hidden');
+        };
+
         const isServerPathMode = () => {
             if (!sourceModeInput) return false;
             const value = String(sourceModeInput.value || '').trim().toLowerCase();
             return value === 'server-path';
+        };
+        const isAutoDetectedMode = () => {
+            if (!sourceModeInput) return false;
+            const value = String(sourceModeInput.value || '').trim().toLowerCase();
+            return value === 'auto-detected';
         };
 
         if (!sourceModeInput || !serverPathInput) {
@@ -522,23 +534,30 @@ function setupUploadZones() {
 
         const controls = document.createElement('div');
         controls.className = 'w-full flex flex-wrap items-center justify-center gap-2 mb-1';
+        const hasDetectedDefault = Boolean(defaultName);
         controls.innerHTML = `
+            <button type="button" data-upload-action="true" class="proxy-upload-auto px-2.5 py-1 text-[10px] rounded border" ${hasDetectedDefault ? '' : 'disabled aria-disabled="true"'}>Pipeline detection</button>
             <button type="button" data-upload-action="true" class="proxy-upload-local px-2.5 py-1 text-[10px] rounded border">Local upload</button>
             <button type="button" data-upload-action="true" class="proxy-upload-server px-2.5 py-1 text-[10px] rounded border">Server file</button>
         `;
         zone.insertBefore(controls, zone.firstChild);
 
+        const autoBtn = controls.querySelector('.proxy-upload-auto');
         const localBtn = controls.querySelector('.proxy-upload-local');
         const serverBtn = controls.querySelector('.proxy-upload-server');
 
         const applyModeVisuals = (mode) => {
             const activeClasses = ['border-primary', 'bg-primary/10', 'text-primary', 'font-semibold'];
             const inactiveClasses = ['border-slate-300', 'dark:border-slate-700', 'text-slate-600', 'dark:text-slate-300'];
-            [localBtn, serverBtn].forEach((btn) => {
+            [autoBtn, localBtn, serverBtn].forEach((btn) => {
+                if (!btn) return;
                 btn.classList.remove(...activeClasses);
                 btn.classList.add(...inactiveClasses);
             });
-            if (mode === 'server-path') {
+            if (mode === 'auto-detected' && autoBtn) {
+                autoBtn.classList.add(...activeClasses);
+                autoBtn.classList.remove(...inactiveClasses);
+            } else if (mode === 'server-path') {
                 serverBtn.classList.add(...activeClasses);
                 serverBtn.classList.remove(...inactiveClasses);
             } else {
@@ -561,7 +580,25 @@ function setupUploadZones() {
                     uploadedBox.classList.remove('hidden');
                     if (clearSelectionBtn) clearSelectionBtn.classList.remove('hidden');
                 } else {
-                    syncUploadedBoxToDefault();
+                    hideUploadedBox();
+                }
+            }
+        };
+
+        const syncAutoDetectedUi = () => {
+            if (filename) {
+                filename.textContent = hasDetectedDefault ? defaultName : 'No detected default file';
+            }
+            if (uploadedBox && uploadedName) {
+                if (hasDetectedDefault && !isDefaultIgnored()) {
+                    uploadedName.textContent = defaultName;
+                    if (uploadedLabel) uploadedLabel.textContent = 'Loaded';
+                    uploadedBox.classList.remove('hidden');
+                    if (clearSelectionBtn) clearSelectionBtn.classList.remove('hidden');
+                } else {
+                    uploadedName.textContent = '';
+                    uploadedBox.classList.add('hidden');
+                    if (clearSelectionBtn) clearSelectionBtn.classList.add('hidden');
                 }
             }
         };
@@ -580,21 +617,25 @@ function setupUploadZones() {
                     uploadedBox.classList.remove('hidden');
                     if (clearSelectionBtn) clearSelectionBtn.classList.remove('hidden');
                 } else {
-                    syncUploadedBoxToDefault();
+                    hideUploadedBox();
                 }
             }
         };
 
         const setMode = (mode) => {
-            const nextMode = mode === 'server-path' ? 'server-path' : 'upload';
+            const normalized = String(mode || '').trim().toLowerCase();
+            const nextMode = normalized === 'server-path'
+                ? 'server-path'
+                : (normalized === 'auto-detected' ? 'auto-detected' : 'upload');
             sourceModeInput.value = nextMode;
             applyModeVisuals(nextMode);
             zone.classList.remove('border-primary', 'bg-primary/5');
-            if (nextMode === 'upload') {
-                serverPathInput.value = '';
+            if (nextMode === 'auto-detected') {
+                setDefaultIgnored(false);
+                syncAutoDetectedUi();
+            } else if (nextMode === 'upload') {
                 syncLocalSelectionUi();
             } else {
-                input.value = '';
                 syncServerSelectionUi();
             }
         };
@@ -621,6 +662,14 @@ function setupUploadZones() {
             localBtn.addEventListener('click', (event) => {
                 event.stopPropagation();
                 setMode('upload');
+                notifyNuExtTrialDetection();
+            });
+        }
+        if (autoBtn) {
+            autoBtn.addEventListener('click', (event) => {
+                event.stopPropagation();
+                if (!hasDetectedDefault) return;
+                setMode('auto-detected');
                 notifyNuExtTrialDetection();
             });
         }
@@ -652,15 +701,19 @@ function setupUploadZones() {
             if (event.target && event.target.closest('[data-upload-action]')) {
                 return;
             }
-            if (isServerPathMode()) {
+            const mode = String(sourceModeInput.value || '').trim().toLowerCase();
+            if (mode === 'server-path') {
                 openServerPicker();
+                return;
+            }
+            if (mode === 'auto-detected') {
                 return;
             }
             input.click();
         });
         zone.addEventListener('dragover', (event) => {
             event.preventDefault();
-            if (isServerPathMode()) {
+            if (isServerPathMode() || isAutoDetectedMode()) {
                 return;
             }
             zone.classList.add('border-primary', 'bg-primary/5');
@@ -670,7 +723,7 @@ function setupUploadZones() {
         });
         zone.addEventListener('drop', (event) => {
             event.preventDefault();
-            if (isServerPathMode()) {
+            if (isServerPathMode() || isAutoDetectedMode()) {
                 return;
             }
             zone.classList.remove('border-primary', 'bg-primary/5');
@@ -700,14 +753,21 @@ function setupUploadZones() {
             if (selectedServerPath) {
                 return { fileKey, kind: 'server', path: selectedServerPath };
             }
-            if (defaultName && !isDefaultIgnored()) {
+            const mode = String(sourceModeInput.value || '').trim().toLowerCase();
+            if ((mode === 'auto-detected' || mode === 'upload') && defaultName && !isDefaultIgnored()) {
                 return { fileKey, kind: 'default', useDefault: true };
             }
             return null;
         });
 
         const initialMode = String(sourceModeInput.value || '').trim().toLowerCase();
-        setMode(initialMode === 'server-path' ? 'server-path' : defaultMode);
+        if (initialMode === 'server-path') {
+            setMode('server-path');
+        } else if (initialMode === 'auto-detected' || (hasDetectedDefault && !isDefaultIgnored())) {
+            setMode('auto-detected');
+        } else {
+            setMode(defaultMode);
+        }
     });
 
     notifyNuExtTrialDetection();

--- a/webui/static/js/handleFileUpload.js
+++ b/webui/static/js/handleFileUpload.js
@@ -101,6 +101,7 @@
             dropZone: getElementByIdSafe(cfg.dropZoneId),
             sourceModeInput: getElementByIdSafe(cfg.sourceModeInputId),
             serverPathInput: getElementByIdSafe(cfg.serverPathInputId),
+            modeAutoBtn: getElementByIdSafe(cfg.modeAutoBtnId),
             modeUploadBtn: getElementByIdSafe(cfg.modeUploadBtnId),
             modeServerBtn: getElementByIdSafe(cfg.modeServerBtnId),
             dropZoneHint: getElementByIdSafe(cfg.dropZoneHintId),
@@ -108,6 +109,7 @@
             selectedLocalList: getElementByIdSafe(cfg.selectedLocalListId),
             selectedServerContainer: getElementByIdSafe(cfg.selectedServerContainerId),
             selectedServerList: getElementByIdSafe(cfg.selectedServerListId),
+            selectedDetectedContainer: getElementByIdSafe(cfg.selectedDetectedContainerId),
             modalRoot: getElementByIdSafe(cfg.modalRootId),
             modalPath: getElementByIdSafe(cfg.modalPathId),
             modalEntries: getElementByIdSafe(cfg.modalEntriesId),
@@ -159,6 +161,8 @@
         const localPickerId = String(cfg.localPickerId || cfg.historyKey || cfg.formId || "ncpi_local_picker");
         const fileInputResetOnClick = cfg.fileInputResetOnClick !== false;
         const allowMultipleServerSelection = cfg.allowMultipleServerSelection !== false;
+        const allowAutoDetectedSource = Boolean(cfg.allowAutoDetectedSource);
+        const detectedAvailable = Boolean(cfg.detectedAvailable);
         const noMatchesText = String(cfg.noMatchesText || "No matching files or subdirectories found.");
         const noServerSelectionText = String(cfg.noServerSelectionText || "Select at least one file.");
         const serverListErrorText = String(cfg.serverListErrorText || "Failed to list server files.");
@@ -178,6 +182,7 @@
         ).toLowerCase();
         const loadUploadHintText = String(cfg.uploadHintText || "Drag and drop pkl files or click to browse");
         const loadServerHintText = String(cfg.serverHintText || loadUploadHintText);
+        const loadAutoHintText = String(cfg.autoHintText || "Using detected files from previous steps");
 
         const onLocalError = typeof cfg.onLocalError === "function" ? cfg.onLocalError : null;
         const onLocalErrorClear = typeof cfg.onLocalErrorClear === "function" ? cfg.onLocalErrorClear : null;
@@ -206,6 +211,12 @@
         }
 
         function submitIfReady() {
+            if (sourceMode === "auto-detected") {
+                if (detectedAvailable) {
+                    elements.form.submit();
+                }
+                return;
+            }
             if (sourceMode === "upload" && elements.fileInput.files && elements.fileInput.files.length > 0) {
                 elements.form.submit();
                 return;
@@ -317,27 +328,56 @@
         }
 
         function setSourceMode(mode) {
-            sourceMode = allowServerSource && mode === "server-path" ? "server-path" : "upload";
+            if (allowAutoDetectedSource && detectedAvailable && mode === "auto-detected") {
+                sourceMode = "auto-detected";
+            } else if (allowServerSource && mode === "server-path") {
+                sourceMode = "server-path";
+            } else {
+                sourceMode = "upload";
+            }
             elements.sourceModeInput.value = sourceMode;
             clearLocalError();
 
+            if (elements.modeAutoBtn) {
+                elements.modeAutoBtn.classList.remove(...activeButtonClasses);
+                elements.modeAutoBtn.classList.add(...inactiveButtonClasses);
+            }
             elements.modeUploadBtn.classList.remove(...activeButtonClasses);
             elements.modeUploadBtn.classList.add(...inactiveButtonClasses);
             elements.modeServerBtn.classList.remove(...activeButtonClasses);
             elements.modeServerBtn.classList.add(...inactiveButtonClasses);
 
-            if (sourceMode === "upload") {
+            if (sourceMode === "auto-detected") {
+                if (elements.modeAutoBtn) {
+                    elements.modeAutoBtn.classList.add(...activeButtonClasses);
+                    elements.modeAutoBtn.classList.remove(...inactiveButtonClasses);
+                }
+                elements.dropZoneHint.textContent = loadAutoHintText;
+                elements.selectedLocalContainer.classList.add("hidden");
+                elements.selectedServerContainer.classList.add("hidden");
+                if (elements.selectedDetectedContainer) {
+                    elements.selectedDetectedContainer.classList.remove("hidden");
+                }
+            } else if (sourceMode === "upload") {
                 elements.modeUploadBtn.classList.add(...activeButtonClasses);
                 elements.modeUploadBtn.classList.remove(...inactiveButtonClasses);
                 elements.dropZoneHint.textContent = loadUploadHintText;
                 elements.selectedServerContainer.classList.add("hidden");
-                elements.serverPathInput.value = "";
-                serverBrowserSelectedPaths = [];
+                renderSelectedLocalFiles(elements.fileInput.files || []);
+                if (elements.selectedDetectedContainer) {
+                    elements.selectedDetectedContainer.classList.add("hidden");
+                }
             } else {
                 elements.modeServerBtn.classList.add(...activeButtonClasses);
                 elements.modeServerBtn.classList.remove(...inactiveButtonClasses);
                 elements.dropZoneHint.textContent = loadServerHintText;
-                hideSelectedLocalFiles();
+                elements.selectedLocalContainer.classList.add("hidden");
+                const selectedServerPaths = parseSelectedServerFiles();
+                serverBrowserSelectedPaths = selectedServerPaths.slice();
+                setSelectedServerFiles(selectedServerPaths);
+                if (elements.selectedDetectedContainer) {
+                    elements.selectedDetectedContainer.classList.add("hidden");
+                }
             }
         }
 
@@ -524,7 +564,6 @@
             }
             setInputFiles(selected);
             renderSelectedLocalFiles(selected);
-            setSelectedServerFiles([]);
             submitIfReady();
         }
 
@@ -533,6 +572,9 @@
         });
 
         elements.dropZone.addEventListener("click", () => {
+            if (sourceMode === "auto-detected") {
+                return;
+            }
             if (sourceMode === "upload") {
                 const supportsFsaPicker = typeof window.showOpenFilePicker === "function" && window.isSecureContext;
                 if (!supportsFsaPicker) {
@@ -570,6 +612,21 @@
             event.stopPropagation();
             setSourceMode("server-path");
         });
+
+        if (elements.modeAutoBtn) {
+            if (!(allowAutoDetectedSource && detectedAvailable)) {
+                elements.modeAutoBtn.disabled = true;
+                elements.modeAutoBtn.setAttribute("aria-disabled", "true");
+            }
+            elements.modeAutoBtn.addEventListener("click", (event) => {
+                event.stopPropagation();
+                if (!(allowAutoDetectedSource && detectedAvailable)) {
+                    return;
+                }
+                setSourceMode("auto-detected");
+                submitIfReady();
+            });
+        }
 
         ["dragenter", "dragover"].forEach((eventName) => {
             elements.dropZone.addEventListener(eventName, (event) => {
@@ -631,7 +688,11 @@
 
         const defaultModeKey = String(cfg.defaultModeKey || "default_simulation_source_mode");
         const runtimeDefault = String(cfg.defaultMode || runtime[defaultModeKey] || "").toLowerCase();
-        setSourceMode(runtimeDefault === "server-path" ? "server-path" : "upload");
+        if (allowAutoDetectedSource && detectedAvailable && runtimeDefault === "auto-detected") {
+            setSourceMode("auto-detected");
+        } else {
+            setSourceMode(runtimeDefault === "server-path" ? "server-path" : "upload");
+        }
 
         return api;
     }

--- a/webui/templates/2.1.0.field_potential_load.html
+++ b/webui/templates/2.1.0.field_potential_load.html
@@ -62,11 +62,16 @@
 
                     <form id="fieldPotentialUploadForm" action="{{ url_for('field_potential_load_precomputed') }}" method="POST" enctype="multipart/form-data" class="space-y-4">
                         <input type="file" id="fieldPotentialFileInput" name="precomputed_fp_file" class="hidden" accept=".pkl,.pickle" multiple />
-                        <input type="hidden" id="fieldPotentialSourceModeInput" name="precomputed_fp_source_mode" value="upload" />
+                        <input type="hidden" id="fieldPotentialSourceModeInput" name="precomputed_fp_source_mode" value="{{ 'auto-detected' if has_field_potential_data else 'upload' }}" />
                         <input type="hidden" id="fieldPotentialServerFilePathInput" name="precomputed_fp_server_file_path" value="" />
                         <div id="fieldPotentialDropZone"
                             class="drop-zone flex-1 flex flex-col items-center justify-center py-10 px-6 border-2 border-slate-200 dark:border-slate-800 rounded-xl hover:border-primary/50 hover:bg-primary/5 dark:hover:bg-primary/5 transition-all cursor-pointer group">
                             <div class="mb-4 flex flex-wrap items-center justify-center gap-2">
+                                <button type="button" id="fieldPotentialModeAutoBtn"
+                                    class="px-3 py-1.5 text-xs rounded-lg border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300"
+                                    {% if not has_field_potential_data %}disabled aria-disabled="true"{% endif %}>
+                                    Pipeline detection
+                                </button>
                                 <button type="button" id="fieldPotentialModeUploadBtn"
                                     class="px-3 py-1.5 text-xs rounded-lg border border-primary bg-primary/10 text-primary font-semibold">
                                     Local upload
@@ -87,6 +92,10 @@
                             <div id="selectedFieldPotentialServerFile" class="mt-4 text-xs text-slate-500 dark:text-slate-400 hidden">
                                 <span class="block font-semibold text-slate-600 dark:text-slate-300">Selected server files</span>
                                 <div id="selectedFieldPotentialServerFilePath" class="mt-2 font-mono break-all"></div>
+                            </div>
+                            <div id="selectedFieldPotentialDetectedFiles" class="mt-4 text-xs text-slate-500 dark:text-slate-400 hidden">
+                                <span class="block font-semibold text-slate-600 dark:text-slate-300">Detected from previous steps</span>
+                                <div class="mt-2">Using the field potential files already detected in this session.</div>
                             </div>
                         </div>
                     </form>
@@ -236,6 +245,7 @@
             dropZoneId: 'fieldPotentialDropZone',
             sourceModeInputId: 'fieldPotentialSourceModeInput',
             serverPathInputId: 'fieldPotentialServerFilePathInput',
+            modeAutoBtnId: 'fieldPotentialModeAutoBtn',
             modeUploadBtnId: 'fieldPotentialModeUploadBtn',
             modeServerBtnId: 'fieldPotentialModeServerBtn',
             dropZoneHintId: 'fieldPotentialDropZoneHint',
@@ -243,6 +253,7 @@
             selectedLocalListId: 'selectedFieldPotentialFilesList',
             selectedServerContainerId: 'selectedFieldPotentialServerFile',
             selectedServerListId: 'selectedFieldPotentialServerFilePath',
+            selectedDetectedContainerId: 'selectedFieldPotentialDetectedFiles',
             modalRootId: 'fieldPotentialServerFileModal',
             modalPathId: 'fieldPotentialServerFileBrowserPath',
             modalEntriesId: 'fieldPotentialServerFileBrowserEntries',
@@ -255,6 +266,9 @@
             activeButtonClasses: ['border-primary', 'bg-primary/10', 'text-primary', 'font-semibold'],
             inactiveButtonClasses: ['border-slate-200', 'dark:border-slate-700', 'text-slate-600', 'dark:text-slate-300'],
             dragActiveClasses: ['border-primary'],
+            allowAutoDetectedSource: true,
+            detectedAvailable: {{ 'true' if has_field_potential_data else 'false' }},
+            defaultMode: '{{ 'auto-detected' if has_field_potential_data else 'upload' }}',
         });
     }
 </script>

--- a/webui/templates/2.2.0.field_potential_kernel.html
+++ b/webui/templates/2.2.0.field_potential_kernel.html
@@ -2245,12 +2245,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const controls = document.createElement('div');
         controls.className = 'w-full flex flex-wrap items-center justify-center gap-2 mb-1';
+        const hasDetectedDefault = Boolean(defaultLoadedName);
         controls.innerHTML = `
+            <button type="button" data-kernel-upload-action="true" class="kernel-upload-auto px-2.5 py-1 text-[10px] rounded border" ${hasDetectedDefault ? '' : 'disabled aria-disabled="true"'}>Pipeline detection</button>
             <button type="button" data-kernel-upload-action="true" class="kernel-upload-local px-2.5 py-1 text-[10px] rounded border">Local upload</button>
             <button type="button" data-kernel-upload-action="true" class="kernel-upload-server px-2.5 py-1 text-[10px] rounded border">Server file</button>
         `;
         zone.insertBefore(controls, zone.firstChild);
 
+        const autoBtn = controls.querySelector('.kernel-upload-auto');
         const localBtn = controls.querySelector('.kernel-upload-local');
         const serverBtn = controls.querySelector('.kernel-upload-server');
         const hintEl = zone.querySelector('[data-role="hint"]') || zone.querySelector('p.text-\\[10px\\]');
@@ -2293,11 +2296,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const applyModeVisuals = (mode) => {
             const activeClasses = ['border-primary', 'bg-primary/10', 'text-primary', 'font-semibold'];
             const inactiveClasses = ['border-slate-300', 'dark:border-slate-700', 'text-slate-600', 'dark:text-slate-300'];
-            [localBtn, serverBtn].forEach((btn) => {
+            [autoBtn, localBtn, serverBtn].forEach((btn) => {
+                if (!btn) return;
                 btn.classList.remove(...activeClasses);
                 btn.classList.add(...inactiveClasses);
             });
-            if (mode === 'server-path') {
+            if (mode === 'auto-detected' && autoBtn) {
+                autoBtn.classList.add(...activeClasses);
+                autoBtn.classList.remove(...inactiveClasses);
+            } else if (mode === 'server-path') {
                 serverBtn.classList.add(...activeClasses);
                 serverBtn.classList.remove(...inactiveClasses);
             } else {
@@ -2313,9 +2320,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
         let fallbackDefaultName = defaultLoadedName;
 
-        const getMode = () => (
-            String(modeInput.value || '').trim().toLowerCase() === 'server-path' ? 'server-path' : 'upload'
-        );
+        const getMode = () => {
+            const mode = String(modeInput.value || '').trim().toLowerCase();
+            if (mode === 'server-path') return 'server-path';
+            if (mode === 'auto-detected') return 'auto-detected';
+            return 'upload';
+        };
 
         const getSelectedLocalFile = () => (
             fileInput.files && fileInput.files[0] ? fileInput.files[0] : null
@@ -2341,7 +2351,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const renderUploadMode = () => {
             const selectedLocal = getSelectedLocalFile();
-            const localName = selectedLocal ? selectedLocal.name : fallbackDefaultName;
+            const localName = selectedLocal ? selectedLocal.name : '';
             setLocalSummary(localName);
         };
 
@@ -2349,19 +2359,39 @@ document.addEventListener('DOMContentLoaded', () => {
             setServerSummary(serverPathInput.value);
         };
 
+        const renderAutoDetectedMode = () => {
+            setLocalSummary(hasDetectedDefault ? fallbackDefaultName : '');
+            if (hintEl) {
+                hintEl.textContent = hasDetectedDefault
+                    ? 'Using detected file from previous steps'
+                    : 'No detected file available';
+            }
+        };
+
         const setMode = (mode) => {
-            const nextMode = mode === 'server-path' ? 'server-path' : 'upload';
+            const normalized = String(mode || '').trim().toLowerCase();
+            const nextMode = normalized === 'server-path'
+                ? 'server-path'
+                : (normalized === 'auto-detected' ? 'auto-detected' : 'upload');
             modeInput.value = nextMode;
             applyModeVisuals(nextMode);
-            if (nextMode === 'server-path') {
-                fileInput.value = '';
+            if (nextMode === 'auto-detected') {
+                renderAutoDetectedMode();
+            } else if (nextMode === 'server-path') {
                 renderServerMode();
             } else {
-                serverPathInput.value = '';
                 renderUploadMode();
             }
         };
 
+        if (autoBtn) {
+            autoBtn.addEventListener('click', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                if (!hasDetectedDefault) return;
+                setMode('auto-detected');
+            });
+        }
         localBtn.addEventListener('click', (event) => {
             event.preventDefault();
             event.stopPropagation();
@@ -2400,9 +2430,13 @@ document.addEventListener('DOMContentLoaded', () => {
             if (event.target && event.target.closest('[data-kernel-upload-action]')) {
                 return;
             }
-            if (getMode() === 'server-path') {
+            const mode = getMode();
+            if (mode === 'server-path') {
                 await openServerFileModal(serverPathInput, cfg.extensions, cfg.historyKey || KERNEL_SERVER_FILE_HISTORY_KEY);
                 renderServerMode();
+                return;
+            }
+            if (mode === 'auto-detected') {
                 return;
             }
             fileInput.click();
@@ -2460,10 +2494,17 @@ document.addEventListener('DOMContentLoaded', () => {
             renderServerMode();
         });
 
-        const initialMode = getMode();
+        const initialModeRaw = String(modeInput.value || '').trim().toLowerCase();
+        const initialMode = initialModeRaw === 'auto-detected'
+            ? 'auto-detected'
+            : (initialModeRaw === 'server-path' ? 'server-path' : 'upload');
         applyModeVisuals(initialMode);
         if (initialMode === 'server-path') {
             renderServerMode();
+        } else if (initialMode === 'auto-detected') {
+            renderAutoDetectedMode();
+        } else if (hasDetectedDefault && !getSelectedLocalFile() && !String(serverPathInput.value || '').trim()) {
+            setMode('auto-detected');
         } else {
             renderUploadMode();
         }

--- a/webui/templates/2.2.0.field_potential_kernel.html
+++ b/webui/templates/2.2.0.field_potential_kernel.html
@@ -725,10 +725,10 @@
         class="flex justify-between items-center gap-4 mt-10 pt-6 border-t border-border-light dark:border-[#323b67]">
         <!-- Previous/Return Button -->
         <template x-if="activeTab === 'create_kernel'">
-            <a href="{{ url_for('dashboard') }}"
+            <a href="{{ url_for('field_potential') }}"
                 class="flex items-center justify-center gap-2 py-2.5 px-5 w-full sm:w-auto text-primary dark:text-white font-bold text-base rounded-lg hover:bg-primary/10 dark:hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50 dark:focus:ring-offset-background-dark transition-colors border border-primary dark:border-white/50">
                 <span class="material-symbols-outlined">arrow_back</span>
-                Return to ncpi dashboard
+                Back to selection
             </a>
         </template>
         <template x-if="activeTab !== 'create_kernel'">

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -2144,9 +2144,13 @@
                     const axis = this.parserArrayAxesEnabled
                         ? Number.parseInt(String(this.parserAxisChannels || '0'), 10)
                         : 0;
-                    const axisValue = Number.isFinite(axis) && axis >= 0 ? axis : 0;
                     const locatorExpr = dataLocator === '__self__' ? 'data' : `data.${dataLocator}`;
-                    chNamesExpr = `[f"ch{i}" for i in range(${locatorExpr}.shape[${axisValue}])]`;
+                    if (this.parserArrayAxesEnabled && Number.isFinite(axis) && axis < 0) {
+                        chNamesExpr = `['ch0']`;
+                    } else {
+                        const axisValue = Number.isFinite(axis) && axis >= 0 ? axis : 0;
+                        chNamesExpr = `[f"ch{i}" for i in range(${locatorExpr}.shape[${axisValue}])]`;
+                    }
                 } else if (chSource) {
                     chNamesExpr = toPyString(chSource);
                 }
@@ -2177,17 +2181,24 @@
                         `        ch_names=${chNamesExpr},`,
                     ];
                     if (this.parserArrayAxesEnabled) {
-                        const axisItems = [
-                            `            'channels': ${Number.parseInt(String(this.parserAxisChannels || '0'), 10)},`,
-                            `            'samples': ${Number.parseInt(String(this.parserAxisSamples || '1'), 10)},`,
-                        ];
+                        const axisItems = [];
+                        const channelsAxis = Number.parseInt(String(this.parserAxisChannels || '-1'), 10);
+                        if (Number.isFinite(channelsAxis) && channelsAxis >= 0) {
+                            axisItems.push(`            'channels': ${channelsAxis},`);
+                        }
+                        const samplesAxis = Number.parseInt(String(this.parserAxisSamples || '1'), 10);
+                        if (Number.isFinite(samplesAxis) && samplesAxis >= 0) {
+                            axisItems.push(`            'samples': ${samplesAxis},`);
+                        }
                         const idsAxis = Number.parseInt(String(this.parserAxisIds || '-1'), 10);
                         const epochsAxis = Number.parseInt(String(this.parserAxisEpochs || '-1'), 10);
                         if (Number.isFinite(idsAxis) && idsAxis >= 0) axisItems.push(`            'ids': ${idsAxis},`);
                         if (Number.isFinite(epochsAxis) && epochsAxis >= 0) axisItems.push(`            'epochs': ${epochsAxis},`);
-                        lines.push('        array_axes={');
-                        lines.push(...axisItems);
-                        lines.push('        },');
+                        if (axisItems.length > 0) {
+                            lines.push('        array_axes={');
+                            lines.push(...axisItems);
+                            lines.push('        },');
+                        }
                     }
                     const metadataEntries = [];
                     if (recordingTypeValue !== 'None') metadataEntries.push(`            'recording_type': ${recordingTypeValue},`);
@@ -2288,17 +2299,24 @@
                     `        ch_names=${chNamesExpr},`,
                 ];
                 if (this.parserArrayAxesEnabled) {
-                    const axisItems = [
-                        `            'channels': ${Number.parseInt(String(this.parserAxisChannels || '0'), 10)},`,
-                        `            'samples': ${Number.parseInt(String(this.parserAxisSamples || '1'), 10)},`,
-                    ];
+                    const axisItems = [];
+                    const channelsAxis = Number.parseInt(String(this.parserAxisChannels || '-1'), 10);
+                    if (Number.isFinite(channelsAxis) && channelsAxis >= 0) {
+                        axisItems.push(`            'channels': ${channelsAxis},`);
+                    }
+                    const samplesAxis = Number.parseInt(String(this.parserAxisSamples || '1'), 10);
+                    if (Number.isFinite(samplesAxis) && samplesAxis >= 0) {
+                        axisItems.push(`            'samples': ${samplesAxis},`);
+                    }
                     const idsAxis = Number.parseInt(String(this.parserAxisIds || '-1'), 10);
                     const epochsAxis = Number.parseInt(String(this.parserAxisEpochs || '-1'), 10);
                     if (Number.isFinite(idsAxis) && idsAxis >= 0) axisItems.push(`            'ids': ${idsAxis},`);
                     if (Number.isFinite(epochsAxis) && epochsAxis >= 0) axisItems.push(`            'epochs': ${epochsAxis},`);
-                    lines.push('        array_axes={');
-                    lines.push(...axisItems);
-                    lines.push('        },');
+                    if (axisItems.length > 0) {
+                        lines.push('        array_axes={');
+                        lines.push(...axisItems);
+                        lines.push('        },');
+                    }
                 }
                 const metadataEntries = [];
                 if (recordingTypeValue !== 'None') metadataEntries.push(`            'recording_type': ${recordingTypeValue},`);
@@ -3328,6 +3346,7 @@
                                                     <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Channels axis</span>
                                                     <select name="parser_axis_channels" x-model="parserAxisChannels"
                                                         class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm">
+                                                        <option value="-1">None</option>
                                                         <option value="0">Dim 0</option>
                                                         <option value="1">Dim 1</option>
                                                         <option value="2">Dim 2</option>
@@ -3629,6 +3648,7 @@
                                                     <span class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Channels axis</span>
                                                     <select name="parser_axis_channels" x-model="parserAxisChannels"
                                                         class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-background-light dark:bg-[#191e33] text-sm">
+                                                        <option value="-1">None</option>
                                                         <option value="0">Dim 0</option>
                                                         <option value="1">Dim 1</option>
                                                         <option value="2">Dim 2</option>

--- a/webui/templates/4.3.0.compute_predictions.html
+++ b/webui/templates/4.3.0.compute_predictions.html
@@ -49,7 +49,7 @@
     id="compute-predictions-root"
     x-data="{
         runtime: (window.__webuiRuntime || {}),
-        featuresSourceMode: 'upload',
+        featuresSourceMode: '{{ "auto-detected" if default_feature_file else "upload" }}',
         featuresServerFilePath: '',
         assetsSourceMode: 'upload',
         assetsServerFolderPath: '',
@@ -137,7 +137,7 @@
             <div class="grid grid-cols-1 gap-6">
                 <div>
                     <input id="existing-features-file" type="hidden" name="existing_features_file" value="{{ default_feature_file | default('') }}">
-                    <input id="features-source-mode" type="hidden" name="features_source_mode" value="upload">
+                    <input id="features-source-mode" type="hidden" name="features_source_mode" value="{{ 'auto-detected' if default_feature_file else 'upload' }}">
                     <input id="features-server-file-path" type="hidden" name="features_server_file_path" value="">
                     <input id="file-upload-features" class="hidden" name="features_predict_file" type="file" />
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
@@ -156,6 +156,14 @@
                         id="features-drop-zone"
                         class="custom-file-card drop-zone rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                         <div class="flex flex-wrap justify-center gap-2">
+                            <button
+                                id="features-source-auto-btn"
+                                type="button"
+                                class="custom-mode-auto-btn px-3 py-1.5 text-xs rounded-lg border"
+                                {% if not default_feature_file %}disabled aria-disabled="true"{% endif %}
+                            >
+                                Pipeline detection
+                            </button>
                             <button id="features-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border">Local upload</button>
                             <button id="features-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server file</button>
                             <button id="features-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
@@ -758,6 +766,7 @@
         const localName = byId("features-selected-local-name");
         const serverSummary = byId("features-selected-server");
         const serverPathEl = byId("features-selected-server-path");
+        const autoBtn = byId("features-source-auto-btn");
         const uploadBtn = byId("features-source-upload-btn");
         const serverBtn = byId("features-source-server-btn");
         const hintEl = byId("features-drop-zone-hint");
@@ -773,15 +782,35 @@
 
         const activeClasses = ["border-primary", "bg-primary/10", "text-primary", "font-semibold"];
         const inactiveClasses = ["border-slate-300", "dark:border-slate-700", "text-slate-600", "dark:text-slate-300"];
-        [uploadBtn, serverBtn].forEach((btn) => {
+        const modeButtons = [uploadBtn, serverBtn];
+        if (autoBtn) modeButtons.push(autoBtn);
+        modeButtons.forEach((btn) => {
             btn.classList.remove(...activeClasses);
             btn.classList.add(...inactiveClasses);
         });
 
-        const sourceMode = String(featuresSourceModeInput.value || "upload").trim().toLowerCase();
+        const rawMode = String(featuresSourceModeInput.value || "upload").trim().toLowerCase();
+        const sourceMode = rawMode === "auto-detected" ? "auto-detected" : (rawMode === "server-path" ? "server-path" : "upload");
         const serverPath = String(featuresServerFilePathInput.value || "").trim();
         const file = (input.files && input.files[0]) ? input.files[0] : null;
         const existingName = (existingInput.value || "").trim();
+
+        if (sourceMode === "auto-detected") {
+            if (autoBtn) {
+                autoBtn.classList.add(...activeClasses);
+                autoBtn.classList.remove(...inactiveClasses);
+            }
+            if (hintEl) hintEl.textContent = "Using detected features dataframe from previous steps";
+            localSummary.classList.add("hidden");
+            serverSummary.classList.add("hidden");
+            serverPathEl.textContent = "";
+            loadedStatus.style.display = existingName ? "" : "none";
+            notLoadedStatus.style.display = existingName ? "none" : "";
+            if (state) {
+                state.featuresSourceMode = "auto-detected";
+            }
+            return;
+        }
 
         if (sourceMode === "server-path") {
             serverBtn.classList.add(...activeClasses);
@@ -811,7 +840,6 @@
         serverPathEl.textContent = "";
         if (state) {
             state.featuresSourceMode = "upload";
-            state.featuresServerFilePath = "";
         }
 
         if (file) {
@@ -819,19 +847,13 @@
             localSummary.classList.remove("hidden");
             loadedStatus.style.display = "none";
             notLoadedStatus.style.display = "none";
-            existingInput.value = "";
             return;
         }
 
         localName.textContent = "";
         localSummary.classList.add("hidden");
-        if (existingName) {
-            loadedStatus.style.display = "";
-            notLoadedStatus.style.display = "none";
-        } else {
-            loadedStatus.style.display = "none";
-            notLoadedStatus.style.display = "";
-        }
+        loadedStatus.style.display = "none";
+        notLoadedStatus.style.display = "";
     }
 
     function refreshAssetsIndividualCards() {
@@ -920,7 +942,6 @@
                 card.uploadBtn.classList.remove(...inactiveClasses);
                 if (card.hint) card.hint.textContent = "Drag and drop files or click to browse";
                 card.serverSummary.classList.add("hidden");
-                card.serverPath.textContent = "";
                 card.localName.textContent = file ? file.name : "";
                 card.localSummary.classList.toggle("hidden", !file);
             }
@@ -1825,6 +1846,7 @@
         const existingInput = byId("existing-features-file");
         const featuresSourceModeInput = byId("features-source-mode");
         const featuresServerFilePathInput = byId("features-server-file-path");
+        const featuresSourceAutoBtn = byId("features-source-auto-btn");
         const featuresSourceUploadBtn = byId("features-source-upload-btn");
         const featuresSourceServerBtn = byId("features-source-server-btn");
         const featuresServerBrowseBtn = byId("features-server-browse-btn");
@@ -1912,18 +1934,28 @@
             refreshFeaturesLoadStatus();
             refreshAssetsIndividualCards();
         });
+        if (featuresSourceAutoBtn && featuresSourceModeInput) {
+            featuresSourceAutoBtn.addEventListener("click", (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                if (featuresSourceAutoBtn.disabled) return;
+                if (state) {
+                    state.featuresSourceMode = "auto-detected";
+                }
+                featuresSourceModeInput.value = "auto-detected";
+                syncInputValue(featuresSourceModeInput);
+                refreshFeaturesLoadStatus();
+            });
+        }
         if (featuresSourceUploadBtn && featuresSourceModeInput && featuresServerFilePathInput) {
             featuresSourceUploadBtn.addEventListener("click", (event) => {
                 event.preventDefault();
                 event.stopPropagation();
                 if (state) {
                     state.featuresSourceMode = "upload";
-                    state.featuresServerFilePath = "";
                 }
                 featuresSourceModeInput.value = "upload";
-                featuresServerFilePathInput.value = "";
                 syncInputValue(featuresSourceModeInput);
-                syncInputValue(featuresServerFilePathInput);
                 refreshFeaturesLoadStatus();
             });
         }
@@ -1933,12 +1965,9 @@
                 event.stopPropagation();
                 if (state) {
                     state.featuresSourceMode = "server-path";
-                    state.featuresServerFilePath = "";
                 }
                 featuresSourceModeInput.value = "server-path";
                 syncInputValue(featuresSourceModeInput);
-                input.value = "";
-                if (existingInput) existingInput.value = "";
                 refreshFeaturesLoadStatus();
             });
         }
@@ -1966,32 +1995,9 @@
             const normalizedMode = String(mode || "upload").trim().toLowerCase() === "server-path" ? "server-path" : "upload";
             if (state) {
                 state.assetsSourceMode = normalizedMode;
-                if (normalizedMode === "upload") {
-                    state.assetsServerFolderPath = "";
-                    state.assetsModelServerFilePath = "";
-                    state.assetsScalerServerFilePath = "";
-                    state.assetsDensityServerFilePath = "";
-                    state.assetsServerDetectedModel = "";
-                    state.assetsServerDetectedScaler = "";
-                    state.assetsServerDetectedDensity = "";
-                    state.assetsServerInspectError = "";
-                    state.assetsServerFolderFilesPreview = [];
-                    state.assetsServerFolderFilesTotal = 0;
-                    state.assetsServerFolderFilesMore = 0;
-                }
             }
             modelAssetsSourceInput.value = normalizedMode;
             syncInputValue(modelAssetsSourceInput);
-            if (normalizedMode === "upload" && assetsServerFolderInput) {
-                assetsServerFolderInput.value = "";
-                if (assetsModelServerFilePathInput) assetsModelServerFilePathInput.value = "";
-                if (assetsScalerServerFilePathInput) assetsScalerServerFilePathInput.value = "";
-                if (assetsDensityServerFilePathInput) assetsDensityServerFilePathInput.value = "";
-                syncInputValue(assetsServerFolderInput);
-                if (assetsModelServerFilePathInput) syncInputValue(assetsModelServerFilePathInput);
-                if (assetsScalerServerFilePathInput) syncInputValue(assetsScalerServerFilePathInput);
-                if (assetsDensityServerFilePathInput) syncInputValue(assetsDensityServerFilePathInput);
-            }
             if (typeof syncAssetsMode === "function") syncAssetsMode();
             refreshAssetsIndividualCards();
         };
@@ -2011,6 +2017,9 @@
                     }
                     return;
                 }
+                if (mode === "auto-detected") {
+                    return;
+                }
                 input.value = "";
                 input.click();
             });
@@ -2023,13 +2032,9 @@
             if (!setInputFiles(input, dropped, true)) return;
             if (state) {
                 state.featuresSourceMode = "upload";
-                state.featuresServerFilePath = "";
             }
             featuresSourceModeInput.value = "upload";
-            if (featuresServerFilePathInput) featuresServerFilePathInput.value = "";
             syncInputValue(featuresSourceModeInput);
-            if (featuresServerFilePathInput) syncInputValue(featuresServerFilePathInput);
-            if (existingInput) existingInput.value = "";
             input.dispatchEvent(new Event("change", { bubbles: true }));
         });
 
@@ -2041,20 +2046,8 @@
             if (assetsModeFolder) {
                 assetsModeFolder.checked = false;
             }
-            if (assetsServerFolderInput) {
-                assetsServerFolderInput.value = "";
-                syncInputValue(assetsServerFolderInput);
-            }
             if (state) {
                 state.assetsUploadMode = "individual";
-                state.assetsServerFolderPath = "";
-                state.assetsServerDetectedModel = "";
-                state.assetsServerDetectedScaler = "";
-                state.assetsServerDetectedDensity = "";
-                state.assetsServerInspectError = "";
-                state.assetsServerFolderFilesPreview = [];
-                state.assetsServerFolderFilesTotal = 0;
-                state.assetsServerFolderFilesMore = 0;
             }
             if (typeof syncAssetsMode === "function") syncAssetsMode();
             refreshAssetsIndividualCards();
@@ -2181,10 +2174,14 @@
                 const hasLocalFeatures = Boolean(input && input.files && input.files.length);
                 const hasExistingFeatures = Boolean(existingInput && String(existingInput.value || "").trim());
                 const hasServerFeatures = Boolean(featuresServerFilePathInput && String(featuresServerFilePathInput.value || "").trim());
-                if (hasServerFeatures && !hasLocalFeatures && !hasExistingFeatures) {
-                    featuresMode = "server-path";
-                } else if (!hasServerFeatures && (hasLocalFeatures || hasExistingFeatures)) {
-                    featuresMode = "upload";
+                if (!["upload", "server-path", "auto-detected"].includes(featuresMode)) {
+                    if (hasExistingFeatures) {
+                        featuresMode = "auto-detected";
+                    } else if (hasServerFeatures) {
+                        featuresMode = "server-path";
+                    } else {
+                        featuresMode = "upload";
+                    }
                 }
                 featuresSourceModeInput.value = featuresMode;
                 syncInputValue(featuresSourceModeInput);
@@ -2192,7 +2189,21 @@
                     liveState.featuresSourceMode = featuresMode;
                 }
 
-                if (featuresMode === "server-path") {
+                if (featuresMode === "auto-detected") {
+                    if (input) input.value = "";
+                    if (featuresServerFilePathInput) {
+                        featuresServerFilePathInput.value = "";
+                        syncInputValue(featuresServerFilePathInput);
+                    }
+                    if (liveState) {
+                        liveState.featuresServerFilePath = "";
+                    }
+                    if (!hasExistingFeatures) {
+                        event.preventDefault();
+                        window.alert("No detected features dataframe is available from previous steps.");
+                        return;
+                    }
+                } else if (featuresMode === "server-path") {
                     if (input) input.value = "";
                     if (existingInput) existingInput.value = "";
                     if (!hasServerFeatures) {
@@ -2208,9 +2219,10 @@
                     if (liveState) {
                         liveState.featuresServerFilePath = "";
                     }
-                    if (!hasLocalFeatures && !hasExistingFeatures) {
+                    if (existingInput) existingInput.value = "";
+                    if (!hasLocalFeatures) {
                         event.preventDefault();
-                        window.alert("Upload features data, or select a detected features dataframe.");
+                        window.alert("Upload features data or switch source mode.");
                         return;
                     }
                 }
@@ -2231,11 +2243,6 @@
                 let assetsSource = String(modelAssetsSourceInput.value || "upload").trim().toLowerCase();
                 if (assetsSource !== "upload" && assetsSource !== "server-path") {
                     assetsSource = hasServerAny ? "server-path" : "upload";
-                }
-                if (hasServerAny && !hasLocalFolder && !hasLocalIndividual) {
-                    assetsSource = "server-path";
-                } else if (!hasServerAny && (hasLocalFolder || hasLocalIndividual)) {
-                    assetsSource = "upload";
                 }
                 modelAssetsSourceInput.value = assetsSource;
                 syncInputValue(modelAssetsSourceInput);


### PR DESCRIPTION
Unify pipeline detection across modules, fix Features pipeline axis validation, and polish Field Potentials UX

## Summary
1. **Pipeline detected** mode added and aligned across all required sections.
2. Source selections (Pipeline detected / Local upload / Server upload) preserved when switching modes.
3. Fix for silent redirect in **Features → Continue simulation pipeline** when `Channel axis` is `None`.
4. Kernel UI navigation consistency improvement (**Back to selection**).

---

## Main Changes

### 1) Pipeline detected mode across all required sections
Added/extended **Pipeline detection** as a third source mode (alongside Local/Server) in:

- **Inference → Load data**
- **Field Potentials → Load Data**
- **Field Potentials → Proxy**
- **Field Potentials → Kernel**

Behavior:
- Pipeline detected is enabled only when upstream pipeline outputs are available.
- The detected source appears in its own mode (not mirrored as Local/Server).
- UI now avoids false duplication where the same detected file appeared as selected in all three modes.

### 2) Preserve per-mode selections while switching source mode
For upload/source selectors, switching between:
- Pipeline detection
- Local upload
- Server upload

no longer clears previous selections in the other modes.

Final execution behavior remains intentional:
- On submit, only the active mode is used to build the request.
- Non-active mode selections are not used for computation.

### 3) Features pipeline compute fix for optional channel axis
Fixed a regression where **Compute features** could redirect back to selection with no clear UI progress when using pipeline source.

Root cause:
- Backend validation still required non-negative `parser_axis_channels` in a pipeline branch.
- UI already allowed `None` as `-1`.

Fix:
- Accept `parser_axis_channels = -1` (`None`) in pipeline validation.
- Keep explicit validation bounds for all axes.
- Build `array_axes` without `channels` when channels axis is disabled (`-1`).
- Keep uniqueness validation only among active axes.

### 4) Field Potential Kernel navigation parity
In **Kernel configuration**, the first-step left button now matches Proxy UX:

- Label: **Back to selection**
- Route: `field_potential`

(replacing the prior dashboard-return behavior in that location).

---

## Files Touched
- `webui/app.py`
- `webui/templates/3.1.features_methods.html`
- `webui/templates/2.1.0.field_potential_load.html`
- `webui/templates/2.2.0.field_potential_kernel.html`
- `webui/templates/2.3.0.field_potential_proxy.html`
- Related frontend JS/state handling in templates for source-mode persistence and pipeline detection rendering.
