### PR TITLE
fix(features): restore parser_deep_scan_status in compute form submission after merge conflict

### DIFF
--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -2399,6 +2399,8 @@
 
                 try {
                     const formData = new FormData(form);
+                    const deepScanStatusValue = String(this.parserDeepScanStatus || '').trim();
+                    formData.set('parser_deep_scan_status', deepScanStatusValue);
                     const filenameFormatValue = String(this.parserFilenameFormat || '').trim();
                     formData.set('parser_filename_format', filenameFormatValue);
                     // Append additional files so the backend can use them for metadata lookup
@@ -3045,6 +3047,7 @@
                     <input type="hidden" name="simulation_data_file_selections" :value="JSON.stringify(simulationDataFileSelections || {})">
                     <input type="hidden" name="parser_analysis_folder_paths" :value="JSON.stringify(parserAnalysisFolderPaths || [])">
                     <input type="hidden" name="parser_analysis_folder_names" :value="JSON.stringify(parserAnalysisFolderNames || [])">
+                    <input type="hidden" name="parser_deep_scan_status" :value="parserDeepScanStatus">
                     <input type="hidden" name="parser_filename_format" :value="String(parserFilenameFormat || '').trim()">
                 
 


### PR DESCRIPTION
This PR fixes a regression in **Features → Compute new features** introduced during conflict resolution in `3.1.features_methods.html`.

After the previous merge, the form kept `parser_filename_format` but dropped `parser_deep_scan_status`.  
Because backend validation requires `parser_deep_scan_status` for folder-based flows, feature computation was blocked even for datasets that previously worked.

## Root Cause
A conflict in the compute form hidden inputs was resolved as either/or instead of keeping both:

- `parser_filename_format`
- `parser_deep_scan_status`

As a result, the backend interpreted the folder inspection as incomplete and rejected computation.

## Changes
- Restored hidden input:
  - `parser_deep_scan_status`
- Added defensive submit-time assignment in JS:
  - `formData.set('parser_deep_scan_status', ...)`
- Kept existing:
  - `formData.set('parser_filename_format', ...)`

## Files Updated
- `webui/templates/3.1.features_methods.html`

## Impact
- Restores feature computation for folder-based datasets.
- Prevents the same issue from reappearing if hidden inputs change again in template merges.

## Validation
- Manually verified request payload now includes both:
  - `parser_deep_scan_status`
  - `parser_filename_format`
- Folder-based Features compute proceeds normally again.