### PR TITLE
refactor(inference-assets): simplify Load Prediction Assets UI, remove folder-mode backend path, add direct picker actions, and gate scaler/SBI settings by uploaded artifacts

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -10564,7 +10564,6 @@ def start_computation_redirect(computation_type):
         inference_features_source_mode = (request.form.get("features_source_mode") or "upload").strip().lower()
         inference_model_assets_source = (request.form.get("model_assets_source") or "upload").strip().lower()
         features_server_file_path = (request.form.get("features_server_file_path") or "").strip()
-        inference_assets_server_folder_path = (request.form.get("inference_assets_server_folder_path") or "").strip()
         inference_model_server_file_path = (request.form.get("inference_model_server_file_path") or "").strip()
         inference_scaler_server_file_path = (request.form.get("inference_scaler_server_file_path") or "").strip()
         inference_density_server_file_path = (request.form.get("inference_density_server_file_path") or "").strip()
@@ -10612,103 +10611,59 @@ def start_computation_redirect(computation_type):
         has_uploaded_model = _has_upload("model_file", "model-file", "file-upload-model")
         has_uploaded_scaler = _has_upload("scaler_file", "scaler-file", "file-upload-scaler")
         has_uploaded_density = _has_upload("density_estimator_file", "density-estimator-file", "file-upload-density-estimator")
-        folder_uploads = [f for f in files_obj.getlist("inference_assets_folder") if f and f.filename]
-        has_folder_uploads = bool(folder_uploads)
         has_individual_assets = has_uploaded_model or has_uploaded_scaler or has_uploaded_density
-        has_server_assets_folder_path = bool(inference_assets_server_folder_path)
         has_server_asset_file_paths = bool(
             inference_model_server_file_path
             or inference_scaler_server_file_path
             or inference_density_server_file_path
         )
-        assets_upload_mode = (request.form.get("assets_upload_mode") or "").strip().lower()
-        if assets_upload_mode not in {"individual", "folder"}:
-            assets_upload_mode = "individual"
         inference_assets_server_files = {}
 
         if inference_model_assets_source not in {"upload", "server-path"}:
-            inference_model_assets_source = "server-path" if (has_server_assets_folder_path or has_server_asset_file_paths) else "upload"
+            inference_model_assets_source = "server-path" if has_server_asset_file_paths else "upload"
         if (
             inference_model_assets_source == "upload"
-            and not has_folder_uploads
             and not has_individual_assets
-            and (has_server_assets_folder_path or has_server_asset_file_paths)
+            and has_server_asset_file_paths
         ):
             inference_model_assets_source = "server-path"
         if (
             inference_model_assets_source == "server-path"
-            and not has_server_assets_folder_path
             and not has_server_asset_file_paths
-            and (has_folder_uploads or has_individual_assets)
+            and has_individual_assets
         ):
             inference_model_assets_source = "upload"
 
         if inference_model_assets_source == "server-path":
-            if assets_upload_mode == "individual" and has_server_assets_folder_path and not has_server_asset_file_paths:
-                assets_upload_mode = "folder"
-            if assets_upload_mode == "folder" and not has_server_assets_folder_path and has_server_asset_file_paths:
-                assets_upload_mode = "individual"
-
-        if inference_model_assets_source == "server-path":
-            if assets_upload_mode == "folder":
+            try:
+                inference_assets_server_files["model_file"] = _validate_existing_file_path(
+                    inference_model_server_file_path,
+                    "Inference server model file",
+                )
+            except Exception as exc:
+                flash(str(exc), 'error')
+                return redirect(request.referrer or url_for('inference'))
+            if inference_scaler_server_file_path:
                 try:
-                    inference_assets_server_files = _collect_inference_assets_folder_files(
-                        inference_assets_server_folder_path
+                    inference_assets_server_files["scaler_file"] = _validate_existing_file_path(
+                        inference_scaler_server_file_path,
+                        "Inference server scaler file",
                     )
                 except Exception as exc:
                     flash(str(exc), 'error')
                     return redirect(request.referrer or url_for('inference'))
-                if "model_file" not in inference_assets_server_files:
-                    flash(
-                        'Server assets folder must contain a model/posterior file (e.g. model.* or posterior.*).',
-                        'error',
-                    )
-                    return redirect(request.referrer or url_for('inference'))
-            else:
+            if inference_density_server_file_path:
                 try:
-                    inference_assets_server_files["model_file"] = _validate_existing_file_path(
-                        inference_model_server_file_path,
-                        "Inference server model file",
+                    inference_assets_server_files["density_estimator_file"] = _validate_existing_file_path(
+                        inference_density_server_file_path,
+                        "Inference server density estimator file",
                     )
                 except Exception as exc:
                     flash(str(exc), 'error')
                     return redirect(request.referrer or url_for('inference'))
-                if inference_scaler_server_file_path:
-                    try:
-                        inference_assets_server_files["scaler_file"] = _validate_existing_file_path(
-                            inference_scaler_server_file_path,
-                            "Inference server scaler file",
-                        )
-                    except Exception as exc:
-                        flash(str(exc), 'error')
-                        return redirect(request.referrer or url_for('inference'))
-                if inference_density_server_file_path:
-                    try:
-                        inference_assets_server_files["density_estimator_file"] = _validate_existing_file_path(
-                            inference_density_server_file_path,
-                            "Inference server density estimator file",
-                        )
-                    except Exception as exc:
-                        flash(str(exc), 'error')
-                        return redirect(request.referrer or url_for('inference'))
         else:
-            if has_folder_uploads and has_individual_assets:
-                flash('Use only one assets upload mode: either individual files or one folder.', 'error')
-                return redirect(request.referrer or url_for('inference'))
-            if assets_upload_mode == "folder" and has_individual_assets:
-                flash('Assets upload mode is set to folder, so individual asset files are not allowed.', 'error')
-                return redirect(request.referrer or url_for('inference'))
-            if assets_upload_mode == "individual" and has_folder_uploads:
-                flash('Assets upload mode is set to individual files, so folder upload is not allowed.', 'error')
-                return redirect(request.referrer or url_for('inference'))
-
-            folder_has_model = False
-            for folder_upload in folder_uploads:
-                if _infer_inference_asset_role(folder_upload.filename or "") == "model_file":
-                    folder_has_model = True
-                    break
-            if not has_uploaded_model and not folder_has_model:
-                flash('Upload a model file, or upload a folder that contains a model/posterior file (e.g. model.* or posterior.*).', 'error')
+            if not has_uploaded_model:
+                flash('Upload a model file or switch assets source to Server file.', 'error')
                 return redirect(request.referrer or url_for('inference'))
 
         estimated_time_remaining = time.time() + 130 # 130 seconds of estimated time remaining
@@ -11167,9 +11122,6 @@ def start_computation_redirect(computation_type):
         }
 
         for i, file_key in enumerate(files_obj):
-            if computation_type == "inference" and file_key == "inference_assets_folder":
-                # Folder uploads are handled below via getlist.
-                continue
             file = files_obj[file_key]
             if not file or not file.filename:
                 if computation_type in {'field_potential_proxy', 'field_potential_kernel', 'field_potential_meeg'}:
@@ -11255,30 +11207,6 @@ def start_computation_redirect(computation_type):
                     file_paths["kernel_params_module_file"] = copied_path
                     kernel_params_module_override = copied_path
         if computation_type == "inference":
-            if inference_model_assets_source != "server-path":
-                folder_uploads = [f for f in files_obj.getlist("inference_assets_folder") if f and f.filename]
-                for idx, upload in enumerate(folder_uploads):
-                    raw_name = upload.filename or ""
-                    base_name = os.path.basename(raw_name)
-                    safe_name = secure_filename(base_name)
-                    if not safe_name:
-                        continue
-                    unique_filename = f"{computation_type}_inference_assets_folder_{idx}_{job_id}_{safe_name}"
-                    file_path = os.path.join(module_upload_dir, unique_filename)
-                    upload.save(file_path)
-
-                    normalized_key = _infer_inference_asset_role(safe_name)
-
-                    # Do not override explicit single-file uploads from dedicated controls.
-                    if normalized_key and normalized_key not in file_paths:
-                        file_paths[normalized_key] = file_path
-                    else:
-                        try:
-                            if os.path.exists(file_path):
-                                os.remove(file_path)
-                        except OSError:
-                            pass
-
             if inference_features_source_mode == "server-path" and inference_features_server_path:
                 copied_name = f"inference_features_predict_0_{job_id}_{os.path.basename(inference_features_server_path)}"
                 copied_path = os.path.join(module_upload_dir, copied_name)
@@ -11324,11 +11252,9 @@ def start_computation_redirect(computation_type):
         data["features_server_file_path"] = (
             inference_features_server_path or (request.form.get("features_server_file_path") or "").strip()
         )
-        data["inference_assets_server_folder_path"] = inference_assets_server_folder_path
         data["inference_model_server_file_path"] = inference_model_server_file_path
         data["inference_scaler_server_file_path"] = inference_scaler_server_file_path
         data["inference_density_server_file_path"] = inference_density_server_file_path
-        data["assets_upload_mode"] = assets_upload_mode
     if computation_type == "inference_training":
         data["training_features_source_mode"] = inference_training_features_source_mode
         data["training_parameters_source_mode"] = inference_training_parameters_source_mode

--- a/webui/templates/4.3.0.compute_predictions.html
+++ b/webui/templates/4.3.0.compute_predictions.html
@@ -63,6 +63,8 @@
         assetsServerFolderFilesPreview: [],
         assetsServerFolderFilesTotal: 0,
         assetsServerFolderFilesMore: 0,
+        hasScalerArtifact: false,
+        hasDensityArtifact: false,
         assetsUploadMode: 'individual',
         modelName: '__auto__',
         autoDetectedBackend: '',
@@ -215,7 +217,7 @@
                 <input id="inference-scaler-server-file-path" type="hidden" name="inference_scaler_server_file_path" value="">
                 <input id="inference-density-server-file-path" type="hidden" name="inference_density_server_file_path" value="">
 
-                <div class="rounded-md border border-slate-200 dark:border-slate-700 p-3 bg-slate-50 dark:bg-slate-800/30">
+                <div class="hidden rounded-md border border-slate-200 dark:border-slate-700 p-3 bg-slate-50 dark:bg-slate-800/30">
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Assets Source</label>
                     <div class="flex flex-wrap gap-2">
                         <button id="assets-source-upload-btn" type="button" data-assets-source-btn="upload" @click="assetsSourceMode = 'upload'; assetsServerFolderPath = ''"
@@ -226,12 +228,12 @@
                         <button id="assets-source-server-btn" type="button" data-assets-source-btn="server-path" @click="assetsSourceMode = 'server-path'"
                             class="px-3 py-1.5 text-xs rounded-lg border transition-colors"
                             :class="assetsSourceMode === 'server-path' ? 'bg-primary/10 border-primary text-primary' : 'border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300'">
-                            Server files
+                            Server upload
                         </button>
                     </div>
                 </div>
 
-                <div>
+                <div class="hidden">
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Assets Selection Mode</label>
                     <div class="flex flex-col sm:flex-row gap-3">
                         <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
@@ -245,7 +247,7 @@
                     </div>
                 </div>
 
-                <div x-show="assetsSourceMode === 'server-path' && assetsUploadMode === 'folder'" x-cloak>
+                <div class="hidden" x-show="assetsSourceMode === 'server-path' && assetsUploadMode === 'folder'" x-cloak>
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                         Assets Folder <span class="text-red-500">*</span>
                     </label>
@@ -287,7 +289,7 @@
                     </div>
                 </div>
 
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6" x-show="assetsUploadMode === 'individual'" x-cloak>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div>
                         <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                             Model / Posterior <span class="text-red-500">*</span>
@@ -297,7 +299,7 @@
                             class="custom-file-card drop-zone mt-1 rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                             <div class="flex flex-wrap justify-center gap-2">
                                 <button id="assets-model-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border">Local upload</button>
-                                <button id="assets-model-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server file</button>
+                                <button id="assets-model-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server upload</button>
                                 <button id="assets-model-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
                             </div>
                             <span class="mt-3 material-symbols-outlined text-4xl text-slate-400 text-center block">upload_file</span>
@@ -332,7 +334,7 @@
                             class="custom-file-card drop-zone mt-1 rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                             <div class="flex flex-wrap justify-center gap-2">
                                 <button id="assets-scaler-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border">Local upload</button>
-                                <button id="assets-scaler-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server file</button>
+                                <button id="assets-scaler-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server upload</button>
                                 <button id="assets-scaler-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
                             </div>
                             <span class="mt-3 material-symbols-outlined text-4xl text-slate-400 text-center block">upload_file</span>
@@ -367,7 +369,7 @@
                             class="custom-file-card drop-zone mt-1 rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                             <div class="flex flex-wrap justify-center gap-2">
                                 <button id="assets-density-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border">Local upload</button>
-                                <button id="assets-density-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server file</button>
+                                <button id="assets-density-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server upload</button>
                                 <button id="assets-density-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
                             </div>
                             <span class="mt-3 material-symbols-outlined text-4xl text-slate-400 text-center block">upload_file</span>
@@ -395,7 +397,7 @@
                     </div>
                 </div>
 
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6" x-show="assetsSourceMode === 'upload' && assetsUploadMode === 'folder'" x-cloak>
+                <div class="hidden grid grid-cols-1 md:grid-cols-2 gap-6" x-show="assetsSourceMode === 'upload' && assetsUploadMode === 'folder'" x-cloak>
                     <div class="md:col-span-2">
                         <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1" for="file-upload-assets-folder">
                             Assets Folder <span class="text-red-500">*</span>
@@ -495,14 +497,21 @@
                     />
                     <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">Used only when "Custom model name..." is selected.</p>
                 </div>
-                <div class="col-span-1 md:col-span-2">
+                <div
+                    class="col-span-1 md:col-span-2 rounded-lg border px-3 py-2 transition-all"
+                    :class="hasScalerArtifact
+                        ? 'border-slate-200 dark:border-slate-700 bg-transparent opacity-100'
+                        : 'border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/30 opacity-60'"
+                >
                     <label class="inline-flex items-center gap-2">
                         <input
+                            id="inference-use-scaler"
                             checked
                             class="rounded border-slate-300 text-primary focus:ring-primary"
                             name="use_scaler"
                             type="checkbox"
                             value="1"
+                            :disabled="!hasScalerArtifact"
                         />
                         <span class="text-sm text-slate-700 dark:text-slate-300">
                             Apply scaler during prediction when a scaler artifact is available
@@ -560,7 +569,12 @@
                 </p>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6" :class="{ 'opacity-60': !isSbiModel() }">
+            <div
+                class="grid grid-cols-1 md:grid-cols-2 gap-6 rounded-lg border p-3 transition-all"
+                :class="(isSbiModel() && hasDensityArtifact)
+                    ? 'border-slate-200 dark:border-slate-700 bg-transparent opacity-100'
+                    : 'border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/30 opacity-60'"
+            >
                 <div>
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-300" for="sbi-num-posterior-samples">
                         num_posterior_samples (optional)
@@ -572,7 +586,7 @@
                         name="sbi_num_posterior_samples"
                         placeholder="500"
                         type="number"
-                        :disabled="!isSbiModel()"
+                        :disabled="!isSbiModel() || !hasDensityArtifact"
                     />
                 </div>
                 <div>
@@ -586,7 +600,7 @@
                         name="sbi_batch_size"
                         placeholder="256"
                         type="number"
-                        :disabled="!isSbiModel()"
+                        :disabled="!isSbiModel() || !hasDensityArtifact"
                     />
                 </div>
                 <div>
@@ -597,7 +611,7 @@
                         class="mt-1 block w-full rounded-md border-slate-300 dark:border-slate-600 shadow-sm focus:border-primary focus:ring-primary sm:text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-white"
                         id="sbi-summary-mode"
                         name="sbi_summary_mode"
-                        :disabled="!isSbiModel()"
+                        :disabled="!isSbiModel() || !hasDensityArtifact"
                     >
                         <option value="mean">Posterior mean</option>
                         <option value="median">Posterior median</option>
@@ -614,7 +628,7 @@
                         placeholder='{}'
                         type="text"
                         value="{}"
-                        :disabled="!isSbiModel()"
+                        :disabled="!isSbiModel() || !hasDensityArtifact"
                     />
                 </div>
             </div>
@@ -622,6 +636,11 @@
             <div class="mt-6" x-show="!isSbiModel()" x-cloak>
                 <p class="text-xs text-slate-500 dark:text-slate-400">
                     SBI settings are not available for non-SBI models.
+                </p>
+            </div>
+            <div class="mt-2" x-show="isSbiModel() && !hasDensityArtifact" x-cloak>
+                <p class="text-xs text-slate-500 dark:text-slate-400">
+                    SBI settings require a Density Estimator artifact.
                 </p>
             </div>
         </section>
@@ -949,6 +968,47 @@
 
         if (state) {
             state.assetsSourceMode = sourceMode;
+        }
+
+        refreshInferenceAssetDependencies();
+    }
+
+    function refreshInferenceAssetDependencies() {
+        const state = getInferenceState();
+        const scalerInput = byId("file-upload-scaler");
+        const densityInput = byId("file-upload-density-estimator");
+        const scalerServerInput = byId("inference-scaler-server-file-path");
+        const densityServerInput = byId("inference-density-server-file-path");
+        const useScalerCheckbox = byId("inference-use-scaler");
+        const sbiNumPosteriorSamplesInput = byId("sbi-num-posterior-samples");
+        const sbiBatchSizeInput = byId("sbi-batch-size");
+        const sbiSummaryModeInput = byId("sbi-summary-mode");
+        const sbiBuildPosteriorKwargsInput = byId("sbi-build-posterior-kwargs");
+
+        const hasScalerArtifact = Boolean(
+            (scalerInput && scalerInput.files && scalerInput.files.length)
+            || (scalerServerInput && String(scalerServerInput.value || "").trim())
+        );
+        const hasDensityArtifact = Boolean(
+            (densityInput && densityInput.files && densityInput.files.length)
+            || (densityServerInput && String(densityServerInput.value || "").trim())
+        );
+        const sbiEnabled = Boolean(state && state.isSbiModel && state.isSbiModel()) && hasDensityArtifact;
+
+        if (useScalerCheckbox) {
+            useScalerCheckbox.disabled = !hasScalerArtifact;
+            if (!hasScalerArtifact) {
+                useScalerCheckbox.checked = false;
+            }
+        }
+        [sbiNumPosteriorSamplesInput, sbiBatchSizeInput, sbiSummaryModeInput, sbiBuildPosteriorKwargsInput].forEach((el) => {
+            if (!el) return;
+            el.disabled = !sbiEnabled;
+        });
+
+        if (state) {
+            state.hasScalerArtifact = hasScalerArtifact;
+            state.hasDensityArtifact = hasDensityArtifact;
         }
     }
 
@@ -2061,6 +2121,8 @@
                     event.preventDefault();
                     event.stopPropagation();
                     setAssetsIndividualSourceMode("upload");
+                    config.input.value = "";
+                    config.input.click();
                 });
             }
             if (config.serverBtn) {
@@ -2068,6 +2130,9 @@
                     event.preventDefault();
                     event.stopPropagation();
                     setAssetsIndividualSourceMode("server-path");
+                    if (config.browseBtn) {
+                        config.browseBtn.click();
+                    }
                 });
             }
             if (config.localClearBtn) {


### PR DESCRIPTION
Simplify Inference Assets flow and enforce artifact-dependent prediction settings

## Summary
This PR refactors **Inference → Compute Predictions → Load Prediction Assets** to reduce UX complexity and align behavior with actual requirements.

Main goals achieved:
- Simplify asset selection UI to direct per-asset upload.
- Remove backend support for deprecated folder-based asset mode.
- Improve interaction by opening pickers immediately from mode buttons.
- Enforce that scaler/SBI options are only configurable when required artifacts are present.

---

## What Changed

### 1) Load Prediction Assets UX simplification
- Removed the effective use of:
  - `Assets source`
  - `Assets Selection Mode`
  - `Assets folder` blocks (local/server)
- Kept direct asset cards as the only visible flow:
  - `Model / Posterior` (required)
  - `Scaler (optional)`
  - `Density Estimator (optional)`

### 2) Terminology update
- Updated button labels in assets cards from:
  - `Server file` → `Server upload`

### 3) Direct picker behavior
- In each asset card:
  - Clicking `Local upload` now opens local file picker immediately.
  - Clicking `Server upload` now opens server file picker immediately.

### 4) Backend cleanup (Inference assets)
Removed deprecated folder-mode handling for inference assets:
- Eliminated backend dependency on:
  - `assets_upload_mode` (`individual` vs `folder`)
  - `inference_assets_folder` (local folder upload)
  - `inference_assets_server_folder_path` (server folder path)
- Inference assets backend now supports only individual assets:
  - `model_file` required
  - `scaler_file` optional
  - `density_estimator_file` optional
- Validation and staging paths were simplified accordingly.

### 5) Artifact-dependent settings gating
- `Apply scaler during prediction when a scaler artifact is available` is disabled when no scaler artifact is loaded.
- `Other Settings (SBI)` fields are disabled unless:
  - current model is SBI-compatible, and
  - a density estimator artifact is loaded.
- Added clear visual “disabled” styling (faded section with muted background/border) for non-configurable states.
- Added explanatory helper text when SBI settings are unavailable due to missing density estimator.

---

## Files Updated
- `webui/templates/4.3.0.compute_predictions.html`
- `webui/app.py`