### PR TITLE
Webui tokens

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -3074,6 +3074,20 @@ def _build_virtual_field_details_for_ui(file_names, filename_format_spec=None):
     return details
 
 
+def _virtual_field_keys_from_details(details):
+    out = []
+    seen = set()
+    for entry in details or []:
+        if not isinstance(entry, dict):
+            continue
+        key = str(entry.get("field") or "").strip()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
+
+
 def _summarize_listed_file_names(listed_file_names):
     cleaned = [str(name or "").replace("\\", "/").strip() for name in (listed_file_names or []) if str(name or "").strip()]
     if not cleaned:
@@ -3123,34 +3137,152 @@ def _summarize_folder_entries(entries):
 
 def _filter_folder_contexts_by_filename_format(folder_contexts, filename_format_spec):
     if not filename_format_spec:
-        return list(folder_contexts or [])
+        return list(folder_contexts or []), {
+            "scope": "file",
+            "matched_count": 0,
+            "total_count": 0,
+            "skipped_names": [],
+        }
     filtered_contexts = []
+    total_count = 0
+    matched_count = 0
+    skipped_names = []
+    filter_scope = "file"
     for context in folder_contexts or []:
         if not isinstance(context, dict):
             continue
         cloned = dict(context)
         selected_entries = list(cloned.get("selected_entries") or [])
         matched_data_files = list(cloned.get("matched_data_files") or [])
-        selected_entries, _ = _filter_named_items_by_filename_format(
-            selected_entries,
-            lambda item: str(item.get("name") or ""),
-            filename_format_spec,
-        )
-        matched_data_files, _ = _filter_named_items_by_filename_format(
-            matched_data_files,
-            lambda item: str(item.get("name") or ""),
-            filename_format_spec,
-        )
+        has_nested_subfolders = bool(cloned.get("has_nested_subfolders"))
+        if has_nested_subfolders:
+            filter_scope = "folder"
+            branch_names = sorted(
+                {
+                    str(item.get("level1_subfolder") or "").strip()
+                    for item in matched_data_files
+                    if str(item.get("level1_subfolder") or "").strip()
+                }
+            )
+            if not branch_names:
+                branch_names = sorted(
+                    {
+                        str(item.get("name") or "").strip()
+                        for item in (cloned.get("all_subfolders") or [])
+                        if str(item.get("name") or "").strip()
+                    }
+                )
+            matched_branch_names, skipped_branch_names = _filter_named_items_by_filename_format(
+                branch_names,
+                lambda item: str(item or ""),
+                filename_format_spec,
+            )
+            total_count += len(branch_names)
+            matched_count += len(matched_branch_names)
+            skipped_names.extend(skipped_branch_names)
+            matched_branch_set = set(matched_branch_names)
+            selected_entries = [
+                item
+                for item in selected_entries
+                if str(item.get("level1_subfolder") or "").strip() in matched_branch_set
+            ]
+            matched_data_files = [
+                item
+                for item in matched_data_files
+                if str(item.get("level1_subfolder") or "").strip() in matched_branch_set
+            ]
+            cloned["all_subfolders"] = [
+                item
+                for item in (cloned.get("all_subfolders") or [])
+                if str(item.get("name") or "").strip() in matched_branch_set
+            ]
+        else:
+            selected_entries, skipped_selected = _filter_named_items_by_filename_format(
+                selected_entries,
+                lambda item: str(item.get("name") or ""),
+                filename_format_spec,
+            )
+            matched_data_files, _ = _filter_named_items_by_filename_format(
+                matched_data_files,
+                lambda item: str(item.get("name") or ""),
+                filename_format_spec,
+            )
+            total_count += len(selected_entries) + len(skipped_selected)
+            matched_count += len(selected_entries)
+            skipped_names.extend(skipped_selected)
         cloned["selected_entries"] = selected_entries
         cloned["matched_data_files"] = matched_data_files
         sample_entry = cloned.get("sample_selected_entry")
-        if not isinstance(sample_entry, dict) or not _matches_filename_format(sample_entry.get("name"), filename_format_spec):
+        if has_nested_subfolders:
+            valid_sample = (
+                isinstance(sample_entry, dict)
+                and str(sample_entry.get("level1_subfolder") or "").strip()
+                and any(
+                    str(item.get("path") or "").strip() == str(sample_entry.get("path") or "").strip()
+                    for item in selected_entries
+                )
+            )
+        else:
+            valid_sample = isinstance(sample_entry, dict) and _matches_filename_format(sample_entry.get("name"), filename_format_spec)
+        if not valid_sample:
             cloned["sample_selected_entry"] = selected_entries[0] if selected_entries else (matched_data_files[0] if matched_data_files else None)
         if cloned["sample_selected_entry"] is None:
             cloned["selected_data_file"] = ""
             cloned["selected_data_pattern"] = ""
         filtered_contexts.append(cloned)
-    return filtered_contexts
+    return filtered_contexts, {
+        "scope": filter_scope,
+        "matched_count": int(matched_count),
+        "total_count": int(total_count),
+        "skipped_names": list(dict.fromkeys([str(item).strip() for item in skipped_names if str(item).strip()])),
+    }
+
+
+def _collect_selected_entries_from_folder_contexts(folder_contexts):
+    collected = []
+    seen_paths = set()
+    for context in folder_contexts or []:
+        if not isinstance(context, dict):
+            continue
+        for entry in (context.get("selected_entries") or []):
+            path = str(entry.get("path") or "").strip() if isinstance(entry, dict) else ""
+            if not path or path in seen_paths:
+                continue
+            seen_paths.add(path)
+            collected.append(entry)
+    collected.sort(key=lambda item: str(item.get("path") or ""))
+    return collected
+
+
+def _filter_selected_entries_by_filename_format(selected_entries, filename_format_spec):
+    rows = [item for item in (selected_entries or []) if isinstance(item, dict)]
+    has_nested_subfolders = any(str(item.get("level1_subfolder") or "").strip() for item in rows)
+    if has_nested_subfolders:
+        level1_names = sorted(
+            {
+                str(item.get("level1_subfolder") or "").strip()
+                for item in rows
+                if str(item.get("level1_subfolder") or "").strip()
+            }
+        )
+        matched_names, skipped_names = _filter_named_items_by_filename_format(
+            level1_names,
+            lambda item: str(item or ""),
+            filename_format_spec,
+        )
+        matched_set = set(matched_names)
+        filtered = [
+            item
+            for item in rows
+            if str(item.get("level1_subfolder") or "").strip() in matched_set
+        ]
+        return filtered, skipped_names, "folder", len(level1_names)
+    filtered, skipped_names = _filter_named_items_by_filename_format(
+        rows,
+        lambda row: str(row.get("name") or ""),
+        filename_format_spec,
+    )
+    return filtered, skipped_names, "file", len(rows)
 
 
 def _filter_empirical_upload_payloads_by_filename_format(payloads, filename_format_spec):
@@ -3214,11 +3346,21 @@ def _build_folder_inspection_profiles(folder_entries, folder_summaries, filename
             continue
 
         if filename_format_spec:
-            folder_file_names = [
-                str(item.get("name") or "").strip()
-                for item in rows
-                if str(item.get("name") or "").strip()
-            ]
+            nested_labels = sorted(
+                {
+                    str(item.get("level1_subfolder") or "").strip()
+                    for item in rows
+                    if str(item.get("level1_subfolder") or "").strip()
+                }
+            )
+            if nested_labels:
+                folder_file_names = nested_labels
+            else:
+                folder_file_names = [
+                    str(item.get("name") or "").strip()
+                    for item in rows
+                    if str(item.get("name") or "").strip()
+                ]
         else:
             folder_file_names = [
                 str(item.get("logical_name") or item.get("name") or "")
@@ -3242,11 +3384,21 @@ def _build_folder_inspection_profiles(folder_entries, folder_summaries, filename
         for ext, ext_rows in sorted(by_ext.items()):
             sample = ext_rows[0]
             if filename_format_spec:
-                ext_names = [
-                    str(item.get("name") or "").strip()
-                    for item in ext_rows
-                    if str(item.get("name") or "").strip()
-                ]
+                nested_ext_labels = sorted(
+                    {
+                        str(item.get("level1_subfolder") or "").strip()
+                        for item in ext_rows
+                        if str(item.get("level1_subfolder") or "").strip()
+                    }
+                )
+                if nested_ext_labels:
+                    ext_names = nested_ext_labels
+                else:
+                    ext_names = [
+                        str(item.get("name") or "").strip()
+                        for item in ext_rows
+                        if str(item.get("name") or "").strip()
+                    ]
             else:
                 ext_names = [
                     str(item.get("logical_name") or item.get("name") or "").strip()
@@ -7046,7 +7198,10 @@ def features_parser_inspect():
     uploads = [f for f in request.files.getlist("file") if f and f.filename]
     _metadata_server_paths_raw = [p.strip() for p in request.form.getlist("metadata_server_path") if p.strip()]
     filename_format_raw = (request.form.get("parser_filename_format") or "").strip()
-    filename_format_spec = _parse_filename_format_spec(filename_format_raw)
+    try:
+        filename_format_spec = _parse_filename_format_spec(filename_format_raw)
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 400
     inspect_path = None
     cleanup_paths = []
     name_candidates = list(listed_file_names)
@@ -7082,30 +7237,33 @@ def features_parser_inspect():
                 data_file_selection_map=empirical_data_file_selections,
             )
             if filename_format_spec:
-                all_entry_count = len(folder_entries)
-                folder_entries, skipped_names = _filter_named_items_by_filename_format(
-                    folder_entries,
-                    lambda row: str(row.get("name") or ""),
+                folder_contexts, folder_filter_stats = _filter_folder_contexts_by_filename_format(
+                    folder_contexts,
                     filename_format_spec,
                 )
-                folder_contexts = _filter_folder_contexts_by_filename_format(folder_contexts, filename_format_spec)
+                folder_entries = _collect_selected_entries_from_folder_contexts(folder_contexts)
                 if not folder_entries:
                     raise ValueError(
-                        f"No files match filename format '{filename_format_spec['raw']}'."
+                        f"No files or first-level folders match filename format '{filename_format_spec['raw']}'."
                     )
                 folder_summaries, extension_summaries = _summarize_folder_entries(folder_entries)
+                skipped_names = folder_filter_stats.get("skipped_names") or []
                 skipped_count = len(skipped_names)
                 if skipped_count > 0:
-                    matched_count = len(folder_entries)
+                    matched_count = int(folder_filter_stats.get("matched_count") or 0)
+                    total_count = int(folder_filter_stats.get("total_count") or 0)
+                    scope = str(folder_filter_stats.get("scope") or "file")
+                    target_label = "first-level folder(s)" if scope == "folder" else "file(s)"
                     filename_filter_stats = {
                         "matched_count": int(matched_count),
                         "skipped_count": int(skipped_count),
                         "skipped_examples": skipped_names[:8],
                         "tokens": list(filename_format_spec.get("tokens") or []),
+                        "scope": scope,
                     }
                     filename_filter_warning = (
-                        f"Filename format filter matched {matched_count} of {all_entry_count} files; "
-                        f"skipped {skipped_count} non-matching file(s)."
+                        f"Filename format filter matched {matched_count} of {total_count} {target_label}; "
+                        f"skipped {skipped_count} non-matching {target_label}."
                     )
             use_prefix = len(folder_summaries) > 1
             for row in folder_entries:
@@ -7157,30 +7315,33 @@ def features_parser_inspect():
                 data_file_selection_map=simulation_data_file_selections,
             )
             if filename_format_spec:
-                all_entry_count = len(folder_entries)
-                folder_entries, skipped_names = _filter_named_items_by_filename_format(
-                    folder_entries,
-                    lambda row: str(row.get("name") or ""),
+                folder_contexts, folder_filter_stats = _filter_folder_contexts_by_filename_format(
+                    folder_contexts,
                     filename_format_spec,
                 )
-                folder_contexts = _filter_folder_contexts_by_filename_format(folder_contexts, filename_format_spec)
+                folder_entries = _collect_selected_entries_from_folder_contexts(folder_contexts)
                 if not folder_entries:
                     raise ValueError(
-                        f"No files match filename format '{filename_format_spec['raw']}'."
+                        f"No files or first-level folders match filename format '{filename_format_spec['raw']}'."
                     )
                 folder_summaries, extension_summaries = _summarize_folder_entries(folder_entries)
+                skipped_names = folder_filter_stats.get("skipped_names") or []
                 skipped_count = len(skipped_names)
                 if skipped_count > 0:
-                    matched_count = len(folder_entries)
+                    matched_count = int(folder_filter_stats.get("matched_count") or 0)
+                    total_count = int(folder_filter_stats.get("total_count") or 0)
+                    scope = str(folder_filter_stats.get("scope") or "file")
+                    target_label = "first-level folder(s)" if scope == "folder" else "file(s)"
                     filename_filter_stats = {
                         "matched_count": int(matched_count),
                         "skipped_count": int(skipped_count),
                         "skipped_examples": skipped_names[:8],
                         "tokens": list(filename_format_spec.get("tokens") or []),
+                        "scope": scope,
                     }
                     filename_filter_warning = (
-                        f"Filename format filter matched {matched_count} of {all_entry_count} files; "
-                        f"skipped {skipped_count} non-matching file(s)."
+                        f"Filename format filter matched {matched_count} of {total_count} {target_label}; "
+                        f"skipped {skipped_count} non-matching {target_label}."
                     )
             use_prefix = len(folder_summaries) > 1
             for row in folder_entries:
@@ -7300,9 +7461,9 @@ def features_parser_inspect():
                         f"Filename format filter matched {len(matched_names)} of {raw_count} files; "
                         f"skipped {len(skipped_names)} non-matching file(s)."
                     )
-            elif not folder_entries:
+            else:
                 raise ValueError(
-                    f"No files match filename format '{filename_format_spec['raw']}'."
+                    f"No files or first-level folders match filename format '{filename_format_spec['raw']}'."
                 )
 
         if folder_entries:
@@ -7454,6 +7615,11 @@ def features_parser_inspect():
                 "fs_hint_hz": fs_hint_hz,
                 "fs_hint_note": fs_hint_note,
             }
+            virtual_keys = _virtual_field_keys_from_details(description.get("virtual_field_details") or [])
+            if virtual_keys:
+                description["candidate_fields"] = list(dict.fromkeys(
+                    list(description.get("candidate_fields") or []) + virtual_keys
+                ))
             if candidate_field_folders and len(folder_summaries) > 1:
                 field_labels = {}
                 for field_name in combined_candidates:
@@ -11254,18 +11420,19 @@ def start_computation_redirect(computation_type):
                     if not selected_entries:
                         raise ValueError("No files available in the selected analysis folder(s).")
                     if filename_format_spec:
-                        selected_entries, skipped_names = _filter_named_items_by_filename_format(
+                        selected_entries, skipped_names, filter_scope, _total_count = _filter_selected_entries_by_filename_format(
                             selected_entries,
-                            lambda row: str(row.get("name") or ""),
                             filename_format_spec,
                         )
                         if skipped_names:
+                            target_label = "first-level subfolder(s)" if filter_scope == "folder" else "file(s)"
                             filename_format_filter_warnings.append(
-                                f"Filename format filter skipped {len(skipped_names)} simulation file(s)."
+                                f"Filename format filter skipped {len(skipped_names)} simulation {target_label}."
                             )
                             app.logger.warning(
-                                "[compute %s] simulation filename format filtered files: matched=%d skipped=%d",
+                                "[compute %s] simulation filename format filtered %s: matched=%d skipped=%d",
                                 job_id,
+                                target_label,
                                 len(selected_entries),
                                 len(skipped_names),
                             )
@@ -11275,11 +11442,15 @@ def start_computation_redirect(computation_type):
                             )
                     use_prefix = len(folder_summaries) > 1
                     for entry in selected_entries:
-                        logical_name = _prefixed_file_name(
-                            entry["name"],
-                            entry.get("folder_name"),
-                            apply_prefix=use_prefix,
-                        )
+                        nested_label = str(entry.get("level1_subfolder") or "").strip()
+                        if filename_format_spec and nested_label:
+                            logical_name = nested_label
+                        else:
+                            logical_name = _prefixed_file_name(
+                                entry["name"],
+                                entry.get("folder_name"),
+                                apply_prefix=use_prefix,
+                            )
                         empirical_upload_paths.append({
                             "name": logical_name,
                             "ext": entry["extension"],
@@ -11478,18 +11649,19 @@ def start_computation_redirect(computation_type):
                     if not selected_entries:
                         raise ValueError("No files available in the selected analysis folder(s).")
                     if filename_format_spec:
-                        selected_entries, skipped_names = _filter_named_items_by_filename_format(
+                        selected_entries, skipped_names, filter_scope, _total_count = _filter_selected_entries_by_filename_format(
                             selected_entries,
-                            lambda row: str(row.get("name") or ""),
                             filename_format_spec,
                         )
                         if skipped_names:
+                            target_label = "first-level subfolder(s)" if filter_scope == "folder" else "file(s)"
                             filename_format_filter_warnings.append(
-                                f"Filename format filter skipped {len(skipped_names)} empirical file(s)."
+                                f"Filename format filter skipped {len(skipped_names)} empirical {target_label}."
                             )
                             app.logger.warning(
-                                "[compute %s] empirical filename format filtered files: matched=%d skipped=%d",
+                                "[compute %s] empirical filename format filtered %s: matched=%d skipped=%d",
                                 job_id,
+                                target_label,
                                 len(selected_entries),
                                 len(skipped_names),
                             )
@@ -11499,11 +11671,15 @@ def start_computation_redirect(computation_type):
                             )
                     use_prefix = len(folder_summaries) > 1
                     for entry in selected_entries:
-                        logical_name = _prefixed_file_name(
-                            entry["name"],
-                            entry.get("folder_name"),
-                            apply_prefix=use_prefix,
-                        )
+                        nested_label = str(entry.get("level1_subfolder") or "").strip()
+                        if filename_format_spec and nested_label:
+                            logical_name = nested_label
+                        else:
+                            logical_name = _prefixed_file_name(
+                                entry["name"],
+                                entry.get("folder_name"),
+                                apply_prefix=use_prefix,
+                            )
                         empirical_upload_paths.append({
                             "name": logical_name,
                             "ext": entry["extension"],

--- a/webui/app.py
+++ b/webui/app.py
@@ -131,6 +131,8 @@ FEATURES_PARSER_FILE_EXTENSIONS = {
 FEATURES_MAX_SUBFOLDER_DEPTH = 6
 FILE_EXTRACTED_VIRTUAL_FIELD = "__file_extracted_label__"
 FILE_EXTRACTED_VIRTUAL_FIELD_PREFIX = "__file_extracted_chain_"
+FILE_TOKEN_VIRTUAL_FIELD_PREFIX = "__file_token_"
+FILE_TOKEN_VIRTUAL_FIELD_SUFFIX = "__"
 FILE_ID_METADATA_LITERAL = "file_ID"
 PICKLE_EXTENSIONS = {".pkl", ".pickle"}
 MAX_EMPIRICAL_UPLOAD_BYTES = int(os.environ.get("NCPI_MAX_EMPIRICAL_UPLOAD_BYTES", str(1024 * 1024 * 1024)))
@@ -2141,6 +2143,121 @@ def _extract_filename_text_chains(file_name):
     return [tok for tok in stem.split("_") if tok.strip()]
 
 
+_FILENAME_FORMAT_TOKEN_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+
+
+def _file_token_virtual_field_key(token_name):
+    token = str(token_name or "").strip().lower()
+    return f"{FILE_TOKEN_VIRTUAL_FIELD_PREFIX}{token}{FILE_TOKEN_VIRTUAL_FIELD_SUFFIX}" if token else ""
+
+
+def _file_token_locator_name(locator):
+    if not isinstance(locator, str):
+        return None
+    raw = str(locator).strip()
+    if not raw.startswith(FILE_TOKEN_VIRTUAL_FIELD_PREFIX):
+        return None
+    token = raw[len(FILE_TOKEN_VIRTUAL_FIELD_PREFIX):]
+    if token.endswith(FILE_TOKEN_VIRTUAL_FIELD_SUFFIX):
+        token = token[: -len(FILE_TOKEN_VIRTUAL_FIELD_SUFFIX)]
+    token = token.strip().lower()
+    if not token or not _FILENAME_FORMAT_TOKEN_NAME_RE.fullmatch(token):
+        return None
+    return token
+
+
+def _parse_filename_format_spec(raw_format):
+    value = str(raw_format or "").strip()
+    if not value:
+        return None
+
+    pieces = []
+    token_names = []
+    token_seen = set()
+    idx = 0
+    while idx < len(value):
+        ch = value[idx]
+        if ch != "$":
+            pieces.append(("literal", ch))
+            idx += 1
+            continue
+        closing = value.find("$", idx + 1)
+        if closing < 0:
+            raise ValueError("Invalid filename format: missing closing '$'.")
+        token_raw = value[idx + 1:closing].strip()
+        if not token_raw:
+            raise ValueError("Invalid filename format: empty token '$$' is not allowed.")
+        token = token_raw.lower()
+        if not _FILENAME_FORMAT_TOKEN_NAME_RE.fullmatch(token):
+            raise ValueError(
+                f"Invalid filename format token '{token_raw}'. Use letters/numbers/underscore and start with a letter."
+            )
+        if token in token_seen:
+            raise ValueError(f"Invalid filename format: token '{token_raw}' is duplicated.")
+        token_seen.add(token)
+        token_names.append(token)
+        pieces.append(("token", token))
+        idx = closing + 1
+
+    if not token_names:
+        raise ValueError("Filename format must include at least one token, e.g. $id$.")
+
+    regex_parts = []
+    group_map = []
+    token_idx = 0
+    for kind, value_part in pieces:
+        if kind == "literal":
+            regex_parts.append(re.escape(value_part))
+            continue
+        group_name = f"tok{token_idx}"
+        token_idx += 1
+        group_map.append((group_name, value_part))
+        regex_parts.append(f"(?P<{group_name}>.+?)")
+
+    return {
+        "raw": value,
+        "tokens": token_names,
+        "group_map": group_map,
+        "regex": re.compile("^" + "".join(regex_parts) + "$"),
+    }
+
+
+def _extract_filename_format_tokens(file_name, format_spec):
+    if not format_spec:
+        return None
+    basename = os.path.basename(str(file_name or "").strip())
+    if not basename:
+        return None
+    matcher = format_spec.get("regex")
+    if matcher is None:
+        return None
+    match = matcher.fullmatch(basename)
+    if not match:
+        return None
+    out = {}
+    for group_name, token_name in (format_spec.get("group_map") or []):
+        out[str(token_name)] = str(match.group(group_name) or "").strip()
+    return out
+
+
+def _matches_filename_format(file_name, format_spec):
+    return _extract_filename_format_tokens(file_name, format_spec) is not None
+
+
+def _filter_named_items_by_filename_format(items, get_name, format_spec):
+    if not format_spec:
+        return list(items or []), []
+    filtered = []
+    skipped = []
+    for item in items or []:
+        name = str(get_name(item) or "").strip()
+        if _matches_filename_format(name, format_spec):
+            filtered.append(item)
+        else:
+            skipped.append(name)
+    return filtered, skipped
+
+
 def _build_file_extracted_virtual_fields(file_names):
     chain_rows = [_extract_filename_text_chains(name) for name in (file_names or [])]
     max_chains = max((len(row) for row in chain_rows), default=0)
@@ -2174,8 +2291,44 @@ def _build_file_extracted_virtual_fields(file_names):
     return fields
 
 
-def _attach_file_extracted_virtual_field(description, file_names):
-    field_infos = _build_file_extracted_virtual_fields(file_names)
+def _build_file_token_virtual_fields(file_names, format_spec):
+    if not format_spec:
+        return []
+    token_values = {token: [] for token in (format_spec.get("tokens") or [])}
+    token_seen = {token: set() for token in token_values}
+    for raw_name in file_names or []:
+        extracted = _extract_filename_format_tokens(raw_name, format_spec)
+        if not extracted:
+            continue
+        for token in token_values:
+            value = str(extracted.get(token) or "").strip()
+            if not value:
+                continue
+            key = value.lower()
+            if key in token_seen[token]:
+                continue
+            token_seen[token].add(key)
+            token_values[token].append(value)
+    fields = []
+    for token in (format_spec.get("tokens") or []):
+        values = token_values.get(token) or []
+        preview = "/".join(values[:6]) if values else token
+        if len(values) > 6:
+            preview += "/..."
+        fields.append({
+            "key": _file_token_virtual_field_key(token),
+            "label": f"file token `{token}`: {preview}",
+            "values": values,
+            "token": token,
+        })
+    return fields
+
+
+def _attach_file_extracted_virtual_field(description, file_names, filename_format_spec=None):
+    if filename_format_spec:
+        field_infos = _build_file_token_virtual_fields(file_names, filename_format_spec)
+    else:
+        field_infos = _build_file_extracted_virtual_fields(file_names)
     if not field_infos:
         return description
     enriched = dict(description or {})
@@ -2222,6 +2375,16 @@ def _resolve_file_extracted_value(file_name, locator):
     if index >= len(chains):
         return None
     return chains[index]
+
+
+def _resolve_file_token_value(file_name, locator, filename_format_spec):
+    token = _file_token_locator_name(locator)
+    if not token:
+        return None
+    extracted = _extract_filename_format_tokens(file_name, filename_format_spec)
+    if not extracted:
+        return None
+    return extracted.get(token)
 
 
 def _collect_feature_pipeline_inputs():
@@ -2828,7 +2991,7 @@ def _manual_field_details_for_ui():
     ]
 
 
-def _build_virtual_field_details_for_ui(file_names):
+def _build_virtual_field_details_for_ui(file_names, filename_format_spec=None):
     normalized_names = []
     seen_names = set()
     for raw in file_names or []:
@@ -2858,7 +3021,12 @@ def _build_virtual_field_details_for_ui(file_names):
         "example_values": file_id_examples,
         "usage_examples": file_id_usage,
     }]
-    for item in _build_file_extracted_virtual_fields(file_names):
+    if filename_format_spec:
+        virtual_items = _build_file_token_virtual_fields(file_names, filename_format_spec)
+    else:
+        virtual_items = _build_file_extracted_virtual_fields(file_names)
+
+    for item in virtual_items:
         key = str(item.get("key") or "").strip()
         if not key:
             continue
@@ -2867,8 +3035,13 @@ def _build_virtual_field_details_for_ui(file_names):
         if len(values) > 5:
             preview += ", ..."
         position = _file_extracted_chain_index(key)
+        token_name = _file_token_locator_name(key)
         usage_examples = []
-        if position is not None and position >= 0:
+        if token_name:
+            usage_examples.append(
+                f"Represents the `{token_name}` token extracted from the filename format."
+            )
+        elif position is not None and position >= 0:
             usage_examples.append(
                 f"Represents token position {position + 1} extracted from file names."
             )
@@ -2890,7 +3063,11 @@ def _build_virtual_field_details_for_ui(file_names):
             "label": str(item.get("label") or key),
             "origin": "virtual",
             "python_type": "str",
-            "detail": f"Tokens extracted from file names: {preview}" if preview else "Tokens extracted from file names.",
+            "detail": (
+                f"Values extracted for token `{token_name}`: {preview}"
+                if token_name and preview
+                else (f"Tokens extracted from file names: {preview}" if preview else "Tokens extracted from file names.")
+            ),
             "example_values": values[:8],
             "usage_examples": usage_examples,
         })
@@ -2924,6 +3101,69 @@ def _summarize_listed_file_names(listed_file_names):
     }
 
 
+def _summarize_folder_entries(entries):
+    folder_counts = defaultdict(int)
+    ext_counts = defaultdict(int)
+    for entry in entries or []:
+        folder_name = str(entry.get("folder_name") or "selected_folder")
+        folder_path = str(entry.get("folder_path") or "")
+        folder_counts[(folder_name, folder_path)] += 1
+        ext = str(entry.get("extension") or Path(str(entry.get("name") or "")).suffix.lower() or "(no extension)")
+        ext_counts[ext] += 1
+    folder_summaries = [
+        {"folder_name": name, "folder_path": path, "file_count": int(count)}
+        for (name, path), count in sorted(folder_counts.items(), key=lambda item: (item[0][0], item[0][1]))
+    ]
+    extension_summaries = [
+        {"extension": ext, "count": int(count)}
+        for ext, count in sorted(ext_counts.items())
+    ]
+    return folder_summaries, extension_summaries
+
+
+def _filter_folder_contexts_by_filename_format(folder_contexts, filename_format_spec):
+    if not filename_format_spec:
+        return list(folder_contexts or [])
+    filtered_contexts = []
+    for context in folder_contexts or []:
+        if not isinstance(context, dict):
+            continue
+        cloned = dict(context)
+        selected_entries = list(cloned.get("selected_entries") or [])
+        matched_data_files = list(cloned.get("matched_data_files") or [])
+        selected_entries, _ = _filter_named_items_by_filename_format(
+            selected_entries,
+            lambda item: str(item.get("name") or ""),
+            filename_format_spec,
+        )
+        matched_data_files, _ = _filter_named_items_by_filename_format(
+            matched_data_files,
+            lambda item: str(item.get("name") or ""),
+            filename_format_spec,
+        )
+        cloned["selected_entries"] = selected_entries
+        cloned["matched_data_files"] = matched_data_files
+        sample_entry = cloned.get("sample_selected_entry")
+        if not isinstance(sample_entry, dict) or not _matches_filename_format(sample_entry.get("name"), filename_format_spec):
+            cloned["sample_selected_entry"] = selected_entries[0] if selected_entries else (matched_data_files[0] if matched_data_files else None)
+        if cloned["sample_selected_entry"] is None:
+            cloned["selected_data_file"] = ""
+            cloned["selected_data_pattern"] = ""
+        filtered_contexts.append(cloned)
+    return filtered_contexts
+
+
+def _filter_empirical_upload_payloads_by_filename_format(payloads, filename_format_spec):
+    if not filename_format_spec:
+        return list(payloads or []), []
+    filtered, skipped = _filter_named_items_by_filename_format(
+        payloads,
+        lambda item: str(item.get("name") or ""),
+        filename_format_spec,
+    )
+    return filtered, skipped
+
+
 def _validate_listed_file_names_by_folder_extension(listed_file_names, label="Selected"):
     entries = []
     for raw in listed_file_names or []:
@@ -2951,7 +3191,7 @@ def _validate_listed_file_names_by_folder_extension(listed_file_names, label="Se
     # selected data source via per-folder data-file selections.
 
 
-def _build_folder_inspection_profiles(folder_entries, folder_summaries):
+def _build_folder_inspection_profiles(folder_entries, folder_summaries, filename_format_spec=None):
     entries_by_folder = defaultdict(list)
     for row in folder_entries or []:
         folder_path = str(row.get("folder_path") or "").strip()
@@ -2973,7 +3213,18 @@ def _build_folder_inspection_profiles(folder_entries, folder_summaries):
         if not rows:
             continue
 
-        folder_file_names = [str(item.get("logical_name") or item.get("name") or "") for item in rows if str(item.get("logical_name") or item.get("name") or "").strip()]
+        if filename_format_spec:
+            folder_file_names = [
+                str(item.get("name") or "").strip()
+                for item in rows
+                if str(item.get("name") or "").strip()
+            ]
+        else:
+            folder_file_names = [
+                str(item.get("logical_name") or item.get("name") or "")
+                for item in rows
+                if str(item.get("logical_name") or item.get("name") or "").strip()
+            ]
         combined_logical_names.extend(folder_file_names)
 
         by_ext = defaultdict(list)
@@ -2990,14 +3241,28 @@ def _build_folder_inspection_profiles(folder_entries, folder_summaries):
         extension_profiles = []
         for ext, ext_rows in sorted(by_ext.items()):
             sample = ext_rows[0]
-            ext_names = [
-                str(item.get("logical_name") or item.get("name") or "").strip()
-                for item in ext_rows
-                if str(item.get("logical_name") or item.get("name") or "").strip()
-            ]
+            if filename_format_spec:
+                ext_names = [
+                    str(item.get("name") or "").strip()
+                    for item in ext_rows
+                    if str(item.get("name") or "").strip()
+                ]
+            else:
+                ext_names = [
+                    str(item.get("logical_name") or item.get("name") or "").strip()
+                    for item in ext_rows
+                    if str(item.get("logical_name") or item.get("name") or "").strip()
+                ]
             ext_description = _describe_parser_source(sample["path"])
-            ext_description = _attach_file_extracted_virtual_field(ext_description, ext_names)
-            ext_description["virtual_field_details"] = _build_virtual_field_details_for_ui(ext_names)
+            ext_description = _attach_file_extracted_virtual_field(
+                ext_description,
+                ext_names,
+                filename_format_spec=filename_format_spec,
+            )
+            ext_description["virtual_field_details"] = _build_virtual_field_details_for_ui(
+                ext_names,
+                filename_format_spec=filename_format_spec,
+            )
             ext_description["manual_field_details"] = _manual_field_details_for_ui()
             ext_description["extension"] = ext
             ext_description["sample_file"] = str(sample.get("logical_name") or sample.get("name") or "")
@@ -3023,7 +3288,10 @@ def _build_folder_inspection_profiles(folder_entries, folder_summaries):
             "file_count": len(rows),
             "extension_summaries": extension_summaries,
             "extension_profiles": extension_profiles,
-            "virtual_field_details": _build_virtual_field_details_for_ui(folder_file_names),
+            "virtual_field_details": _build_virtual_field_details_for_ui(
+                folder_file_names,
+                filename_format_spec=filename_format_spec,
+            ),
         })
 
     extension_summaries_global = [
@@ -3144,6 +3412,38 @@ def _parse_metadata_field_source(form, source_key, value_key):
         return source
     value = (form.get(value_key) or "").strip()
     return value or None
+
+
+def _validate_parse_cfg_filename_token_locators(parse_cfg, form):
+    metadata_locators = (
+        dict(parse_cfg.fields.metadata or {})
+        if getattr(parse_cfg, "fields", None) is not None
+        else {}
+    )
+    requested_tokens = {}
+    for meta_key, locator in metadata_locators.items():
+        token = _file_token_locator_name(locator)
+        if token:
+            requested_tokens[str(meta_key)] = token
+    if not requested_tokens:
+        return None
+
+    filename_format_spec = _parse_filename_format_spec(form.get("parser_filename_format"))
+    if not filename_format_spec:
+        fields = ", ".join(sorted(requested_tokens.keys()))
+        raise ValueError(
+            "Filename format is required because metadata fields use filename token locators: "
+            f"{fields}."
+        )
+    allowed_tokens = set(filename_format_spec.get("tokens") or [])
+    missing_tokens = sorted({token for token in requested_tokens.values() if token not in allowed_tokens})
+    if missing_tokens:
+        raise ValueError(
+            "Filename format does not define token(s) used in metadata mapping: "
+            + ", ".join(missing_tokens)
+            + "."
+        )
+    return filename_format_spec
 
 
 def _collect_dataframe_candidate_fields_from_description(description):
@@ -4036,6 +4336,7 @@ def _normalize_features_input_path(source_path, form, job_id, upload_dir=None):
         )
 
     parse_cfg = _build_parse_config_from_form(form)
+    filename_format_spec = _validate_parse_cfg_filename_token_locators(parse_cfg, form)
     _validate_data_locator_against_dataframe_source(
         parse_cfg.fields.data,
         source_obj,
@@ -4075,6 +4376,11 @@ def _normalize_features_input_path(source_path, form, job_id, upload_dir=None):
         for key, locator in metadata_map.items()
         if _file_extracted_chain_index(locator) is not None
     }
+    file_token_fields = {
+        str(key): str(locator)
+        for key, locator in metadata_map.items()
+        if _file_token_locator_name(locator) is not None
+    }
     source_label = os.path.basename(str(source_path or ""))
     if file_id_fields:
         for col_name in file_id_fields:
@@ -4082,6 +4388,15 @@ def _normalize_features_input_path(source_path, form, job_id, upload_dir=None):
     if file_extracted_fields:
         for col_name, locator in file_extracted_fields.items():
             parsed_df[col_name] = _resolve_file_extracted_value(source_label, locator)
+    if file_token_fields:
+        for col_name, locator in file_token_fields.items():
+            token_value = _resolve_file_token_value(source_label, locator, filename_format_spec)
+            if token_value is None:
+                token_name = _file_token_locator_name(locator) or locator
+                raise ValueError(
+                    f"Source file '{source_label}' does not match the filename format for token '{token_name}'."
+                )
+            parsed_df[col_name] = token_value
     target_upload_dir = upload_dir or _module_uploads_dir_for("features")
     os.makedirs(target_upload_dir, exist_ok=True)
     normalized_path = os.path.join(target_upload_dir, f"features_data_file_0_{job_id}_parsed.pkl")
@@ -6730,6 +7045,8 @@ def features_parser_inspect():
     listed_file_names = [str(item).strip() for item in request.form.getlist("listed_file_names") if str(item).strip()]
     uploads = [f for f in request.files.getlist("file") if f and f.filename]
     _metadata_server_paths_raw = [p.strip() for p in request.form.getlist("metadata_server_path") if p.strip()]
+    filename_format_raw = (request.form.get("parser_filename_format") or "").strip()
+    filename_format_spec = _parse_filename_format_spec(filename_format_raw)
     inspect_path = None
     cleanup_paths = []
     name_candidates = list(listed_file_names)
@@ -6742,6 +7059,8 @@ def features_parser_inspect():
     folder_contexts = []
     candidate_field_folders = {}
     folder_file_count = 0
+    filename_filter_stats = None
+    filename_filter_warning = ""
 
     try:
         if listed_file_names:
@@ -6750,6 +7069,10 @@ def features_parser_inspect():
         if existing_data_path:
             inspect_path = _validate_feature_existing_path(existing_data_path)
             file_name = os.path.basename(inspect_path)
+            if filename_format_spec and not _matches_filename_format(file_name, filename_format_spec):
+                raise ValueError(
+                    f"No files match filename format '{filename_format_spec['raw']}'."
+                )
             if not name_candidates:
                 name_candidates.append(file_name)
         elif empirical_folder_paths:
@@ -6758,6 +7081,32 @@ def features_parser_inspect():
                 "Empirical",
                 data_file_selection_map=empirical_data_file_selections,
             )
+            if filename_format_spec:
+                all_entry_count = len(folder_entries)
+                folder_entries, skipped_names = _filter_named_items_by_filename_format(
+                    folder_entries,
+                    lambda row: str(row.get("name") or ""),
+                    filename_format_spec,
+                )
+                folder_contexts = _filter_folder_contexts_by_filename_format(folder_contexts, filename_format_spec)
+                if not folder_entries:
+                    raise ValueError(
+                        f"No files match filename format '{filename_format_spec['raw']}'."
+                    )
+                folder_summaries, extension_summaries = _summarize_folder_entries(folder_entries)
+                skipped_count = len(skipped_names)
+                if skipped_count > 0:
+                    matched_count = len(folder_entries)
+                    filename_filter_stats = {
+                        "matched_count": int(matched_count),
+                        "skipped_count": int(skipped_count),
+                        "skipped_examples": skipped_names[:8],
+                        "tokens": list(filename_format_spec.get("tokens") or []),
+                    }
+                    filename_filter_warning = (
+                        f"Filename format filter matched {matched_count} of {all_entry_count} files; "
+                        f"skipped {skipped_count} non-matching file(s)."
+                    )
             use_prefix = len(folder_summaries) > 1
             for row in folder_entries:
                 row["logical_name"] = _prefixed_file_name(row["name"], row["folder_name"], apply_prefix=use_prefix)
@@ -6780,7 +7129,11 @@ def features_parser_inspect():
                 _combined_candidates_from_profiles,
                 _candidate_field_folders_from_profiles,
                 combined_logical_names,
-            ) = _build_folder_inspection_profiles(folder_entries, folder_summaries)
+            ) = _build_folder_inspection_profiles(
+                folder_entries,
+                folder_summaries,
+                filename_format_spec=filename_format_spec,
+            )
             if not name_candidates:
                 name_candidates = combined_logical_names
             extension_profiles = [
@@ -6791,6 +7144,10 @@ def features_parser_inspect():
         elif simulation_file_path:
             inspect_path = _validate_simulation_file_path(simulation_file_path)
             file_name = os.path.basename(inspect_path)
+            if filename_format_spec and not _matches_filename_format(file_name, filename_format_spec):
+                raise ValueError(
+                    f"No files match filename format '{filename_format_spec['raw']}'."
+                )
             if not name_candidates:
                 name_candidates.append(file_name)
         elif simulation_folder_paths:
@@ -6799,6 +7156,32 @@ def features_parser_inspect():
                 "Simulation outputs",
                 data_file_selection_map=simulation_data_file_selections,
             )
+            if filename_format_spec:
+                all_entry_count = len(folder_entries)
+                folder_entries, skipped_names = _filter_named_items_by_filename_format(
+                    folder_entries,
+                    lambda row: str(row.get("name") or ""),
+                    filename_format_spec,
+                )
+                folder_contexts = _filter_folder_contexts_by_filename_format(folder_contexts, filename_format_spec)
+                if not folder_entries:
+                    raise ValueError(
+                        f"No files match filename format '{filename_format_spec['raw']}'."
+                    )
+                folder_summaries, extension_summaries = _summarize_folder_entries(folder_entries)
+                skipped_count = len(skipped_names)
+                if skipped_count > 0:
+                    matched_count = len(folder_entries)
+                    filename_filter_stats = {
+                        "matched_count": int(matched_count),
+                        "skipped_count": int(skipped_count),
+                        "skipped_examples": skipped_names[:8],
+                        "tokens": list(filename_format_spec.get("tokens") or []),
+                    }
+                    filename_filter_warning = (
+                        f"Filename format filter matched {matched_count} of {all_entry_count} files; "
+                        f"skipped {skipped_count} non-matching file(s)."
+                    )
             use_prefix = len(folder_summaries) > 1
             for row in folder_entries:
                 row["logical_name"] = _prefixed_file_name(row["name"], row["folder_name"], apply_prefix=use_prefix)
@@ -6821,7 +7204,11 @@ def features_parser_inspect():
                 _combined_candidates_from_profiles,
                 _candidate_field_folders_from_profiles,
                 combined_logical_names,
-            ) = _build_folder_inspection_profiles(folder_entries, folder_summaries)
+            ) = _build_folder_inspection_profiles(
+                folder_entries,
+                folder_summaries,
+                filename_format_spec=filename_format_spec,
+            )
             if not name_candidates:
                 name_candidates = combined_logical_names
             extension_profiles = [
@@ -6859,6 +7246,30 @@ def features_parser_inspect():
                 upload_entries.append({"path": real_path, "name": srv_name, "folder_name": srv_name})
             if not upload_entries:
                 return jsonify({"error": "No valid files provided for inspection."}), 400
+            if filename_format_spec:
+                all_entry_count = len(upload_entries)
+                upload_entries, skipped_names = _filter_named_items_by_filename_format(
+                    upload_entries,
+                    lambda row: str(row.get("name") or ""),
+                    filename_format_spec,
+                )
+                if not upload_entries:
+                    raise ValueError(
+                        f"No files match filename format '{filename_format_spec['raw']}'."
+                    )
+                skipped_count = len(skipped_names)
+                if skipped_count > 0:
+                    matched_count = len(upload_entries)
+                    filename_filter_stats = {
+                        "matched_count": int(matched_count),
+                        "skipped_count": int(skipped_count),
+                        "skipped_examples": skipped_names[:8],
+                        "tokens": list(filename_format_spec.get("tokens") or []),
+                    }
+                    filename_filter_warning = (
+                        f"Filename format filter matched {matched_count} of {all_entry_count} files; "
+                        f"skipped {skipped_count} non-matching file(s)."
+                    )
             inspect_path = upload_entries[0]["path"]
             file_name = upload_entries[0]["name"]
             if len(upload_entries) > 1:
@@ -6868,6 +7279,31 @@ def features_parser_inspect():
 
         else:
             return jsonify({"error": "Provide an existing pipeline file, a simulation folder path, an empirical folder path, or upload a file to inspect."}), 400
+
+        if filename_format_spec and name_candidates:
+            raw_count = len(name_candidates)
+            matched_names, skipped_names = _filter_named_items_by_filename_format(
+                name_candidates,
+                lambda name: name,
+                filename_format_spec,
+            )
+            if matched_names:
+                name_candidates = matched_names
+                if skipped_names and not filename_filter_stats:
+                    filename_filter_stats = {
+                        "matched_count": int(len(matched_names)),
+                        "skipped_count": int(len(skipped_names)),
+                        "skipped_examples": skipped_names[:8],
+                        "tokens": list(filename_format_spec.get("tokens") or []),
+                    }
+                    filename_filter_warning = (
+                        f"Filename format filter matched {len(matched_names)} of {raw_count} files; "
+                        f"skipped {len(skipped_names)} non-matching file(s)."
+                    )
+            elif not folder_entries:
+                raise ValueError(
+                    f"No files match filename format '{filename_format_spec['raw']}'."
+                )
 
         if folder_entries:
             selected_description = _describe_parser_source(inspect_path)
@@ -6962,8 +7398,15 @@ def features_parser_inspect():
                         if str(item.get("name") or "").strip()
                     ]
                     sample_profile = _describe_parser_source(sample_path)
-                    sample_profile = _attach_file_extracted_virtual_field(sample_profile, sample_names or [str(sample_entry.get("name") or "")])
-                    sample_profile["virtual_field_details"] = _build_virtual_field_details_for_ui(sample_names or [str(sample_entry.get("name") or "")])
+                    sample_profile = _attach_file_extracted_virtual_field(
+                        sample_profile,
+                        sample_names or [str(sample_entry.get("name") or "")],
+                        filename_format_spec=filename_format_spec,
+                    )
+                    sample_profile["virtual_field_details"] = _build_virtual_field_details_for_ui(
+                        sample_names or [str(sample_entry.get("name") or "")],
+                        filename_format_spec=filename_format_spec,
+                    )
                     sample_profile["manual_field_details"] = _manual_field_details_for_ui()
                     sample_profile["extension"] = str(sample_entry.get("extension") or "")
                     sample_profile["sample_file"] = str(sample_entry.get("subfolder_relative_path") or sample_entry.get("relative_path") or sample_entry.get("name") or "")
@@ -6986,7 +7429,10 @@ def features_parser_inspect():
                 ),
                 "field_details": combined_field_details,
                 "manual_field_details": _manual_field_details_for_ui(),
-                "virtual_field_details": _build_virtual_field_details_for_ui(name_candidates),
+                "virtual_field_details": _build_virtual_field_details_for_ui(
+                    name_candidates,
+                    filename_format_spec=filename_format_spec,
+                ),
                 "extension_profiles": extension_profiles,
                 "folder_profiles": folder_profiles,
                 "folder_summaries": folder_summaries,
@@ -7076,7 +7522,11 @@ def features_parser_inspect():
                 description["folder_summaries"] = [{"folder_name": file_name, "folder_path": "", "file_count": 1}]
 
             
-        description = _attach_file_extracted_virtual_field(description, name_candidates)
+        description = _attach_file_extracted_virtual_field(
+            description,
+            name_candidates,
+            filename_format_spec=filename_format_spec,
+        )
         if "dataframe_candidate_fields" not in description:
             description["dataframe_candidate_fields"] = _collect_dataframe_candidate_fields_from_description(description)
         if "data_file_candidate_fields" not in description:
@@ -7095,7 +7545,17 @@ def features_parser_inspect():
         if "data_file_source_type" not in description:
             description["data_file_source_type"] = str(description.get("source_type") or "")
         if "virtual_field_details" not in description:
-            description["virtual_field_details"] = _build_virtual_field_details_for_ui(name_candidates)
+            description["virtual_field_details"] = _build_virtual_field_details_for_ui(
+                name_candidates,
+                filename_format_spec=filename_format_spec,
+            )
+        if filename_format_spec:
+            description["filename_format"] = filename_format_spec.get("raw")
+            description["filename_format_tokens"] = list(filename_format_spec.get("tokens") or [])
+            if filename_filter_stats:
+                description["filename_format_filter"] = filename_filter_stats
+            if filename_filter_warning:
+                description["filename_format_warning"] = filename_filter_warning
         description["source_name"] = file_name
         if folder_summaries:
             description["folder_path"] = folder_summaries[0]["folder_path"]
@@ -10724,6 +11184,7 @@ def start_computation_redirect(computation_type):
     prepared_features_df = None
     empirical_upload_paths = None
     parser_config_obj = None
+    filename_format_filter_warnings = []
     if computation_type == "features":
         data_source_kind = (request.form.get("data_source_kind") or "new-simulation").strip()
         empirical_source_mode = (request.form.get("empirical_source_mode") or "upload").strip()
@@ -10751,6 +11212,8 @@ def start_computation_redirect(computation_type):
             try:
                 cfg_started = time.perf_counter()
                 parse_cfg = _build_parse_config_from_form(request.form)
+                filename_format_spec = _parse_filename_format_spec(request.form.get("parser_filename_format"))
+                _validate_parse_cfg_filename_token_locators(parse_cfg, request.form)
                 app.logger.warning(
                     "[compute %s] simulation parser config built in %.1f ms",
                     job_id,
@@ -10790,6 +11253,26 @@ def start_computation_redirect(computation_type):
                         selected_entries = selected_data_entries
                     if not selected_entries:
                         raise ValueError("No files available in the selected analysis folder(s).")
+                    if filename_format_spec:
+                        selected_entries, skipped_names = _filter_named_items_by_filename_format(
+                            selected_entries,
+                            lambda row: str(row.get("name") or ""),
+                            filename_format_spec,
+                        )
+                        if skipped_names:
+                            filename_format_filter_warnings.append(
+                                f"Filename format filter skipped {len(skipped_names)} simulation file(s)."
+                            )
+                            app.logger.warning(
+                                "[compute %s] simulation filename format filtered files: matched=%d skipped=%d",
+                                job_id,
+                                len(selected_entries),
+                                len(skipped_names),
+                            )
+                        if not selected_entries:
+                            raise ValueError(
+                                f"No files match filename format '{filename_format_spec['raw']}'."
+                            )
                     use_prefix = len(folder_summaries) > 1
                     for entry in selected_entries:
                         logical_name = _prefixed_file_name(
@@ -10853,7 +11336,27 @@ def start_computation_redirect(computation_type):
                         )
                     if selected_token:
                         upload_items = [row for row in upload_items if row[3] == selected_token]
+                    if filename_format_spec:
+                        upload_items, skipped_names = _filter_named_items_by_filename_format(
+                            upload_items,
+                            lambda row: str(row[1] if len(row) > 1 else ""),
+                            filename_format_spec,
+                        )
+                        if skipped_names:
+                            filename_format_filter_warnings.append(
+                                f"Filename format filter skipped {len(skipped_names)} local simulation file(s)."
+                            )
+                            app.logger.warning(
+                                "[compute %s] simulation filename format filtered local files: matched=%d skipped=%d",
+                                job_id,
+                                len(upload_items),
+                                len(skipped_names),
+                            )
                     if not upload_items:
+                        if filename_format_spec:
+                            raise ValueError(
+                                f"No files match filename format '{filename_format_spec['raw']}'."
+                            )
                         raise ValueError("No files available in the selected analysis folder(s).")
                     use_prefix = len(local_folder_tokens) > 1
 
@@ -10918,6 +11421,8 @@ def start_computation_redirect(computation_type):
             try:
                 cfg_started = time.perf_counter()
                 parse_cfg = _build_parse_config_from_form(request.form)
+                filename_format_spec = _parse_filename_format_spec(request.form.get("parser_filename_format"))
+                _validate_parse_cfg_filename_token_locators(parse_cfg, request.form)
                 app.logger.warning(
                     "[compute %s] parser config built in %.1f ms",
                     job_id,
@@ -10972,6 +11477,26 @@ def start_computation_redirect(computation_type):
                         selected_entries = selected_data_entries
                     if not selected_entries:
                         raise ValueError("No files available in the selected analysis folder(s).")
+                    if filename_format_spec:
+                        selected_entries, skipped_names = _filter_named_items_by_filename_format(
+                            selected_entries,
+                            lambda row: str(row.get("name") or ""),
+                            filename_format_spec,
+                        )
+                        if skipped_names:
+                            filename_format_filter_warnings.append(
+                                f"Filename format filter skipped {len(skipped_names)} empirical file(s)."
+                            )
+                            app.logger.warning(
+                                "[compute %s] empirical filename format filtered files: matched=%d skipped=%d",
+                                job_id,
+                                len(selected_entries),
+                                len(skipped_names),
+                            )
+                        if not selected_entries:
+                            raise ValueError(
+                                f"No files match filename format '{filename_format_spec['raw']}'."
+                            )
                     use_prefix = len(folder_summaries) > 1
                     for entry in selected_entries:
                         logical_name = _prefixed_file_name(
@@ -11079,7 +11604,27 @@ def start_computation_redirect(computation_type):
 
                     if selected_token:
                         upload_items = [row for row in upload_items if row[3] == selected_token]
+                    if filename_format_spec:
+                        upload_items, skipped_names = _filter_named_items_by_filename_format(
+                            upload_items,
+                            lambda row: str(row[1] if len(row) > 1 else ""),
+                            filename_format_spec,
+                        )
+                        if skipped_names:
+                            filename_format_filter_warnings.append(
+                                f"Filename format filter skipped {len(skipped_names)} local empirical file(s)."
+                            )
+                            app.logger.warning(
+                                "[compute %s] empirical filename format filtered local files: matched=%d skipped=%d",
+                                job_id,
+                                len(upload_items),
+                                len(skipped_names),
+                            )
                     if not upload_items:
+                        if filename_format_spec:
+                            raise ValueError(
+                                f"No files match filename format '{filename_format_spec['raw']}'."
+                            )
                         raise ValueError("No files available in the selected analysis folder(s).")
                     use_prefix = len(local_folder_tokens) > 1
 
@@ -11304,6 +11849,8 @@ def start_computation_redirect(computation_type):
         )
     if kernel_params_module_override is not None:
         data["kernel_params_module"] = kernel_params_module_override
+    if computation_type == "features" and filename_format_filter_warnings:
+        data["filename_format_filter_warnings"] = list(filename_format_filter_warnings)
     # Add file information to the data dictionary
     data['file_paths'] = file_paths
     if prepared_features_df is not None:

--- a/webui/compute_utils.py
+++ b/webui/compute_utils.py
@@ -297,6 +297,8 @@ _PROGRESS_PERCENT_RE = re.compile(r"(?:^|\s)(\d{1,3})%")
 _FOLD_PROGRESS_RE = re.compile(r"Fold\s+(\d+)\s*/\s*(\d+)")
 FILE_EXTRACTED_VIRTUAL_FIELD = "__file_extracted_label__"
 FILE_EXTRACTED_VIRTUAL_FIELD_PREFIX = "__file_extracted_chain_"
+FILE_TOKEN_VIRTUAL_FIELD_PREFIX = "__file_token_"
+FILE_TOKEN_VIRTUAL_FIELD_SUFFIX = "__"
 FILE_ID_METADATA_LITERAL = "file_ID"
 
 
@@ -339,6 +341,105 @@ def _resolve_file_extracted_value(file_name, locator):
     if index >= len(chains):
         return None
     return chains[index]
+
+
+_FILENAME_FORMAT_TOKEN_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+
+
+def _file_token_locator_name(locator):
+    if not isinstance(locator, str):
+        return None
+    raw = str(locator).strip()
+    if not raw.startswith(FILE_TOKEN_VIRTUAL_FIELD_PREFIX):
+        return None
+    token = raw[len(FILE_TOKEN_VIRTUAL_FIELD_PREFIX):]
+    if token.endswith(FILE_TOKEN_VIRTUAL_FIELD_SUFFIX):
+        token = token[: -len(FILE_TOKEN_VIRTUAL_FIELD_SUFFIX)]
+    token = token.strip().lower()
+    if not token or not _FILENAME_FORMAT_TOKEN_NAME_RE.fullmatch(token):
+        return None
+    return token
+
+
+def _parse_filename_format_spec(raw_format):
+    value = str(raw_format or "").strip()
+    if not value:
+        return None
+    parts = []
+    tokens = []
+    seen = set()
+    i = 0
+    while i < len(value):
+        ch = value[i]
+        if ch != "$":
+            parts.append(("literal", ch))
+            i += 1
+            continue
+        j = value.find("$", i + 1)
+        if j < 0:
+            raise ValueError("Invalid filename format: missing closing '$'.")
+        token_raw = value[i + 1:j].strip()
+        if not token_raw:
+            raise ValueError("Invalid filename format: empty token '$$' is not allowed.")
+        token = token_raw.lower()
+        if not _FILENAME_FORMAT_TOKEN_NAME_RE.fullmatch(token):
+            raise ValueError(
+                f"Invalid filename format token '{token_raw}'. Use letters/numbers/underscore and start with a letter."
+            )
+        if token in seen:
+            raise ValueError(f"Invalid filename format: token '{token_raw}' is duplicated.")
+        seen.add(token)
+        tokens.append(token)
+        parts.append(("token", token))
+        i = j + 1
+    if not tokens:
+        raise ValueError("Filename format must include at least one token, e.g. $id$.")
+
+    regex_parts = []
+    group_map = []
+    token_idx = 0
+    for kind, value_part in parts:
+        if kind == "literal":
+            regex_parts.append(re.escape(value_part))
+            continue
+        group_name = f"tok{token_idx}"
+        token_idx += 1
+        group_map.append((group_name, value_part))
+        regex_parts.append(f"(?P<{group_name}>.+?)")
+    return {
+        "raw": value,
+        "tokens": tokens,
+        "group_map": group_map,
+        "regex": re.compile("^" + "".join(regex_parts) + "$"),
+    }
+
+
+def _extract_filename_format_tokens(file_name, format_spec):
+    if not format_spec:
+        return None
+    basename = os.path.basename(str(file_name or "").strip())
+    if not basename:
+        return None
+    matcher = format_spec.get("regex")
+    if matcher is None:
+        return None
+    match = matcher.fullmatch(basename)
+    if not match:
+        return None
+    out = {}
+    for group_name, token_name in (format_spec.get("group_map") or []):
+        out[str(token_name)] = str(match.group(group_name) or "").strip()
+    return out
+
+
+def _resolve_file_token_value(file_name, locator, filename_format_spec):
+    token = _file_token_locator_name(locator)
+    if not token:
+        return None
+    extracted = _extract_filename_format_tokens(file_name, filename_format_spec)
+    if not extracted:
+        return None
+    return extracted.get(token)
 
 
 class _JobOutputCapture(io.TextIOBase):
@@ -1907,6 +2008,10 @@ def features_computation(job_id, job_status, params, temp_uploaded_files):
             # Keep progress at 0 during data loading/preparation.
             job_status[job_id]["progress"] = 0
         _append_job_output(job_status, job_id, "Loading data for features...")
+        for warning in (params.get("filename_format_filter_warnings") or []):
+            message = str(warning or "").strip()
+            if message:
+                _append_job_output(job_status, job_id, f"Warning: {message}")
 
         prepared_df = params.get("prepared_features_df")
         if isinstance(prepared_df, pd.DataFrame):
@@ -1918,6 +2023,7 @@ def features_computation(job_id, job_status, params, temp_uploaded_files):
                 raise ValueError("Missing parser configuration for empirical uploads.")
             from ncpi.EphysDatasetParser import EphysDatasetParser
             parser = EphysDatasetParser(parse_cfg)
+            filename_format_spec = _parse_filename_format_spec(params.get("parser_filename_format"))
             metadata_locators = (
                 dict(parse_cfg.fields.metadata or {})
                 if getattr(parse_cfg, "fields", None) is not None
@@ -1931,6 +2037,16 @@ def features_computation(job_id, job_status, params, temp_uploaded_files):
             for meta_key, locator in metadata_locators.items():
                 if _file_extracted_chain_index(locator) is not None:
                     file_extracted_metadata_fields[str(meta_key)] = str(locator)
+            file_token_metadata_fields = {}
+            for meta_key, locator in metadata_locators.items():
+                if _file_token_locator_name(locator) is not None:
+                    file_token_metadata_fields[str(meta_key)] = str(locator)
+            if file_token_metadata_fields and not filename_format_spec:
+                fields = ", ".join(sorted(file_token_metadata_fields.keys()))
+                raise ValueError(
+                    "Filename format is required because metadata fields use filename token locators: "
+                    f"{fields}."
+                )
 
             empirical_uploads = list(params.get("empirical_upload_paths") or [])
 
@@ -2076,6 +2192,15 @@ def features_computation(job_id, job_status, params, temp_uploaded_files):
                 if file_extracted_metadata_fields:
                     for col_name, locator in file_extracted_metadata_fields.items():
                         parsed[col_name] = _resolve_file_extracted_value(name, locator)
+                if file_token_metadata_fields:
+                    for col_name, locator in file_token_metadata_fields.items():
+                        token_value = _resolve_file_token_value(name, locator, filename_format_spec)
+                        if token_value is None:
+                            token_name = _file_token_locator_name(locator) or locator
+                            raise ValueError(
+                                f"File '{name}' does not match filename format for token '{token_name}'."
+                            )
+                        parsed[col_name] = token_value
                 parsed_frames.append(parsed)
 
                 # Do not advance global progress bar during data loading.

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -414,7 +414,6 @@
                 delete this.uploads['empirical-files'];
                 this.empiricalUploadSummary = '';
                 this.empiricalListedFileNames = [];
-                this.parserFilenameFormat = '';
             },
             clearSimulationUploadInput() {
                 const input = document.getElementById('data-file');
@@ -422,7 +421,6 @@
                 delete this.uploads['data-file'];
                 this.simulationListedFileNames = [];
                 this.simulationLocalFiles = [];
-                this.parserFilenameFormat = '';
             },
             setSimulationSourceMode(mode) {
                 const nextMode = mode === 'upload' ? 'upload' : 'server-path';
@@ -1117,6 +1115,32 @@
                 const value = String(this.parserFilenameFormat || '').trim();
                 if (value) formData.append('parser_filename_format', value);
             },
+            async parseJsonFromResponse(response, defaultErrorMessage) {
+                const fallback = String(defaultErrorMessage || 'Request failed.');
+                const status = Number(response?.status || 0);
+                const rawBody = await response.text();
+                let payload = {};
+                if (rawBody) {
+                    try {
+                        payload = JSON.parse(rawBody);
+                    } catch (_err) {
+                        if (status >= 400) {
+                            throw new Error(`${fallback} (HTTP ${status})`);
+                        }
+                        throw new Error('Server returned an invalid response format.');
+                    }
+                }
+                if (!response.ok) {
+                    const fromPayload = payload && typeof payload === 'object' ? String(payload.error || '').trim() : '';
+                    throw new Error(fromPayload || `${fallback} (HTTP ${status || 'error'})`);
+                }
+                return payload && typeof payload === 'object' ? payload : {};
+            },
+            isFilenameFormatMatchError(message) {
+                const token = String(message || '').toLowerCase();
+                return token.includes('filename format')
+                    && (token.includes('no files') || token.includes('no files or first-level folders'));
+            },
             async applyFilenameFormatAndReinspect() {
                 this.submitError = '';
                 this.parserError = '';
@@ -1158,6 +1182,10 @@
                         await this.inspectParserSource('', inspectCandidate);
                     }
                 }
+            },
+            async clearFilenameFormatAndReinspect() {
+                this.parserFilenameFormat = '';
+                await this.applyFilenameFormatAndReinspect();
             },
             parserFolderSummaries() {
                 return Array.isArray(this.parserInfo?.folder_summaries) ? this.parserInfo.folder_summaries : [];
@@ -1626,7 +1654,16 @@
                     return;
                 }
                 this.parserLoading = true;
-                this.parserInfo = null;
+                const previousParserInfo = this.parserInfo || this._baseParserInfo || null;
+                const previousSimulationFileCount = this.simulationFileCount;
+                const previousSimulationSampleName = this.simulationSampleName;
+                const previousSimulationInspectedSamples = Array.isArray(this.simulationInspectedSamples)
+                    ? [...this.simulationInspectedSamples]
+                    : [];
+                const previousFolderPaths = Array.isArray(this.simulationFolderPaths)
+                    ? [...this.simulationFolderPaths]
+                    : [];
+                const previousFolderPath = String(this.simulationFolderPath || '').trim();
                 try {
                     this.simulationSourceMode = 'server-path';
                     this.clearSimulationUploadInput();
@@ -1646,8 +1683,7 @@
                         method: 'POST',
                         body: formData,
                     });
-                    const payload = await response.json();
-                    if (!response.ok) throw new Error(payload.error || 'Failed to inspect simulation outputs folder.');
+                    const payload = await this.parseJsonFromResponse(response, 'Failed to inspect simulation outputs folder.');
                     this.parserInfo = payload;
                     this._baseParserInfo = payload;
                     this.syncDataFileSelectionsFromPayload(payload, 'simulation');
@@ -1684,12 +1720,26 @@
                 } catch (error) {
                     const message = error.message || 'Failed to inspect simulation outputs folder.';
                     this.parserError = message;
+                    if (this.isFilenameFormatMatchError(message)) {
+                        this.parserInfo = null;
+                        this._baseParserInfo = null;
+                        this.simulationFileCount = previousSimulationFileCount;
+                        this.simulationSampleName = previousSimulationSampleName;
+                        this.simulationInspectedSamples = previousSimulationInspectedSamples;
+                        this.simulationFolderPaths = previousFolderPaths;
+                        this.simulationFolderPath = previousFolderPath;
+                        return;
+                    }
+                    this.parserInfo = previousParserInfo;
+                    this._baseParserInfo = previousParserInfo;
                     this.simulationFolderExtensionError = this.isMultipleFolderExtensionError(message)
                         ? 'Warning: in this folder there is more than one type of file extension. Please, select a folder that contains files with the same file extension.'
                         : message;
-                    this.simulationFileCount = 0;
-                    this.simulationSampleName = '';
-                    this.simulationInspectedSamples = [];
+                    this.simulationFileCount = previousSimulationFileCount;
+                    this.simulationSampleName = previousSimulationSampleName;
+                    this.simulationInspectedSamples = previousSimulationInspectedSamples;
+                    this.simulationFolderPaths = previousFolderPaths;
+                    this.simulationFolderPath = previousFolderPath;
                 } finally {
                     this.parserLoading = false;
                 }
@@ -1711,7 +1761,10 @@
                     return;
                 }
                 this.parserLoading = true;
-                this.parserInfo = null;
+                const previousParserInfo = this.parserInfo || this._baseParserInfo || null;
+                const previousEmpiricalFileCount = this.empiricalFileCount;
+                const previousEmpiricalSampleName = this.empiricalSampleName;
+                const previousEmpiricalFolderPath = String(this.empiricalFolderPath || '').trim();
                 this.empiricalSubfolderSelections = {};
                 try {
                     this.empiricalSourceMode = 'server-path';
@@ -1731,8 +1784,7 @@
                         method: 'POST',
                         body: formData,
                     });
-                    const payload = await response.json();
-                    if (!response.ok) throw new Error(payload.error || 'Failed to inspect empirical folder.');
+                    const payload = await this.parseJsonFromResponse(response, 'Failed to inspect empirical folder.');
                     this.parserInfo = payload;
                     this._baseParserInfo = payload
                     this.syncDataFileSelectionsFromPayload(payload, 'empirical');
@@ -1745,9 +1797,21 @@
                     }
 
                 } catch (error) {
-                    this.parserError = error.message || 'Failed to inspect empirical folder.';
-                    this.empiricalFileCount = 0;
-                    this.empiricalSampleName = '';
+                    const message = error.message || 'Failed to inspect empirical folder.';
+                    this.parserError = message;
+                    if (this.isFilenameFormatMatchError(message)) {
+                        this.parserInfo = null;
+                        this._baseParserInfo = null;
+                        this.empiricalFileCount = previousEmpiricalFileCount;
+                        this.empiricalSampleName = previousEmpiricalSampleName;
+                        this.empiricalFolderPath = previousEmpiricalFolderPath;
+                        return;
+                    }
+                    this.parserInfo = previousParserInfo;
+                    this._baseParserInfo = previousParserInfo;
+                    this.empiricalFileCount = previousEmpiricalFileCount;
+                    this.empiricalSampleName = previousEmpiricalSampleName;
+                    this.empiricalFolderPath = previousEmpiricalFolderPath;
                 } finally {
                     this.parserLoading = false;
                 }
@@ -1911,7 +1975,7 @@
             async inspectParserSource(existingPath, file) {
                 this.parserLoading = true;
                 this.parserError = '';
-                this.parserInfo = null;
+                const previousParserInfo = this.parserInfo || this._baseParserInfo || null;
                 const formData = new FormData();
                 if (existingPath) formData.append('existing_data_path', existingPath);
                 if (file) formData.append('file', file);
@@ -1930,8 +1994,7 @@
                         method: 'POST',
                         body: formData,
                     });
-                    const payload = await response.json();
-                    if (!response.ok) throw new Error(payload.error || 'Failed to inspect data source.');
+                    const payload = await this.parseJsonFromResponse(response, 'Failed to inspect data source.');
                     this.parserInfo = payload;
                     this._baseParserInfo = payload;
                     this.applyParserDefaults(payload);
@@ -1940,7 +2003,12 @@
                         await this.inspectAllAdditionalFiles();
                     }
                 } catch (error) {
-                    this.parserError = error.message || 'Failed to inspect data source.';
+                    const message = error.message || 'Failed to inspect data source.';
+                    this.parserError = message;
+                    if (this.isFilenameFormatMatchError(message)) {
+                        this.parserInfo = null;
+                        this._baseParserInfo = null;
+                    }
                 } finally {
                     this.parserLoading = false;
                 }
@@ -3073,6 +3141,42 @@
                     </div>
                 </div>
 
+                    <div x-show="hasAnyData() && !parserInfo" x-cloak class="mt-6 bg-white dark:bg-[#111422] border border-gray-200 dark:border-[#323b67] rounded-xl p-6 space-y-3">
+                        <div class="flex items-center gap-2">
+                            <span class="material-symbols-outlined text-primary">rule_settings</span>
+                            <h3 class="font-bold text-base text-[#34495E] dark:text-white">Filename format filter</h3>
+                        </div>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">
+                            You can change the format and inspect again, or return to automatic detection.
+                        </p>
+                        <label class="text-sm block">
+                            <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Filename format (optional)</span>
+                            <input
+                                type="text"
+                                name="parser_filename_format"
+                                x-model="parserFilenameFormat"
+                                placeholder="$id$_comp_reject.mat"
+                                @keydown.enter.prevent="applyFilenameFormatAndReinspect()"
+                                class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                            >
+                        </label>
+                        <div class="flex flex-wrap gap-2">
+                            <button
+                                type="button"
+                                @click="applyFilenameFormatAndReinspect()"
+                                class="px-2 py-1 rounded border border-primary/40 bg-white dark:bg-[#191e33] text-primary text-[11px] font-semibold hover:bg-primary/10">
+                                Inspect
+                            </button>
+                            <button
+                                type="button"
+                                @click="clearFilenameFormatAndReinspect()"
+                                class="px-2 py-1 rounded border border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-gray-700 dark:text-gray-300 text-[11px] font-semibold hover:bg-gray-50 dark:hover:bg-[#222a45]">
+                                Use automatic detection
+                            </button>
+                        </div>
+                        <p class="text-[11px] text-red-700 dark:text-red-300" x-show="parserError" x-text="parserError"></p>
+                    </div>
+
                     <template x-if="hasAnyData() && parserInfo && (((parserInfo.folder_summaries || []).length > 0) || ((parserInfo.extension_summaries || []).length > 0) || ((parserInfo.extension_profiles || []).length > 0))">
                     <div class="mt-6 bg-white dark:bg-[#111422] border border-gray-200 dark:border-[#323b67] rounded-xl p-6 space-y-4">
                         <div class="flex items-center gap-2">
@@ -3093,7 +3197,7 @@
                                 >
                             </label>
                             <p class="text-[11px] text-gray-500 dark:text-gray-400">
-                                Use literal text + tokens between <code>$...$</code>. Only files matching this format are used for file-based auto-mapping and parsing.
+                                Use literal text + tokens between <code>$...$</code>. In nested datasets, this is applied to first-level folder names; otherwise it is applied to file names.
                             </p>
                             <div class="flex flex-wrap gap-2">
                                 <template x-for="token in parserFilenameFormatTokens()" :key="'filename-format-token-'+token">
@@ -3108,7 +3212,13 @@
                                     type="button"
                                     @click="applyFilenameFormatAndReinspect()"
                                     class="px-2 py-1 rounded border border-primary/40 bg-white dark:bg-[#191e33] text-primary text-[11px] font-semibold hover:bg-primary/10">
-                                    Apply format
+                                    Inspect
+                                </button>
+                                <button
+                                    type="button"
+                                    @click="clearFilenameFormatAndReinspect()"
+                                    class="px-2 py-1 rounded border border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-gray-700 dark:text-gray-300 text-[11px] font-semibold hover:bg-gray-50 dark:hover:bg-[#222a45]">
+                                    Use automatic detection
                                 </button>
                             </div>
                             <p class="text-[11px] text-amber-700 dark:text-amber-300" x-show="parserInfo.filename_format_warning" x-text="parserInfo.filename_format_warning"></p>

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -1049,6 +1049,30 @@
                 const fields = Array.isArray(this.parserInfo?.candidate_fields) ? this.parserInfo.candidate_fields : [];
                 return fields.filter((field) => !this.parserIsFileExtractedField(field));
             },
+            parserFsSourceCandidates() {
+                const base = this.parserCandidateFieldsWithoutFileExtracted()
+                    .map((field) => String(field || '').trim())
+                    .filter((field) => field.length > 0);
+                const out = [];
+                const seen = new Set();
+                for (const field of base) {
+                    if (seen.has(field)) continue;
+                    seen.add(field);
+                    out.push(field);
+                }
+                const samplingTokenField = this.parserFilenameTokenField('sampling_frequency');
+                const allCandidates = Array.isArray(this.parserInfo?.candidate_fields)
+                    ? this.parserInfo.candidate_fields.map((field) => String(field || '').trim())
+                    : [];
+                if (
+                    samplingTokenField &&
+                    allCandidates.includes(samplingTokenField) &&
+                    !seen.has(samplingTokenField)
+                ) {
+                    out.push(samplingTokenField);
+                }
+                return out;
+            },
             parserChannelNameSourceCandidates() {
                 const base = this.parserCandidateFieldsWithoutFileExtracted()
                     .map((field) => String(field || '').trim())
@@ -1097,23 +1121,18 @@
             },
             parserFilenameFormatTokens() {
                 return [
-                    '$id$',
                     '$subject_id$',
                     '$group$',
                     '$condition$',
                     '$species$',
-                    '$session$',
-                    '$ses$',
-                    '$run$',
-                    '$trial$',
-                    '$task$',
-                    '$state$',
                     '$recording_type$',
-                    '$site$',
-                    '$cohort$',
-                    '$date$',
-                    '$time$',
+                    '$sampling_frequency$',
                 ];
+            },
+            parserFilenameTokenField(tokenName) {
+                const token = String(tokenName || '').trim().toLowerCase();
+                if (!token) return '';
+                return `__file_token_${token}__`;
             },
             insertFilenameFormatToken(token) {
                 const clean = String(token || '').trim();
@@ -1860,6 +1879,22 @@
                 const dataFileCandidates = this.parserDataFileCandidateFields();
                 const defaults = payload?.defaults || {};
                 const dataCandidates = this.parserDataLocatorCandidates();
+                const candidateSet = new Set(
+                    (Array.isArray(payload?.candidate_fields) ? payload.candidate_fields : [])
+                        .map((field) => String(field || '').trim())
+                        .filter((field) => field.length > 0)
+                );
+                const formatTokens = new Set(
+                    (Array.isArray(payload?.filename_format_tokens) ? payload.filename_format_tokens : [])
+                        .map((token) => String(token || '').trim().toLowerCase())
+                        .filter((token) => token.length > 0)
+                );
+                const resolveMappedTokenField = (tokenName) => {
+                    const token = String(tokenName || '').trim().toLowerCase();
+                    if (!token || !formatTokens.has(token)) return '';
+                    const field = this.parserFilenameTokenField(token);
+                    return candidateSet.has(field) ? field : '';
+                };
                 const autoData = this.autoPickCandidateField(['lfp', 'eeg', 'meg', 'ecog', 'signal', 'data'], dataCandidates);
                 const autoFs = this.autoPickCandidateField(
                     ['fs', 'sfreq', 'freq', 'frequency', 'sampling_rate', 'sampling_frequency'],
@@ -1926,6 +1961,28 @@
                 } else {
                     this.parserChNamesSource = '__autocomplete__';
                     this.parserChNamesLocator = '';
+                }
+
+                // Auto-assign parser dropdowns from explicit filename tokens when present.
+                const tokenSubjectField = resolveMappedTokenField('subject_id');
+                if (tokenSubjectField) this.parserMetadataSubjectIdSource = tokenSubjectField;
+                const tokenGroupField = resolveMappedTokenField('group');
+                if (tokenGroupField) this.parserMetadataGroupSource = tokenGroupField;
+                const tokenSpeciesField = resolveMappedTokenField('species');
+                if (tokenSpeciesField) this.parserMetadataSpeciesSource = tokenSpeciesField;
+                const tokenConditionField = resolveMappedTokenField('condition');
+                if (tokenConditionField) this.parserMetadataConditionSource = tokenConditionField;
+                const tokenRecordingTypeField = resolveMappedTokenField('recording_type');
+                if (tokenRecordingTypeField) {
+                    this.parserRecordingTypeSource = tokenRecordingTypeField;
+                    this.parserRecordingTypeLocator = tokenRecordingTypeField;
+                    this.parserRecordingType = '';
+                }
+                const tokenSamplingFrequencyField = resolveMappedTokenField('sampling_frequency');
+                if (tokenSamplingFrequencyField) {
+                    this.parserFsSource = tokenSamplingFrequencyField;
+                    this.parserFsLocator = tokenSamplingFrequencyField;
+                    this.parserFsManual = '';
                 }
 
                 const allowedChSources = new Set(this.parserChannelNameSourceCandidates().map((field) => String(field)));
@@ -3558,7 +3615,8 @@
                                     Menu colors:
                                     <span style="color: #0f766e;">data fields</span>,
                                     <span style="color: #1d4ed8; font-weight: 600;">manual entries</span>,
-                                    <span style="color: #b45309; font-weight: 600;">file-extracted fields</span>.
+                                    <span style="color: #b45309; font-weight: 600;">file-extracted fields</span>,
+                                    <span style="color: #0e7490; font-weight: 700;">token fields</span>.
                                 </p>
 
                                 <div x-show="resolvedDataSourceKind() === 'pipeline' || resolvedDataSourceKind() === 'new-simulation'" class="space-y-4">
@@ -3655,7 +3713,7 @@
                                             <select name="parser_fs_source" x-model="parserFsSource" @change="onPipelineFsSourceChange()"
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                                 <option value="__numeric__" :style="parserManualOptionStyle()">Numeric value</option>
-                                                <template x-for="field in parserCandidateFieldsWithoutFileExtracted()" :key="'pipeline-fs-source-'+field">
+                                                <template x-for="field in parserFsSourceCandidates()" :key="'pipeline-fs-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>
                                                 <option value="__none__" :style="parserNeutralOptionStyle()">None</option>
@@ -3961,7 +4019,7 @@
                                             <select name="parser_fs_source" x-model="parserFsSource" @change="onPipelineFsSourceChange()"
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                                 <option value="__numeric__" :style="parserManualOptionStyle()">Numeric value</option>
-                                                <template x-for="field in parserCandidateFieldsWithoutFileExtracted()" :key="'fs-source-'+field">
+                                                <template x-for="field in parserFsSourceCandidates()" :key="'fs-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>
                                                 <option value="__none__" :style="parserNeutralOptionStyle()">None</option>

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -57,6 +57,7 @@
             _baseParserInfo: null,
             parserLoading: false,
             parserError: '',
+            parserFilenameFormat: '',
             parserAnalysisFolderPaths: [],
             parserAnalysisFolderNames: [],
             empiricalDataFileSelections: {},
@@ -240,6 +241,7 @@
                     '_baseParserInfo',
                     'parserLoading',
                     'parserError',
+                    'parserFilenameFormat',
                     'parserAnalysisFolderPaths',
                     'parserAnalysisFolderNames',
                     'parserDataLocator',
@@ -412,6 +414,7 @@
                 delete this.uploads['empirical-files'];
                 this.empiricalUploadSummary = '';
                 this.empiricalListedFileNames = [];
+                this.parserFilenameFormat = '';
             },
             clearSimulationUploadInput() {
                 const input = document.getElementById('data-file');
@@ -419,11 +422,13 @@
                 delete this.uploads['data-file'];
                 this.simulationListedFileNames = [];
                 this.simulationLocalFiles = [];
+                this.parserFilenameFormat = '';
             },
             setSimulationSourceMode(mode) {
                 const nextMode = mode === 'upload' ? 'upload' : 'server-path';
                 if (this.simulationSourceMode === nextMode) return;
                 this.simulationSourceMode = nextMode;
+                this.parserFilenameFormat = '';
                 this.parserError = '';
                 this.resetParserConfig();
                 this.simulationDropActive = false;
@@ -459,6 +464,7 @@
                 const incomingFiles = Array.from(event?.target?.files || []);
                 const shouldAppend = !!this.appendSimulationSelection;
                 this.appendSimulationSelection = false;
+                this.parserFilenameFormat = '';
                 const previous = shouldAppend ? Array.from(this.simulationLocalFiles || []) : [];
                 const merged = [];
                 const seen = new Set();
@@ -555,6 +561,7 @@
                 const nextMode = mode === 'upload' ? 'upload' : 'server-path';
                 if (this.empiricalSourceMode === nextMode) return;
                 this.empiricalSourceMode = nextMode;
+                this.parserFilenameFormat = '';
                 this.parserError = '';
                 this.resetParserConfig();
                 this.empiricalFileCount = 0;
@@ -570,6 +577,7 @@
             },
             async onEmpiricalUploadSelected(event) {
                 const files = Array.from(event?.target?.files || []);
+                this.parserFilenameFormat = '';
                 this.submitError = '';
                 this.parserError = '';
                 this.dataSourceKind = 'new-empirical';
@@ -672,6 +680,7 @@
                 this.simulationFileCount = 0;
                 this.simulationSampleName = '';
                 this.simulationDataFileSelections = {};
+                this.parserFilenameFormat = '';
                 this.parserInfo = null;
             },
             isMultipleFolderExtensionError(message) {
@@ -829,6 +838,10 @@
                 if (target === 'simulation') {
                     await this.addSimulationFolderPath(selectedPath);
                 } else {
+                    const previousPath = String(this.empiricalFolderPath || '').trim();
+                    if (previousPath && previousPath !== selectedPath) {
+                        this.parserFilenameFormat = '';
+                    }
                     this.empiricalFolderPath = selectedPath;
                     await this.inspectEmpiricalFolderPath();
                 }
@@ -983,7 +996,11 @@
                 if (key === '__file_id__') {
                     return this.parserFileIdOptionLabel();
                 }
-                if (key === '__file_extracted_label__' || key.startsWith('__file_extracted_chain_')) {
+                if (
+                    key === '__file_extracted_label__'
+                    || key.startsWith('__file_extracted_chain_')
+                    || key.startsWith('__file_token_')
+                ) {
                     const sourceHint = 'from source file names';
                     if (!rendered.toLowerCase().includes(sourceHint)) {
                         rendered = `${rendered} (${sourceHint})`;
@@ -1015,13 +1032,15 @@
                 if (!key) return false;
                 return key === '__file_id__'
                     || key === '__file_extracted_label__'
-                    || key.startsWith('__file_extracted_chain_');
+                    || key.startsWith('__file_extracted_chain_')
+                    || key.startsWith('__file_token_');
             },
             parserIsFileExtractedField(field) {
                 const key = String(field || '').trim();
                 if (!key) return false;
                 return key === '__file_extracted_label__'
-                    || key.startsWith('__file_extracted_chain_');
+                    || key.startsWith('__file_extracted_chain_')
+                    || key.startsWith('__file_token_');
             },
             parserCandidateFieldsWithoutFileExtracted() {
                 const fields = Array.isArray(this.parserInfo?.candidate_fields) ? this.parserInfo.candidate_fields : [];
@@ -1066,6 +1085,79 @@
             },
             parserNeutralOptionStyle() {
                 return 'color: #6b7280;';
+            },
+            parserFilenameFormatTokens() {
+                return [
+                    '$id$',
+                    '$subject_id$',
+                    '$group$',
+                    '$condition$',
+                    '$species$',
+                    '$session$',
+                    '$ses$',
+                    '$run$',
+                    '$trial$',
+                    '$task$',
+                    '$state$',
+                    '$recording_type$',
+                    '$site$',
+                    '$cohort$',
+                    '$date$',
+                    '$time$',
+                ];
+            },
+            insertFilenameFormatToken(token) {
+                const clean = String(token || '').trim();
+                if (!clean) return;
+                const current = String(this.parserFilenameFormat || '').trim();
+                this.parserFilenameFormat = current ? `${current}${clean}` : clean;
+            },
+            appendFilenameFormatToFormData(formData) {
+                if (!formData || typeof formData.append !== 'function') return;
+                const value = String(this.parserFilenameFormat || '').trim();
+                if (value) formData.append('parser_filename_format', value);
+            },
+            async applyFilenameFormatAndReinspect() {
+                this.submitError = '';
+                this.parserError = '';
+                if (this.parserLoading || !this.hasAnyData()) return;
+                if (this.selectedPipelinePath) {
+                    await this.inspectParserSource(this.selectedPipelinePath, null);
+                    return;
+                }
+                if (this.dataSourceKind === 'new-simulation') {
+                    if (this.simulationSourceMode === 'server-path') {
+                        await this.inspectSimulationFolderPath();
+                        return;
+                    }
+                    const inspectCandidate = (this.simulationLocalFiles || []).find((item) => {
+                        const name = String(item?.name || '');
+                        const idx = name.lastIndexOf('.');
+                        if (idx < 0) return false;
+                        return supportedParserFileExtensions.has(name.slice(idx).toLowerCase());
+                    });
+                    if (inspectCandidate) {
+                        await this.inspectParserSource('', inspectCandidate);
+                    }
+                    return;
+                }
+                if (this.dataSourceKind === 'new-empirical') {
+                    if (this.empiricalSourceMode === 'server-path') {
+                        await this.inspectEmpiricalFolderPath();
+                        return;
+                    }
+                    const input = document.getElementById('empirical-files');
+                    const localFiles = Array.from(input?.files || []);
+                    const inspectCandidate = localFiles.find((item) => {
+                        const name = String(item?.name || '');
+                        const idx = name.lastIndexOf('.');
+                        if (idx < 0) return false;
+                        return supportedParserFileExtensions.has(name.slice(idx).toLowerCase());
+                    });
+                    if (inspectCandidate) {
+                        await this.inspectParserSource('', inspectCandidate);
+                    }
+                }
             },
             parserFolderSummaries() {
                 return Array.isArray(this.parserInfo?.folder_summaries) ? this.parserInfo.folder_summaries : [];
@@ -1549,6 +1641,7 @@
                     if (Object.keys(simulationSelections).length > 0) {
                         formData.append('simulation_data_file_selections', JSON.stringify(simulationSelections));
                     }
+                    this.appendFilenameFormatToFormData(formData);
                     const response = await fetch('{{ url_for('features_parser_inspect') }}', {
                         method: 'POST',
                         body: formData,
@@ -1633,6 +1726,7 @@
                     if (Object.keys(empiricalSelections).length > 0) {
                         formData.append('empirical_data_file_selections', JSON.stringify(empiricalSelections));
                     }
+                    this.appendFilenameFormatToFormData(formData);
                     const response = await fetch('{{ url_for('features_parser_inspect') }}', {
                         method: 'POST',
                         body: formData,
@@ -1830,6 +1924,7 @@
                         if (safeName) formData.append('listed_file_names', safeName);
                     });
                 }
+                this.appendFilenameFormatToFormData(formData);
                 try {
                     const response = await fetch('{{ url_for('features_parser_inspect') }}', {
                         method: 'POST',
@@ -2985,6 +3080,39 @@
                             <h3 class="font-bold text-base text-[#34495E] dark:text-white">Folder and File Inspection</h3>
                         </div>
                         <p class="text-xs text-gray-500 dark:text-gray-100" x-text="parserInfo.summary"></p>
+                        <div class="space-y-2 rounded-lg border border-gray-200 dark:border-[#323b67] bg-gray-50/70 dark:bg-[#191e33]/60 p-3">
+                            <label class="text-sm block">
+                                <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Filename format (optional)</span>
+                                <input
+                                    type="text"
+                                    name="parser_filename_format"
+                                    x-model="parserFilenameFormat"
+                                    placeholder="$id$-$group$_$condition$.pkl"
+                                    @keydown.enter.prevent="applyFilenameFormatAndReinspect()"
+                                    class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                >
+                            </label>
+                            <p class="text-[11px] text-gray-500 dark:text-gray-400">
+                                Use literal text + tokens between <code>$...$</code>. Only files matching this format are used for file-based auto-mapping and parsing.
+                            </p>
+                            <div class="flex flex-wrap gap-2">
+                                <template x-for="token in parserFilenameFormatTokens()" :key="'filename-format-token-'+token">
+                                    <button
+                                        type="button"
+                                        @click="insertFilenameFormatToken(token)"
+                                        class="px-2 py-1 rounded border border-primary/30 bg-primary/10 text-primary text-[11px] font-semibold hover:bg-primary/20"
+                                        x-text="token">
+                                    </button>
+                                </template>
+                                <button
+                                    type="button"
+                                    @click="applyFilenameFormatAndReinspect()"
+                                    class="px-2 py-1 rounded border border-primary/40 bg-white dark:bg-[#191e33] text-primary text-[11px] font-semibold hover:bg-primary/10">
+                                    Apply format
+                                </button>
+                            </div>
+                            <p class="text-[11px] text-amber-700 dark:text-amber-300" x-show="parserInfo.filename_format_warning" x-text="parserInfo.filename_format_warning"></p>
+                        </div>
 
                         <div x-show="(parserInfo.folder_summaries || []).length > 0" class="space-y-2">
                             <h4 class="text-xs font-semibold text-[#34495E] dark:text-white uppercase tracking-wide">Files per folder</h4>

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -1033,6 +1033,11 @@
                     || key.startsWith('__file_extracted_chain_')
                     || key.startsWith('__file_token_');
             },
+            parserIsTokenField(field) {
+                const key = String(field || '').trim();
+                if (!key) return false;
+                return key.startsWith('__file_token_');
+            },
             parserIsFileExtractedField(field) {
                 const key = String(field || '').trim();
                 if (!key) return false;
@@ -1068,6 +1073,9 @@
                 return out;
             },
             parserFieldOptionStyle(field) {
+                if (this.parserIsTokenField(field)) {
+                    return this.parserTokenOptionStyle();
+                }
                 return this.parserIsVirtualField(field)
                     ? this.parserVirtualOptionStyle()
                     : this.parserDataframeOptionStyle();
@@ -1080,6 +1088,9 @@
             },
             parserVirtualOptionStyle() {
                 return 'color: #b45309; font-weight: 600;';
+            },
+            parserTokenOptionStyle() {
+                return 'color: #0e7490; font-weight: 700;';
             },
             parserNeutralOptionStyle() {
                 return 'color: #6b7280;';


### PR DESCRIPTION
Improve filename token workflow in Features parser (format validation, token mapping, and UX recovery)

## Summary
This PR refines the filename-format token feature in the **Features → Compute new features → New data** flow.

Main goals:
- Make token-based parsing reliable and predictable.
- Ensure token-derived fields are clearly visible and selectable in parser dropdowns.
- Improve UX when format matching fails (no hard lock of the configurator).
- Reduce token suggestions to only meaningful parser-mapped fields.

## What Changed

### 1. Filename format filtering behavior
- Added/adjusted strict validation for `parser_filename_format`.
- If a format does not match any candidate source:
  - inspection now returns a clear controlled error,
  - no silent fallback to “all files”.
- Matching now supports nested datasets as intended:
  - for nested folder structures, format is applied to **first-level subfolder names**,
  - otherwise, format is applied to **file names**.

### 2. Token virtual fields in parser options
- Ensured token-derived virtual fields (`__file_token_*__`) are added to parser candidate options.
- Token-derived options are now consistently available in parser source dropdowns.

### 3. Token visual distinction in dropdowns
- Added a dedicated style for token-derived fields (`__file_token_*__`) so they are visually distinct from:
  - regular detected dataframe fields,
  - generic file-extracted fields.

### 4. Token suggestions simplified
- Reduced suggested tokens to only parser-relevant mappings:
  - `$subject_id$`
  - `$group$`
  - `$species$`
  - `$condition$`
  - `$recording_type$`
  - `$sampling_frequency$`
- Removed redundant/noisy suggestions (including `$id$` and unrelated tokens).

### 5. Auto-map tokens to parser dropdowns after Inspect
When tokens are present in the filename format and detected in inspection results, parser fields are auto-selected as:

- `Subject ID source` → `$subject_id$`
- `Group source` → `$group$`
- `Species source` → `$species$`
- `Condition source` → `$condition$`
- `Recording type source` → `$recording_type$`
- `Sampling frequency source` → `$sampling_frequency$`

Users can still manually override all dropdown values afterward.

### 6. Inspect button and recovery UX
- Renamed format action to **Inspect** for clarity.
- Added **Use automatic detection** action to quickly clear format and re-inspect.
- Prevented UI dead-end states:
  - if format fails, user can immediately try another format or switch back to automatic detection.
- Added robust handling for non-JSON/HTML error responses to avoid frontend crashes like:
  - `Unexpected token '<', "<!doctype"... is not valid JSON`.

### 7. State reset correctness on dataset changes
- Fixed stale format application when changing/removing datasets:
  - format no longer incorrectly persists across unrelated dataset selections.
- Preserved selected dataset context while handling format errors, so users are not forced to reselect data.

## Notes
- No changes to core feature computation algorithms.
- Users retain full manual control of parser mappings even when token auto-selection is applied.