### PR TITLE
Webui inference fix

### DIFF
--- a/webui/templates/4.3.0.compute_predictions.html
+++ b/webui/templates/4.3.0.compute_predictions.html
@@ -45,13 +45,14 @@
 
 
 {% block content %}
+{% set inference_default_source_mode = 'server-path' if (webui_runtime.default_analysis_source_mode|default('upload')) == 'server-path' else 'upload' %}
 <div
     id="compute-predictions-root"
     x-data="{
         runtime: (window.__webuiRuntime || {}),
-        featuresSourceMode: '{{ "auto-detected" if default_feature_file else "server-path" }}',
+        featuresSourceMode: '{{ "auto-detected" if default_feature_file else inference_default_source_mode }}',
         featuresServerFilePath: '',
-        assetsSourceMode: 'server-path',
+        assetsSourceMode: '{{ inference_default_source_mode }}',
         assetsServerFolderPath: '',
         assetsModelServerFilePath: '',
         assetsScalerServerFilePath: '',
@@ -139,7 +140,7 @@
             <div class="grid grid-cols-1 gap-6">
                 <div>
                     <input id="existing-features-file" type="hidden" name="existing_features_file" value="{{ default_feature_file | default('') }}">
-                    <input id="features-source-mode" type="hidden" name="features_source_mode" value="{{ 'auto-detected' if default_feature_file else 'server-path' }}">
+                    <input id="features-source-mode" type="hidden" name="features_source_mode" value="{{ 'auto-detected' if default_feature_file else inference_default_source_mode }}">
                     <input id="features-server-file-path" type="hidden" name="features_server_file_path" value="">
                     <input id="file-upload-features" class="hidden" name="features_predict_file" type="file" />
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
@@ -210,7 +211,7 @@
                 Load Prediction Assets
             </h2>
             <div class="grid grid-cols-1 gap-6">
-                <input id="model-assets-source" type="hidden" name="model_assets_source" value="server-path">
+                <input id="model-assets-source" type="hidden" name="model_assets_source" value="{{ inference_default_source_mode }}">
                 <input type="hidden" id="assets-upload-mode-hidden" name="assets_upload_mode" value="individual">
                 <input id="inference-assets-server-folder-path" type="hidden" name="inference_assets_server_folder_path" value="">
                 <input id="inference-model-server-file-path" type="hidden" name="inference_model_server_file_path" value="">
@@ -298,8 +299,8 @@
                         <div id="assets-model-drop-zone"
                             class="custom-file-card drop-zone mt-1 rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                             <div class="flex flex-wrap justify-center gap-2">
-                                <button id="assets-model-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300">Local upload</button>
-                                <button id="assets-model-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border border-primary bg-primary/10 text-primary font-semibold">Server upload</button>
+                                <button id="assets-model-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border {% if inference_default_source_mode == 'upload' %}border-primary bg-primary/10 text-primary font-semibold{% else %}border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300{% endif %}">Local upload</button>
+                                <button id="assets-model-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border {% if inference_default_source_mode == 'server-path' %}border-primary bg-primary/10 text-primary font-semibold{% else %}border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300{% endif %}">Server upload</button>
                                 <button id="assets-model-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
                             </div>
                             <span class="mt-3 material-symbols-outlined text-4xl text-slate-400 text-center block">upload_file</span>
@@ -333,8 +334,8 @@
                         <div id="assets-scaler-drop-zone"
                             class="custom-file-card drop-zone mt-1 rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                             <div class="flex flex-wrap justify-center gap-2">
-                                <button id="assets-scaler-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300">Local upload</button>
-                                <button id="assets-scaler-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border border-primary bg-primary/10 text-primary font-semibold">Server upload</button>
+                                <button id="assets-scaler-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border {% if inference_default_source_mode == 'upload' %}border-primary bg-primary/10 text-primary font-semibold{% else %}border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300{% endif %}">Local upload</button>
+                                <button id="assets-scaler-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border {% if inference_default_source_mode == 'server-path' %}border-primary bg-primary/10 text-primary font-semibold{% else %}border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300{% endif %}">Server upload</button>
                                 <button id="assets-scaler-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
                             </div>
                             <span class="mt-3 material-symbols-outlined text-4xl text-slate-400 text-center block">upload_file</span>
@@ -368,8 +369,8 @@
                         <div id="assets-density-drop-zone"
                             class="custom-file-card drop-zone mt-1 rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                             <div class="flex flex-wrap justify-center gap-2">
-                                <button id="assets-density-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300">Local upload</button>
-                                <button id="assets-density-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border border-primary bg-primary/10 text-primary font-semibold">Server upload</button>
+                                <button id="assets-density-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border {% if inference_default_source_mode == 'upload' %}border-primary bg-primary/10 text-primary font-semibold{% else %}border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300{% endif %}">Local upload</button>
+                                <button id="assets-density-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border {% if inference_default_source_mode == 'server-path' %}border-primary bg-primary/10 text-primary font-semibold{% else %}border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300{% endif %}">Server upload</button>
                                 <button id="assets-density-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
                             </div>
                             <span class="mt-3 material-symbols-outlined text-4xl text-slate-400 text-center block">upload_file</span>

--- a/webui/templates/4.3.0.compute_predictions.html
+++ b/webui/templates/4.3.0.compute_predictions.html
@@ -49,7 +49,7 @@
     id="compute-predictions-root"
     x-data="{
         runtime: (window.__webuiRuntime || {}),
-        featuresSourceMode: '{{ "auto-detected" if default_feature_file else "upload" }}',
+        featuresSourceMode: '{{ "auto-detected" if default_feature_file else "server-path" }}',
         featuresServerFilePath: '',
         assetsSourceMode: 'server-path',
         assetsServerFolderPath: '',
@@ -139,7 +139,7 @@
             <div class="grid grid-cols-1 gap-6">
                 <div>
                     <input id="existing-features-file" type="hidden" name="existing_features_file" value="{{ default_feature_file | default('') }}">
-                    <input id="features-source-mode" type="hidden" name="features_source_mode" value="{{ 'auto-detected' if default_feature_file else 'upload' }}">
+                    <input id="features-source-mode" type="hidden" name="features_source_mode" value="{{ 'auto-detected' if default_feature_file else 'server-path' }}">
                     <input id="features-server-file-path" type="hidden" name="features_server_file_path" value="">
                     <input id="file-upload-features" class="hidden" name="features_predict_file" type="file" />
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
@@ -237,7 +237,7 @@
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Assets Selection Mode</label>
                     <div class="flex flex-col sm:flex-row gap-3">
                         <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
-                            <input id="assets-mode-individual" type="radio" class="text-primary focus:ring-primary" x-model="assetsUploadMode" value="individual">
+                            <input id="assets-mode-individual" type="radio" class="text-primary focus:ring-primary" x-model="assetsUploadMode" value="individual" checked>
                             Individual files
                         </label>
                         <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
@@ -298,8 +298,8 @@
                         <div id="assets-model-drop-zone"
                             class="custom-file-card drop-zone mt-1 rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                             <div class="flex flex-wrap justify-center gap-2">
-                                <button id="assets-model-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border">Local upload</button>
-                                <button id="assets-model-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server upload</button>
+                                <button id="assets-model-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300">Local upload</button>
+                                <button id="assets-model-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border border-primary bg-primary/10 text-primary font-semibold">Server upload</button>
                                 <button id="assets-model-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
                             </div>
                             <span class="mt-3 material-symbols-outlined text-4xl text-slate-400 text-center block">upload_file</span>
@@ -333,8 +333,8 @@
                         <div id="assets-scaler-drop-zone"
                             class="custom-file-card drop-zone mt-1 rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                             <div class="flex flex-wrap justify-center gap-2">
-                                <button id="assets-scaler-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border">Local upload</button>
-                                <button id="assets-scaler-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server upload</button>
+                                <button id="assets-scaler-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300">Local upload</button>
+                                <button id="assets-scaler-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border border-primary bg-primary/10 text-primary font-semibold">Server upload</button>
                                 <button id="assets-scaler-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
                             </div>
                             <span class="mt-3 material-symbols-outlined text-4xl text-slate-400 text-center block">upload_file</span>
@@ -368,8 +368,8 @@
                         <div id="assets-density-drop-zone"
                             class="custom-file-card drop-zone mt-1 rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
                             <div class="flex flex-wrap justify-center gap-2">
-                                <button id="assets-density-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border">Local upload</button>
-                                <button id="assets-density-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border">Server upload</button>
+                                <button id="assets-density-source-upload-btn" type="button" class="custom-mode-upload-btn px-3 py-1.5 text-xs rounded-lg border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300">Local upload</button>
+                                <button id="assets-density-source-server-btn" type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border border-primary bg-primary/10 text-primary font-semibold">Server upload</button>
                                 <button id="assets-density-server-browse-btn" type="button" class="hidden" aria-hidden="true" tabindex="-1"></button>
                             </div>
                             <span class="mt-3 material-symbols-outlined text-4xl text-slate-400 text-center block">upload_file</span>

--- a/webui/templates/4.3.0.compute_predictions.html
+++ b/webui/templates/4.3.0.compute_predictions.html
@@ -1507,8 +1507,10 @@
             fileModal.classList.remove("hidden");
             fileModal.classList.add("flex");
             const current = String(currentSelectionPath || "").trim();
-            const startPath = current && current.includes("/")
-                ? current.slice(0, current.lastIndexOf("/"))
+            const normalizedCurrent = current.replace(/\\/g, "/");
+            const looksLikeFilePath = /\/[^/]+\.[^/]+$/.test(normalizedCurrent);
+            const startPath = normalizedCurrent
+                ? (looksLikeFilePath ? normalizedCurrent.slice(0, normalizedCurrent.lastIndexOf("/")) : normalizedCurrent)
                 : "";
             selectedFilePath = current;
             await loadServerFiles(startPath);


### PR DESCRIPTION
Inference defaults and server-path consistency fixes (source mode + asset browser behavior)

## Summary
This PR includes the last three Inference updates requested for `Compute predictions`:

1. **Default source mode alignment with runtime context**  
2. **Stable visual selection for `Server upload` in Load Prediction Assets**  
3. **Server file browser path fix for Scaler/Density (same path as Model/Posterior)**

---

## Changes

### 1) Inference defaults now follow local/server runtime
Updated Inference source defaults so they match how the rest of the app behaves:

- In local workflows: default is **Local upload** (`upload`)
- In server workflows: default is **Server upload** (`server-path`)
- Exception preserved:
  - if pipeline features are detected, `Load data` defaults to **auto-detected**

Applied to:
- Alpine initial state (`featuresSourceMode`, `assetsSourceMode`)
- Hidden form inputs (`features_source_mode`, `model_assets_source`)
- Initial button styling classes for Model/Scaler/Density cards

---

### 2) `Server upload` visual selection stays correctly highlighted
`Load Prediction Assets` now keeps the active source button visually selected from initial render (green active state), consistent with the selected mode.

This resolves the issue where the selection appeared briefly and then looked unselected after page initialization.

---

### 3) Scaler/Density browser opens in the same path as Model/Posterior
Fixed server browser start-path logic in the file modal flow:

- If the incoming value is already a **folder path**, use it as-is.
- If it is a **file path**, start from its parent directory.

This prevents the previous behavior where Scaler/Density started one directory level above the path selected in Model/Posterior.

---

## File Changed
- `webui/templates/4.3.0.compute_predictions.html`