### PR TITLE
Webui edf

### DIFF
--- a/ncpi/EphysDatasetParser.py
+++ b/ncpi/EphysDatasetParser.py
@@ -512,7 +512,7 @@ class EphysDatasetParser:
       - numpy arrays (ndarray)
       - dict-like (including scipy.io.loadmat output, json-loaded dict)
       - pandas DataFrame (wide/long), and file paths to csv/parquet if pandas installed
-      - .npy, .json, .mat, .set, .edf, .tsv paths
+      - .npy, .json, .mat, .set, .fif, .edf, .tsv paths
 
     Output:
       - pandas DataFrame with DEFAULT_COLUMNS
@@ -604,7 +604,23 @@ class EphysDatasetParser:
 
                 return mne.io.read_raw_eeglab(str(path), preload=self.config.preload), source_file
 
+            if suffix == ".fif":
+                if not path.is_file():
+                    raise ValueError(
+                        f"FIF file does not exist or is not a regular file: '{path}'. "
+                        "Verify the dataset path and that the file is available on disk."
+                    )
+                _require_mne("MNE FIF .fif loading")
+                import mne  # type: ignore
+
+                return mne.io.read_raw_fif(str(path), preload=self.config.preload, verbose=False), source_file
+
             if suffix == ".edf":
+                if not path.is_file():
+                    raise ValueError(
+                        f"EDF file does not exist or is not a regular file: '{path}'. "
+                        "Verify the dataset path and that the file is available on disk."
+                    )
                 return _load_edf_with_pyedflib(path), source_file
 
             if suffix in (".csv", ".parquet", ".tsv"):

--- a/ncpi/EphysDatasetParser.py
+++ b/ncpi/EphysDatasetParser.py
@@ -87,6 +87,15 @@ def _require_h5py(context: str = "") -> None:
         raise ImportError(msg)
 
 
+def _require_pyedflib(context: str = "") -> None:
+    if not tools.ensure_module("pyedflib"):
+        msg = "pyEDFlib is required"
+        if context:
+            msg += f" for {context}"
+        msg += " but is not installed."
+        raise ImportError(msg)
+
+
 def _is_matlab_v73_error(exc: Exception) -> bool:
     return "please use hdf reader for matlab v7.3 files" in str(exc or "").lower()
 
@@ -216,6 +225,144 @@ def _load_mat_with_fallback(path: Path) -> Any:
                 f"scipy: {scipy_exc}; h5py: {exc}"
             )
         raise
+
+
+def _load_edf_with_pyedflib(path: Path) -> Dict[str, Any]:
+    _require_pyedflib("EDF .edf loading")
+    import pyedflib  # type: ignore
+
+    def _as_text(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="ignore").strip()
+        return str(value).strip()
+
+    def _safe_reader_call(reader: Any, method_name: str) -> Any:
+        fn = getattr(reader, method_name, None)
+        if callable(fn):
+            try:
+                return fn()
+            except Exception:
+                return None
+        return None
+
+    reader = pyedflib.EdfReader(str(path))
+    try:
+        n_signals = int(getattr(reader, "signals_in_file", 0) or 0)
+        if n_signals <= 0:
+            raise ValueError(f"EDF file '{path}' does not contain readable signals.")
+
+        labels_raw = _safe_reader_call(reader, "getSignalLabels") or []
+        ch_names = [
+            (_as_text(labels_raw[i]) if i < len(labels_raw) else "") or f"ch{i}"
+            for i in range(n_signals)
+        ]
+
+        sample_freqs = np.asarray(_safe_reader_call(reader, "getSampleFrequencies"), dtype=float).reshape(-1)
+        if sample_freqs.size != n_signals:
+            raise ValueError(
+                f"EDF file '{path}' returned {sample_freqs.size} sample-frequency values for {n_signals} channels."
+            )
+        if not np.isfinite(sample_freqs).all() or float(sample_freqs[0]) <= 0:
+            raise ValueError(f"EDF file '{path}' contains invalid sample-frequency values.")
+
+        fs = float(sample_freqs[0])
+        if np.any(np.abs(sample_freqs - fs) > 1e-9):
+            unique_freqs = sorted({float(v) for v in sample_freqs.tolist()})
+            raise ValueError(
+                f"EDF file '{path}' contains mixed sampling frequencies across channels: {unique_freqs}. "
+                "A single shared frequency is required."
+            )
+
+        n_samples_arr = np.asarray(_safe_reader_call(reader, "getNSamples"), dtype=int).reshape(-1)
+        if n_samples_arr.size != n_signals:
+            raise ValueError(
+                f"EDF file '{path}' returned {n_samples_arr.size} sample-count values for {n_signals} channels."
+            )
+        if np.any(n_samples_arr <= 0):
+            raise ValueError(f"EDF file '{path}' contains non-positive sample counts.")
+        if np.any(n_samples_arr != int(n_samples_arr[0])):
+            unique_counts = sorted({int(v) for v in n_samples_arr.tolist()})
+            raise ValueError(
+                f"EDF file '{path}' contains inconsistent sample counts across channels: {unique_counts}."
+            )
+
+        n_samples = int(n_samples_arr[0])
+        data = np.empty((n_signals, n_samples), dtype=float)
+        for ch_idx in range(n_signals):
+            sig = np.asarray(reader.readSignal(ch_idx), dtype=float).reshape(-1)
+            if sig.size != n_samples:
+                raise ValueError(
+                    f"EDF file '{path}' channel {ch_idx} has {sig.size} samples, expected {n_samples}."
+                )
+            data[ch_idx, :] = sig
+
+        start_dt = _safe_reader_call(reader, "getStartdatetime")
+        recording_start = start_dt.isoformat() if start_dt is not None and hasattr(start_dt, "isoformat") else None
+
+        annotations: list[Dict[str, Any]] = []
+        raw_annotations = _safe_reader_call(reader, "readAnnotations")
+        if isinstance(raw_annotations, tuple) and len(raw_annotations) >= 3:
+            onsets, durations, descriptions = raw_annotations[0], raw_annotations[1], raw_annotations[2]
+            for onset, duration, description in zip(onsets, durations, descriptions):
+                try:
+                    onset_val = float(onset)
+                except Exception:
+                    onset_val = None
+                try:
+                    duration_val = float(duration)
+                except Exception:
+                    duration_val = None
+                annotations.append(
+                    {
+                        "onset_s": onset_val,
+                        "duration_s": duration_val,
+                        "description": _as_text(description),
+                    }
+                )
+
+        header = {}
+        header_fields = {
+            "patient_code": "getPatientCode",
+            "patient_name": "getPatientName",
+            "admin_code": "getAdmincode",
+            "technician": "getTechnician",
+            "equipment": "getEquipment",
+            "recording_additional": "getRecordingAdditional",
+            "patient_additional": "getPatientAdditional",
+            "gender": "getGender",
+            "birthdate": "getBirthdate",
+        }
+        for key, method_name in header_fields.items():
+            value = _safe_reader_call(reader, method_name)
+            value_text = _as_text(value)
+            if value_text:
+                header[key] = value_text
+
+        subject_id = header.get("patient_code") or header.get("patient_name")
+        duration_s = float(n_samples) / fs
+        out: Dict[str, Any] = {
+            "__source_format__": "edf",
+            "data": data,
+            "fs": fs,
+            "ch_names": ch_names,
+            "time": np.arange(n_samples, dtype=float) / fs,
+            "duration_s": duration_s,
+            "recording_start": recording_start,
+            "n_channels": int(n_signals),
+            "n_samples": int(n_samples),
+            "annotations": annotations,
+            "header": header,
+        }
+        if subject_id:
+            out["subject_id"] = subject_id
+        return out
+    finally:
+        try:
+            reader.close()
+        except Exception:
+            pass
 
 
 # ---- Locators -------------------------------------------------------------
@@ -365,7 +512,7 @@ class EphysDatasetParser:
       - numpy arrays (ndarray)
       - dict-like (including scipy.io.loadmat output, json-loaded dict)
       - pandas DataFrame (wide/long), and file paths to csv/parquet if pandas installed
-      - .npy, .json, .mat, .set, .tsv paths
+      - .npy, .json, .mat, .set, .edf, .tsv paths
 
     Output:
       - pandas DataFrame with DEFAULT_COLUMNS
@@ -456,6 +603,9 @@ class EphysDatasetParser:
                 import mne  # type: ignore
 
                 return mne.io.read_raw_eeglab(str(path), preload=self.config.preload), source_file
+
+            if suffix == ".edf":
+                return _load_edf_with_pyedflib(path), source_file
 
             if suffix in (".csv", ".parquet", ".tsv"):
                 if not tools.ensure_module("pandas"):

--- a/webui/app.py
+++ b/webui/app.py
@@ -127,7 +127,7 @@ job_futures = {}
 # Set NCPI_MAX_OUTPUT_LINES <= 0 for unlimited output retention (default).
 MAX_OUTPUT_LINES = max(0, int(os.environ.get("NCPI_MAX_OUTPUT_LINES", "0")))
 FEATURES_PARSER_FILE_EXTENSIONS = {
-    ".mat", ".json", ".npy", ".csv", ".parquet", ".pkl", ".pickle", ".xlsx", ".xls", ".feather", ".set", ".edf", ".tsv"
+    ".mat", ".json", ".npy", ".csv", ".parquet", ".pkl", ".pickle", ".xlsx", ".xls", ".feather", ".set", ".fif", ".edf", ".tsv"
 }
 FEATURES_MAX_SUBFOLDER_DEPTH = 6
 FILE_EXTRACTED_VIRTUAL_FIELD = "__file_extracted_label__"
@@ -2194,6 +2194,9 @@ def _collect_supported_folder_file_entries(folder_paths, kind_label, data_file_s
     extension_counts = defaultdict(int)
     folder_contexts = []
     selection_map = data_file_selection_map if isinstance(data_file_selection_map, dict) else {}
+    skipped_unreadable_paths = defaultdict(list)
+    skipped_unreadable_by_ext = defaultdict(lambda: defaultdict(int))
+    skipped_broken_symlink_paths = defaultdict(list)
 
     for folder_idx, root in enumerate(roots, start=1):
         folder_name = _folder_display_name(root, fallback_index=folder_idx)
@@ -2224,6 +2227,12 @@ def _collect_supported_folder_file_entries(folder_paths, kind_label, data_file_s
                 if ext not in FEATURES_PARSER_FILE_EXTENSIONS:
                     continue
                 full_path = os.path.join(current_root, name)
+                if not os.path.isfile(full_path):
+                    skipped_unreadable_paths[root].append(full_path)
+                    skipped_unreadable_by_ext[root][ext or "(no extension)"] += 1
+                    if os.path.islink(full_path):
+                        skipped_broken_symlink_paths[root].append(full_path)
+                    continue
                 rel_path = _to_posix_relpath(os.path.relpath(full_path, root))
                 rel_parts = [token for token in rel_path.split("/") if token]
                 file_depth = max(0, len(rel_parts) - 1)
@@ -2552,6 +2561,26 @@ def _collect_supported_folder_file_entries(folder_paths, kind_label, data_file_s
                 for item in selected_entries
             ]
 
+        if skipped_unreadable_paths.get(root):
+            ext_parts = []
+            for _ext, _count in sorted(skipped_unreadable_by_ext.get(root, {}).items()):
+                ext_parts.append(f"{_ext} ({_count})")
+            ext_text = ", ".join(ext_parts) if ext_parts else "supported extensions"
+            broken_links = skipped_broken_symlink_paths.get(root, [])
+            if broken_links:
+                example_link = str(broken_links[0])
+                structure_warnings.append(
+                    "Some candidate files were skipped because they are not readable regular files "
+                    f"(detected: {ext_text}). "
+                    f"Broken symlink example: {example_link}. "
+                    "If this dataset uses git-annex/datalad links, fetch the file contents first."
+                )
+            else:
+                structure_warnings.append(
+                    "Some candidate files were skipped because they are not readable regular files "
+                    f"(detected: {ext_text})."
+                )
+
         folder_summaries.append({
             "folder_path": root,
             "folder_name": folder_name,
@@ -2570,15 +2599,31 @@ def _collect_supported_folder_file_entries(folder_paths, kind_label, data_file_s
             "selected_data_extension": selected_data_extension,
             "matched_data_files": matched_data_files,
             "selected_entries": selected_entries,
+            "all_entries": list(folder_entries),
             "sample_selected_entry": selected_sample_entry,
             "all_subfolders": all_subfolders,
             "structure_warnings": structure_warnings,
+            "skipped_unreadable_paths": list(skipped_unreadable_paths.get(root, []))[:20],
         })
 
     entries.sort(key=lambda item: item["path"])
 
     if not entries:
         joined = ", ".join(roots)
+        unreadable_count = sum(len(v) for v in skipped_unreadable_paths.values())
+        if unreadable_count > 0:
+            sample_unreadable = []
+            for root in roots:
+                sample_unreadable.extend(skipped_unreadable_paths.get(root, []))
+                if len(sample_unreadable) >= 5:
+                    break
+            sample_text = ", ".join(sample_unreadable[:5])
+            raise ValueError(
+                f"No supported readable {kind_label.lower()} files found in selected folder(s): {joined}. "
+                f"Detected {unreadable_count} path(s) that are not regular readable files"
+                + (f" (e.g., {sample_text})" if sample_text else "")
+                + "."
+            )
         raise ValueError(f"No supported {kind_label.lower()} files found in selected folder(s): {joined}")
 
     return entries, folder_summaries, dict(sorted(extension_counts.items())), folder_contexts
@@ -2679,11 +2724,14 @@ def _parse_filename_format_spec(raw_format):
         group_map.append((group_name, value_part))
         regex_parts.append(f"(?P<{group_name}>.+?)")
 
+    has_explicit_extension = bool(re.search(r"\.[A-Za-z0-9]+$", value))
+
     return {
         "raw": value,
         "tokens": token_names,
         "group_map": group_map,
         "regex": re.compile("^" + "".join(regex_parts) + "$"),
+        "has_explicit_extension": has_explicit_extension,
     }
 
 
@@ -2696,13 +2744,22 @@ def _extract_filename_format_tokens(file_name, format_spec):
     matcher = format_spec.get("regex")
     if matcher is None:
         return None
-    match = matcher.fullmatch(basename)
-    if not match:
-        return None
-    out = {}
-    for group_name, token_name in (format_spec.get("group_map") or []):
-        out[str(token_name)] = str(match.group(group_name) or "").strip()
-    return out
+    has_explicit_extension = bool(format_spec.get("has_explicit_extension"))
+    candidates = [basename]
+    if not has_explicit_extension:
+        stem = Path(basename).stem
+        if stem and stem != basename:
+            candidates.append(stem)
+
+    for candidate in candidates:
+        match = matcher.fullmatch(candidate)
+        if not match:
+            continue
+        out = {}
+        for group_name, token_name in (format_spec.get("group_map") or []):
+            out[str(token_name)] = str(match.group(group_name) or "").strip()
+        return out
+    return None
 
 
 def _matches_filename_format(file_name, format_spec):
@@ -3656,64 +3713,25 @@ def _filter_folder_contexts_by_filename_format(folder_contexts, filename_format_
         if not isinstance(context, dict):
             continue
         cloned = dict(context)
-        selected_entries = list(cloned.get("selected_entries") or [])
-        matched_data_files = list(cloned.get("matched_data_files") or [])
+        # When a filename format is explicitly provided, it takes precedence over
+        # Data Source Selection. Filter against all discovered files in the folder.
+        all_entries = list(cloned.get("all_entries") or [])
+        selected_entries = all_entries
+        matched_data_files = all_entries
         has_nested_subfolders = bool(cloned.get("has_nested_subfolders"))
-        if has_nested_subfolders:
-            filter_scope = "folder"
-            branch_names = sorted(
-                {
-                    str(item.get("level1_subfolder") or "").strip()
-                    for item in matched_data_files
-                    if str(item.get("level1_subfolder") or "").strip()
-                }
-            )
-            if not branch_names:
-                branch_names = sorted(
-                    {
-                        str(item.get("name") or "").strip()
-                        for item in (cloned.get("all_subfolders") or [])
-                        if str(item.get("name") or "").strip()
-                    }
-                )
-            matched_branch_names, skipped_branch_names = _filter_named_items_by_filename_format(
-                branch_names,
-                lambda item: str(item or ""),
-                filename_format_spec,
-            )
-            total_count += len(branch_names)
-            matched_count += len(matched_branch_names)
-            skipped_names.extend(skipped_branch_names)
-            matched_branch_set = set(matched_branch_names)
-            selected_entries = [
-                item
-                for item in selected_entries
-                if str(item.get("level1_subfolder") or "").strip() in matched_branch_set
-            ]
-            matched_data_files = [
-                item
-                for item in matched_data_files
-                if str(item.get("level1_subfolder") or "").strip() in matched_branch_set
-            ]
-            cloned["all_subfolders"] = [
-                item
-                for item in (cloned.get("all_subfolders") or [])
-                if str(item.get("name") or "").strip() in matched_branch_set
-            ]
-        else:
-            selected_entries, skipped_selected = _filter_named_items_by_filename_format(
-                selected_entries,
-                lambda item: str(item.get("name") or ""),
-                filename_format_spec,
-            )
-            matched_data_files, _ = _filter_named_items_by_filename_format(
-                matched_data_files,
-                lambda item: str(item.get("name") or ""),
-                filename_format_spec,
-            )
-            total_count += len(selected_entries) + len(skipped_selected)
-            matched_count += len(selected_entries)
-            skipped_names.extend(skipped_selected)
+        selected_entries, skipped_selected = _filter_named_items_by_filename_format(
+            selected_entries,
+            lambda item: str(item.get("name") or ""),
+            filename_format_spec,
+        )
+        matched_data_files, _ = _filter_named_items_by_filename_format(
+            matched_data_files,
+            lambda item: str(item.get("name") or ""),
+            filename_format_spec,
+        )
+        total_count += len(selected_entries) + len(skipped_selected)
+        matched_count += len(selected_entries)
+        skipped_names.extend(skipped_selected)
         cloned["selected_entries"] = selected_entries
         cloned["matched_data_files"] = matched_data_files
         sample_entry = cloned.get("sample_selected_entry")
@@ -3758,34 +3776,93 @@ def _collect_selected_entries_from_folder_contexts(folder_contexts):
     return collected
 
 
+def _expand_entries_for_filename_format_scope(
+    source_entries,
+    selected_path_set,
+    folder_contexts,
+    subfolder_filter_map=None,
+):
+    selected_paths = set(str(path or "").strip() for path in (selected_path_set or set()) if str(path or "").strip())
+    if not selected_paths:
+        return []
+
+    out = []
+    for entry in source_entries or []:
+        if not isinstance(entry, dict):
+            continue
+        folder_path = str(entry.get("folder_path") or "").strip()
+        if folder_path not in selected_paths:
+            continue
+        out.append(entry)
+
+    filter_map = subfolder_filter_map if isinstance(subfolder_filter_map, dict) else {}
+    if filter_map:
+        filtered = []
+        for entry in out:
+            folder_path = str(entry.get("folder_path") or "").strip()
+            included = filter_map.get(folder_path, [])
+            if not included:
+                filtered.append(entry)
+                continue
+            sub_name = str(entry.get("level1_subfolder") or "").strip()
+            if not sub_name or sub_name in included:
+                filtered.append(entry)
+        out = filtered
+
+    out.sort(key=lambda item: str(item.get("path") or ""))
+    return out
+
+
+def _expand_entries_for_selected_extensions_scope(
+    source_entries,
+    selected_path_set,
+    selected_extensions,
+    subfolder_filter_map=None,
+):
+    selected_paths = set(str(path or "").strip() for path in (selected_path_set or set()) if str(path or "").strip())
+    wanted_exts = set(str(ext or "").strip().lower() for ext in (selected_extensions or []) if str(ext or "").strip())
+    if not selected_paths or not wanted_exts:
+        return []
+
+    out = []
+    for entry in source_entries or []:
+        if not isinstance(entry, dict):
+            continue
+        folder_path = str(entry.get("folder_path") or "").strip()
+        if folder_path not in selected_paths:
+            continue
+        entry_ext = str(entry.get("extension") or "").strip().lower()
+        if entry_ext not in wanted_exts:
+            continue
+        out.append(entry)
+
+    filter_map = subfolder_filter_map if isinstance(subfolder_filter_map, dict) else {}
+    if filter_map:
+        filtered = []
+        for entry in out:
+            folder_path = str(entry.get("folder_path") or "").strip()
+            included = filter_map.get(folder_path, [])
+            if not included:
+                filtered.append(entry)
+                continue
+            sub_name = str(entry.get("level1_subfolder") or "").strip()
+            if not sub_name or sub_name in included:
+                filtered.append(entry)
+        out = filtered
+
+    out.sort(key=lambda item: str(item.get("path") or ""))
+    return out
+
+
 def _filter_selected_entries_by_filename_format(selected_entries, filename_format_spec):
     rows = [item for item in (selected_entries or []) if isinstance(item, dict)]
-    has_nested_subfolders = any(str(item.get("level1_subfolder") or "").strip() for item in rows)
-    if has_nested_subfolders:
-        level1_names = sorted(
-            {
-                str(item.get("level1_subfolder") or "").strip()
-                for item in rows
-                if str(item.get("level1_subfolder") or "").strip()
-            }
-        )
-        matched_names, skipped_names = _filter_named_items_by_filename_format(
-            level1_names,
-            lambda item: str(item or ""),
-            filename_format_spec,
-        )
-        matched_set = set(matched_names)
-        filtered = [
-            item
-            for item in rows
-            if str(item.get("level1_subfolder") or "").strip() in matched_set
-        ]
-        return filtered, skipped_names, "folder", len(level1_names)
     filtered, skipped_names = _filter_named_items_by_filename_format(
         rows,
         lambda row: str(row.get("name") or ""),
         filename_format_spec,
     )
+    # Even for nested folder layouts (e.g., BIDS), filename-format filtering
+    # should operate on every candidate file name, not only top-level subfolder names.
     return filtered, skipped_names, "file", len(rows)
 
 
@@ -3850,21 +3927,12 @@ def _build_folder_inspection_profiles(folder_entries, folder_summaries, filename
             continue
 
         if filename_format_spec:
-            nested_labels = sorted(
-                {
-                    str(item.get("level1_subfolder") or "").strip()
-                    for item in rows
-                    if str(item.get("level1_subfolder") or "").strip()
-                }
-            )
-            if nested_labels:
-                folder_file_names = nested_labels
-            else:
-                folder_file_names = [
-                    str(item.get("name") or "").strip()
-                    for item in rows
-                    if str(item.get("name") or "").strip()
-                ]
+            # Filename-format filtering is file-based even for nested datasets (e.g., BIDS).
+            folder_file_names = [
+                str(item.get("name") or "").strip()
+                for item in rows
+                if str(item.get("name") or "").strip()
+            ]
         else:
             folder_file_names = [
                 str(item.get("logical_name") or item.get("name") or "")
@@ -4251,8 +4319,10 @@ def _resolve_locator_value(obj, locator):
     parser = EphysDatasetParser(ParseConfig())
     try:
         return parser._resolve(obj, locator)
-    except Exception as e:
-        traceback.print_exc()
+    except Exception:
+        # Locator probing during parser inspection is best-effort:
+        # unresolved optional paths (e.g. info.subject_info.his_id when subject_info is None)
+        # should not spam server logs with full tracebacks.
         return None
 
 
@@ -4666,12 +4736,32 @@ def _describe_parser_source(path):
             sfreq = float(getattr(source_obj.info, "sfreq", 0))
         except Exception:
             sfreq = None
+        duration_s = None
+        try:
+            if hasattr(source_obj, "n_times") and sfreq and float(sfreq) > 0:
+                duration_s = float(getattr(source_obj, "n_times", 0)) / float(sfreq)
+        except Exception:
+            duration_s = None
+        bads_count = 0
+        try:
+            bads_count = len(getattr(source_obj.info, "bads", []) or [])
+        except Exception:
+            bads_count = 0
         mne_candidates = [
             "get_data",
             "ch_names",
             "info.sfreq",
             "info.subject_info",
+            "info.subject_info.his_id",
+            "info.subject_info.id",
             "info.description",
+            "info.meas_date",
+            "info.line_freq",
+            "info.lowpass",
+            "info.highpass",
+            "info.bads",
+            "info.experimenter",
+            "info.device_info",
         ]
         mne_defaults = {
             "data": "get_data",
@@ -4686,6 +4776,9 @@ def _describe_parser_source(path):
         summary_parts = [f"MNE {type(source_obj).__name__}", f"{n_ch} channels"]
         if sfreq:
             summary_parts.append(f"{sfreq:g} Hz")
+        if duration_s and np.isfinite(duration_s) and duration_s > 0:
+            summary_parts.append(f"{duration_s:.3f}s")
+        summary_parts.append(f"{bads_count} bad channel(s)")
         payload = {
             "source_type": "mne_raw",
             "candidate_fields": mne_candidates,
@@ -7879,7 +7972,7 @@ def features_parser_inspect():
                 folder_entries = _collect_selected_entries_from_folder_contexts(folder_contexts)
                 if not folder_entries:
                     raise ValueError(
-                        f"No files or first-level folders match filename format '{filename_format_spec['raw']}'."
+                        f"No files match filename format '{filename_format_spec['raw']}'."
                     )
                 folder_summaries, extension_summaries = _summarize_folder_entries(folder_entries)
                 skipped_names = folder_filter_stats.get("skipped_names") or []
@@ -7957,7 +8050,7 @@ def features_parser_inspect():
                 folder_entries = _collect_selected_entries_from_folder_contexts(folder_contexts)
                 if not folder_entries:
                     raise ValueError(
-                        f"No files or first-level folders match filename format '{filename_format_spec['raw']}'."
+                        f"No files match filename format '{filename_format_spec['raw']}'."
                     )
                 folder_summaries, extension_summaries = _summarize_folder_entries(folder_entries)
                 skipped_names = folder_filter_stats.get("skipped_names") or []
@@ -8098,7 +8191,7 @@ def features_parser_inspect():
                     )
             else:
                 raise ValueError(
-                    f"No files or first-level folders match filename format '{filename_format_spec['raw']}'."
+                    f"No files match filename format '{filename_format_spec['raw']}'."
                 )
 
         if folder_entries:
@@ -13248,6 +13341,12 @@ def start_computation_redirect(computation_type):
                 cfg_started = time.perf_counter()
                 parse_cfg = _build_parse_config_from_form(request.form)
                 filename_format_spec = _parse_filename_format_spec(request.form.get("parser_filename_format"))
+                app.logger.warning(
+                    "[compute %s] simulation filename_format raw=%r parsed=%s",
+                    job_id,
+                    (request.form.get("parser_filename_format") or ""),
+                    "yes" if filename_format_spec else "no",
+                )
                 _validate_parse_cfg_filename_token_locators(parse_cfg, request.form)
                 app.logger.warning(
                     "[compute %s] simulation parser config built in %.1f ms",
@@ -13286,6 +13385,41 @@ def start_computation_redirect(computation_type):
                         selected_data_entries.extend(list(context.get("selected_entries") or []))
                     if selected_data_entries:
                         selected_entries = selected_data_entries
+                    if not filename_format_spec:
+                        nested_selected_exts = {
+                            str(context.get("selected_data_extension") or "").strip().lower()
+                            for context in folder_contexts
+                            if str(context.get("folder_path") or "").strip() in selected_path_set
+                            and bool(context.get("has_nested_subfolders"))
+                            and str(context.get("selected_data_extension") or "").strip()
+                        }
+                        if nested_selected_exts:
+                            expanded_auto_entries = _expand_entries_for_selected_extensions_scope(
+                                source_entries,
+                                selected_path_set,
+                                nested_selected_exts,
+                            )
+                            if expanded_auto_entries:
+                                selected_entries = expanded_auto_entries
+                    app.logger.warning(
+                        "[compute %s] simulation entries baseline selected=%d source_total=%d",
+                        job_id,
+                        len(selected_entries),
+                        len(source_entries),
+                    )
+                    if filename_format_spec:
+                        expanded_entries = _expand_entries_for_filename_format_scope(
+                            source_entries,
+                            selected_path_set,
+                            folder_contexts,
+                        )
+                        if expanded_entries:
+                            selected_entries = expanded_entries
+                        app.logger.warning(
+                            "[compute %s] simulation entries expanded=%d",
+                            job_id,
+                            len(selected_entries),
+                        )
                     if not selected_entries:
                         raise ValueError("No files available in the selected analysis folder(s).")
                     if filename_format_spec:
@@ -13311,15 +13445,11 @@ def start_computation_redirect(computation_type):
                             )
                     use_prefix = len(folder_summaries) > 1
                     for entry in selected_entries:
-                        nested_label = str(entry.get("level1_subfolder") or "").strip()
-                        if filename_format_spec and nested_label:
-                            logical_name = nested_label
-                        else:
-                            logical_name = _prefixed_file_name(
-                                entry["name"],
-                                entry.get("folder_name"),
-                                apply_prefix=use_prefix,
-                            )
+                        logical_name = _prefixed_file_name(
+                            entry["name"],
+                            entry.get("folder_name"),
+                            apply_prefix=use_prefix,
+                        )
                         empirical_upload_paths.append({
                             "name": logical_name,
                             "ext": entry["extension"],
@@ -13462,6 +13592,12 @@ def start_computation_redirect(computation_type):
                 cfg_started = time.perf_counter()
                 parse_cfg = _build_parse_config_from_form(request.form)
                 filename_format_spec = _parse_filename_format_spec(request.form.get("parser_filename_format"))
+                app.logger.warning(
+                    "[compute %s] empirical filename_format raw=%r parsed=%s",
+                    job_id,
+                    (request.form.get("parser_filename_format") or ""),
+                    "yes" if filename_format_spec else "no",
+                )
                 _validate_parse_cfg_filename_token_locators(parse_cfg, request.form)
                 app.logger.warning(
                     "[compute %s] parser config built in %.1f ms",
@@ -13515,6 +13651,43 @@ def start_computation_redirect(computation_type):
                         selected_data_entries = _filtered
                     if selected_data_entries:
                         selected_entries = selected_data_entries
+                    if not filename_format_spec:
+                        nested_selected_exts = {
+                            str(context.get("selected_data_extension") or "").strip().lower()
+                            for context in folder_contexts
+                            if str(context.get("folder_path") or "").strip() in selected_path_set
+                            and bool(context.get("has_nested_subfolders"))
+                            and str(context.get("selected_data_extension") or "").strip()
+                        }
+                        if nested_selected_exts:
+                            expanded_auto_entries = _expand_entries_for_selected_extensions_scope(
+                                source_entries,
+                                selected_path_set,
+                                nested_selected_exts,
+                                empirical_subfolder_filter_map,
+                            )
+                            if expanded_auto_entries:
+                                selected_entries = expanded_auto_entries
+                    app.logger.warning(
+                        "[compute %s] empirical entries baseline selected=%d source_total=%d",
+                        job_id,
+                        len(selected_entries),
+                        len(source_entries),
+                    )
+                    if filename_format_spec:
+                        expanded_entries = _expand_entries_for_filename_format_scope(
+                            source_entries,
+                            selected_path_set,
+                            folder_contexts,
+                            empirical_subfolder_filter_map,
+                        )
+                        if expanded_entries:
+                            selected_entries = expanded_entries
+                        app.logger.warning(
+                            "[compute %s] empirical entries expanded=%d",
+                            job_id,
+                            len(selected_entries),
+                        )
                     if not selected_entries:
                         raise ValueError("No files available in the selected analysis folder(s).")
                     if filename_format_spec:
@@ -13540,15 +13713,11 @@ def start_computation_redirect(computation_type):
                             )
                     use_prefix = len(folder_summaries) > 1
                     for entry in selected_entries:
-                        nested_label = str(entry.get("level1_subfolder") or "").strip()
-                        if filename_format_spec and nested_label:
-                            logical_name = nested_label
-                        else:
-                            logical_name = _prefixed_file_name(
-                                entry["name"],
-                                entry.get("folder_name"),
-                                apply_prefix=use_prefix,
-                            )
+                        logical_name = _prefixed_file_name(
+                            entry["name"],
+                            entry.get("folder_name"),
+                            apply_prefix=use_prefix,
+                        )
                         empirical_upload_paths.append({
                             "name": logical_name,
                             "ext": entry["extension"],

--- a/webui/app.py
+++ b/webui/app.py
@@ -127,7 +127,7 @@ job_futures = {}
 # Set NCPI_MAX_OUTPUT_LINES <= 0 for unlimited output retention (default).
 MAX_OUTPUT_LINES = max(0, int(os.environ.get("NCPI_MAX_OUTPUT_LINES", "0")))
 FEATURES_PARSER_FILE_EXTENSIONS = {
-    ".mat", ".json", ".npy", ".csv", ".parquet", ".pkl", ".pickle", ".xlsx", ".xls", ".feather", ".set", ".tsv"
+    ".mat", ".json", ".npy", ".csv", ".parquet", ".pkl", ".pickle", ".xlsx", ".xls", ".feather", ".set", ".edf", ".tsv"
 }
 FEATURES_MAX_SUBFOLDER_DEPTH = 6
 FILE_EXTRACTED_VIRTUAL_FIELD = "__file_extracted_label__"
@@ -4708,6 +4708,49 @@ def _describe_parser_source(path):
         data_guess = defaults.get("data")
         resolved_data = _resolve_locator_value(source_obj, data_guess)
         sensor_count = _estimate_sensor_count(resolved_data) if resolved_data is not None else None
+        source_format = str(source_obj.get("__source_format__") or "").strip().lower()
+        if source_format == "edf":
+            fs_val = source_obj.get("fs")
+            try:
+                fs_float = float(fs_val) if fs_val is not None else None
+            except Exception:
+                fs_float = None
+            duration_val = source_obj.get("duration_s")
+            try:
+                duration_float = float(duration_val) if duration_val is not None else None
+            except Exception:
+                duration_float = None
+            ann_count = len(source_obj.get("annotations") or [])
+            n_channels = source_obj.get("n_channels")
+            if isinstance(n_channels, (int, float)):
+                try:
+                    n_channels = int(n_channels)
+                except Exception:
+                    n_channels = sensor_count
+            else:
+                n_channels = sensor_count
+            summary_parts = ["EDF recording"]
+            if isinstance(n_channels, int) and n_channels > 0:
+                summary_parts.append(f"{n_channels} channels")
+            if fs_float is not None and np.isfinite(fs_float) and fs_float > 0:
+                summary_parts.append(f"{fs_float:g} Hz")
+            if duration_float is not None and np.isfinite(duration_float) and duration_float > 0:
+                summary_parts.append(f"{duration_float:.3f}s")
+            summary_parts.append(f"{ann_count} annotation(s)")
+            payload = {
+                "source_type": "edf",
+                "candidate_fields": candidate_fields,
+                "top_keys": top_keys,
+                "defaults": defaults,
+                "summary": " · ".join(summary_parts) + ".",
+                "sensor_count_estimate": n_channels if isinstance(n_channels, int) else sensor_count,
+                "multi_sensor_detected": bool((n_channels if isinstance(n_channels, int) else sensor_count) and (n_channels if isinstance(n_channels, int) else sensor_count) > 1),
+                "fs_hint_hz": fs_float,
+                "fs_hint_note": f"Sampling rate from EDF header: {fs_float:g} Hz." if fs_float else None,
+            }
+            payload["field_details"] = _describe_source_fields_for_ui(source_obj, candidate_fields, "field")
+            payload["manual_field_details"] = _manual_field_details_for_ui()
+            return payload
         payload = {
             "source_type": "mapping",
             "candidate_fields": candidate_fields,

--- a/webui/compute_utils.py
+++ b/webui/compute_utils.py
@@ -754,7 +754,29 @@ def _load_uploaded_source_bytes(name, ext, content):
     if ext == ".mat":
         return _load_mat_with_fallback(raw, in_memory=True, source_name=safe_name)
 
+    if ext == ".edf":
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(prefix="ncpi_edf_", suffix=".edf", delete=False) as handle:
+                handle.write(raw)
+                temp_path = handle.name
+            return _load_uploaded_source_path(temp_path, name=safe_name, ext=".edf")
+        finally:
+            if temp_path and os.path.isfile(temp_path):
+                try:
+                    os.remove(temp_path)
+                except OSError:
+                    pass
+
     raise ValueError(f"Unsupported empirical file extension '{ext}' for '{safe_name}'.")
+
+
+def _load_edf_with_parser(path):
+    from ncpi.EphysDatasetParser import EphysDatasetParser, ParseConfig
+
+    parser = EphysDatasetParser(ParseConfig())
+    source_obj, _ = parser._load_source(path)
+    return source_obj
 
 
 def _load_uploaded_source_path(path, name=None, ext=None):
@@ -804,6 +826,12 @@ def _load_uploaded_source_path(path, name=None, ext=None):
         except Exception as exc:
             raise ValueError(f"mne is required to parse .set files: {exc}")
         return mne.io.read_raw_eeglab(safe_path, preload=True)
+
+    if ext == ".edf":
+        try:
+            return _load_edf_with_parser(safe_path)
+        except ImportError as exc:
+            raise ValueError(f"pyEDFlib is required to parse .edf files: {exc}")
 
     raise ValueError(f"Unsupported empirical file extension '{ext}' for '{safe_name}'.")
 

--- a/webui/compute_utils.py
+++ b/webui/compute_utils.py
@@ -768,6 +768,20 @@ def _load_uploaded_source_bytes(name, ext, content):
                 except OSError:
                     pass
 
+    if ext == ".fif":
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(prefix="ncpi_fif_", suffix=".fif", delete=False) as handle:
+                handle.write(raw)
+                temp_path = handle.name
+            return _load_uploaded_source_path(temp_path, name=safe_name, ext=".fif")
+        finally:
+            if temp_path and os.path.isfile(temp_path):
+                try:
+                    os.remove(temp_path)
+                except OSError:
+                    pass
+
     raise ValueError(f"Unsupported empirical file extension '{ext}' for '{safe_name}'.")
 
 
@@ -783,6 +797,8 @@ def _load_uploaded_source_path(path, name=None, ext=None):
     safe_path = str(path or "")
     if not safe_path or not os.path.exists(safe_path):
         raise ValueError(f"Uploaded file path does not exist: '{safe_path}'.")
+    if not os.path.isfile(safe_path):
+        raise ValueError(f"Uploaded path is not a regular file: '{safe_path}'.")
     safe_name = str(name or os.path.basename(safe_path) or "uploaded_file")
     ext = str(ext or os.path.splitext(safe_name)[1]).lower()
 
@@ -826,6 +842,13 @@ def _load_uploaded_source_path(path, name=None, ext=None):
         except Exception as exc:
             raise ValueError(f"mne is required to parse .set files: {exc}")
         return mne.io.read_raw_eeglab(safe_path, preload=True)
+
+    if ext == ".fif":
+        try:
+            import mne
+        except Exception as exc:
+            raise ValueError(f"mne is required to parse .fif files: {exc}")
+        return mne.io.read_raw_fif(safe_path, preload=True, verbose=False)
 
     if ext == ".edf":
         try:

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -32,7 +32,7 @@
             }
         }
         const supportedParserFileExtensions = new Set([
-            '.mat', '.json', '.npy', '.csv', '.parquet', '.pkl', '.pickle', '.xlsx', '.xls', '.feather', '.set', '.tsv'
+            '.mat', '.json', '.npy', '.csv', '.parquet', '.pkl', '.pickle', '.xlsx', '.xls', '.feather', '.set', '.edf', '.tsv'
         ]);
         return {
             activeTab: initialActiveTab,

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -32,7 +32,7 @@
             }
         }
         const supportedParserFileExtensions = new Set([
-            '.mat', '.json', '.npy', '.csv', '.parquet', '.pkl', '.pickle', '.xlsx', '.xls', '.feather', '.set', '.edf', '.tsv'
+            '.mat', '.json', '.npy', '.csv', '.parquet', '.pkl', '.pickle', '.xlsx', '.xls', '.feather', '.set', '.fif', '.edf', '.tsv'
         ]);
         return {
             activeTab: initialActiveTab,
@@ -1113,6 +1113,13 @@
                 const token = String(tokenName || '').trim().toLowerCase();
                 if (!token) return '';
                 return `__file_token_${token}__`;
+            },
+            parserFilenameFormatHasExplicitExtension() {
+                const formatValue = String(this.parserFilenameFormat || '').trim();
+                if (!formatValue) return false;
+                // Consider extension explicitly specified only when literal suffix
+                // ends with ".ext" (e.g. ".fif", ".mat", ".edf").
+                return /\.[a-z0-9]+$/i.test(formatValue);
             },
             insertFilenameFormatToken(token) {
                 const clean = String(token || '').trim();
@@ -2308,6 +2315,8 @@
 
                 try {
                     const formData = new FormData(form);
+                    const filenameFormatValue = String(this.parserFilenameFormat || '').trim();
+                    formData.set('parser_filename_format', filenameFormatValue);
                     // Append additional files so the backend can use them for metadata lookup
                     for (const f of this.additionalLocalFiles || []) {
                         formData.append('additional_metadata_file', f);
@@ -2952,6 +2961,7 @@
                     <input type="hidden" name="simulation_data_file_selections" :value="JSON.stringify(simulationDataFileSelections || {})">
                     <input type="hidden" name="parser_analysis_folder_paths" :value="JSON.stringify(parserAnalysisFolderPaths || [])">
                     <input type="hidden" name="parser_analysis_folder_names" :value="JSON.stringify(parserAnalysisFolderNames || [])">
+                    <input type="hidden" name="parser_filename_format" :value="String(parserFilenameFormat || '').trim()">
                 
 
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -3201,7 +3211,6 @@
                             <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Filename format (optional)</span>
                             <input
                                 type="text"
-                                name="parser_filename_format"
                                 x-model="parserFilenameFormat"
                                 placeholder="$id$_comp_reject.mat"
                                 @keydown.enter.prevent="applyFilenameFormatAndReinspect()"
@@ -3237,7 +3246,6 @@
                                 <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Filename format (optional)</span>
                                 <input
                                     type="text"
-                                    name="parser_filename_format"
                                     x-model="parserFilenameFormat"
                                     placeholder="$id$-$group$_$condition$.pkl"
                                     @keydown.enter.prevent="applyFilenameFormatAndReinspect()"
@@ -3245,7 +3253,7 @@
                                 >
                             </label>
                             <p class="text-[11px] text-gray-500 dark:text-gray-400">
-                                Use literal text + tokens between <code>$...$</code>. In nested datasets, this is applied to first-level folder names; otherwise it is applied to file names.
+                                Use literal text + tokens between <code>$...$</code>. The format is always matched against file names (including extension), also for nested datasets.
                             </p>
                             <div class="flex flex-wrap gap-2">
                                 <template x-for="token in parserFilenameFormatTokens()" :key="'filename-format-token-'+token">
@@ -3323,7 +3331,7 @@
                                         <div class="text-xs text-gray-500 dark:text-gray-400"><span x-text="folderProfile.file_count || 0"></span> file(s)</div>
                                     </div>
 
-                                    <div x-show="parserFolderDataFileCandidates(folderProfile).length > 0" class="space-y-2 rounded-lg border border-red-200/70 dark:border-red-900/40 bg-red-50/40 dark:bg-red-950/20 p-3">
+                                    <div x-show="parserFolderDataFileCandidates(folderProfile).length > 0 && !parserFilenameFormatHasExplicitExtension()" class="space-y-2 rounded-lg border border-red-200/70 dark:border-red-900/40 bg-red-50/40 dark:bg-red-950/20 p-3">
                                         <h4 class="text-xs font-semibold text-red-800 dark:text-red-300 uppercase tracking-wide">Data source selection</h4>
                                         <p class="text-[11px] text-red-800/90 dark:text-red-200/90" x-show="folderProfile.has_nested_subfolders">
                                             Sample subfolder:
@@ -3351,14 +3359,17 @@
                                         </p>
                                     </div>
 
+                                    <div x-show="(folderProfile.structure_warnings || []).length > 0"
+                                         class="space-y-1 rounded-lg border border-amber-200/70 dark:border-amber-800/40 bg-amber-50/40 dark:bg-amber-950/20 p-3">
+                                        <h4 class="text-xs font-semibold text-amber-800 dark:text-amber-300 uppercase tracking-wide">Data source warnings</h4>
+                                        <template x-for="(warn, wi) in folderProfile.structure_warnings || []" :key="'fsw-'+wi">
+                                            <p class="text-[11px] text-amber-800 dark:text-amber-300" x-text="warn"></p>
+                                        </template>
+                                    </div>
+
                                     <!-- Subfolder inclusion filter -->
                                     <div x-show="folderProfile.has_nested_subfolders && parserFolderAllSubfolders(folderProfile).length > 0"
                                          class="space-y-2 rounded-lg border border-amber-200/70 dark:border-amber-800/40 bg-amber-50/40 dark:bg-amber-950/20 p-3">
-                                        <div x-show="(folderProfile.structure_warnings || []).length > 0" class="space-y-1">
-                                            <template x-for="(warn, wi) in folderProfile.structure_warnings || []" :key="'sw-'+wi">
-                                                <p class="text-[11px] text-amber-800 dark:text-amber-300" x-text="warn"></p>
-                                            </template>
-                                        </div>
                                         <div class="flex items-center justify-between gap-2">
                                             <h4 class="text-xs font-semibold text-amber-800 dark:text-amber-300 uppercase tracking-wide">Subfolder filter</h4>
                                             <span class="text-[11px] text-amber-700 dark:text-amber-400"


### PR DESCRIPTION
## PR Title
Features parser: prioritize filename format, improve token matching, and fix nested auto-selection for BIDS-style datasets

## Summary
This PR improves the **Features → New data** parsing flow for token-based filename matching and nested dataset handling.

It addresses four recent changes:
1. **Filename format now has priority over Data Source Selection** when filtering files.
2. **Data Source Selection is hidden** when `Filename format` includes an explicit extension (e.g. `.fif`, `.mat`).
3. **Filename format without extension now matches by stem** (so patterns like `$subject_id$_$species$_$condition$_meg` can match `..._meg.fif`).
4. **Automatic mode (no filename format) now uses all matching data files in nested structures** (e.g. BIDS), instead of collapsing to one file per top-level branch.

## Problem Solved
Previously, users could get inconsistent behavior:
- manual token format could detect all expected files, while automatic mode only used a subset;
- format-based filtering still depended on selected extension in some paths;
- format strings without extension failed to match valid files;
- UI exposed redundant extension selection even when format already defined it.

## Changes Included

### Backend (`webui/app.py`)
- Updated filename-format filtering to run against full discovered entries when format is provided.
- Removed extension-gating during filename-format expansion.
- Standardized errors to `No files match filename format ...`.
- Added `has_explicit_extension` in parsed format spec.
- Updated token extraction to try:
  - full basename, and
  - basename stem (when no explicit extension is provided).
- Added `_expand_entries_for_selected_extensions_scope(...)` and used it in compute (`new-simulation` / `new-empirical`) for nested automatic selection.

### Frontend (`webui/templates/3.1.features_methods.html`)
- Added `parserFilenameFormatHasExplicitExtension()`.
- `Data Source Selection` panel now only appears when filename format does **not** include an explicit extension.

## Expected Behavior After This PR
- If user defines `Filename format`, that filter drives file selection first.
- If format includes extension, extension picker is hidden.
- If format omits extension, matching still works (via stem).
- In nested datasets (BIDS-like), automatic mode can process all relevant files of selected data extension (e.g. all session `.fif` files), not just first-session equivalents.

