### PR TITLE
Added support to read CTF data

### DIFF
--- a/ncpi/EphysDatasetParser.py
+++ b/ncpi/EphysDatasetParser.py
@@ -494,7 +494,7 @@ class EphysDatasetParser:
       - numpy arrays (ndarray)
       - dict-like (including scipy.io.loadmat output, json-loaded dict)
       - pandas DataFrame (wide/long), and file paths to csv/parquet if pandas installed
-      - .npy, .json, .mat, .set, .fif, .edf, .tsv paths
+      - .npy, .json, .mat, .set, .fif, .edf, .ds, .tsv paths
 
     Output:
       - pandas DataFrame with DEFAULT_COLUMNS
@@ -604,6 +604,17 @@ class EphysDatasetParser:
                         "Verify the dataset path and that the file is available on disk."
                     )
                 return _load_edf_with_pyedflib(path), source_file
+
+            if suffix == ".ds":
+                if not path.is_dir():
+                    raise ValueError(
+                        f"CTF dataset does not exist or is not a directory: '{path}'. "
+                        "CTF recordings must be provided as the .ds folder."
+                    )
+                _require_mne("CTF .ds loading")
+                import mne  # type: ignore
+
+                return mne.io.read_raw_ctf(str(path), preload=self.config.preload, verbose=False), source_file
 
             if suffix in (".csv", ".parquet", ".tsv"):
                 if not tools.ensure_module("pandas"):

--- a/webui/app.py
+++ b/webui/app.py
@@ -128,9 +128,23 @@ job_futures = {}
 # Set NCPI_MAX_OUTPUT_LINES <= 0 for unlimited output retention (default).
 MAX_OUTPUT_LINES = max(0, int(os.environ.get("NCPI_MAX_OUTPUT_LINES", "0")))
 FEATURES_PARSER_FILE_EXTENSIONS = {
-    ".mat", ".json", ".npy", ".csv", ".parquet", ".pkl", ".pickle", ".xlsx", ".xls", ".feather", ".set", ".fif", ".edf", ".tsv"
+    ".mat", ".json", ".npy", ".csv", ".parquet", ".pkl", ".pickle", ".xlsx", ".xls", ".feather", ".set", ".fif", ".edf", ".ds", ".tsv"
 }
 FEATURES_MAX_SUBFOLDER_DEPTH = 6
+
+
+def _is_supported_ctf_dataset_path(path):
+    return os.path.isdir(path) and Path(str(path)).suffix.lower() == ".ds"
+
+
+def _is_supported_parser_regular_file(path):
+    return os.path.isfile(path) and Path(str(path)).suffix.lower() in FEATURES_PARSER_FILE_EXTENSIONS
+
+
+def _is_supported_parser_path(path):
+    return _is_supported_ctf_dataset_path(path) or _is_supported_parser_regular_file(path)
+
+
 FILE_EXTRACTED_VIRTUAL_FIELD = "__file_extracted_label__"
 FILE_EXTRACTED_VIRTUAL_FIELD_PREFIX = "__file_extracted_chain_"
 FILE_TOKEN_VIRTUAL_FIELD_PREFIX = "__file_token_"
@@ -2496,7 +2510,13 @@ def _collect_empirical_folder_files(folder_path):
         raise ValueError(f"Empirical folder does not exist: {root}")
 
     matches = []
-    for current_root, _, files in os.walk(root):
+    if _is_supported_ctf_dataset_path(root):
+        return [root]
+    for current_root, dirs, files in os.walk(root):
+        ctf_dirs = [name for name in dirs if Path(name).suffix.lower() == ".ds"]
+        dirs[:] = [name for name in dirs if Path(name).suffix.lower() != ".ds"]
+        for name in ctf_dirs:
+            matches.append(os.path.join(current_root, name))
         for name in files:
             ext = Path(name).suffix.lower()
             if ext in FEATURES_PARSER_FILE_EXTENSIONS:
@@ -2515,7 +2535,13 @@ def _collect_simulation_folder_files(folder_path):
         raise ValueError(f"Simulation outputs folder does not exist: {root}")
 
     matches = []
-    for current_root, _, files in os.walk(root):
+    if _is_supported_ctf_dataset_path(root):
+        return [root]
+    for current_root, dirs, files in os.walk(root):
+        ctf_dirs = [name for name in dirs if Path(name).suffix.lower() == ".ds"]
+        dirs[:] = [name for name in dirs if Path(name).suffix.lower() != ".ds"]
+        for name in ctf_dirs:
+            matches.append(os.path.join(current_root, name))
         for name in files:
             ext = Path(name).suffix.lower()
             if ext in FEATURES_PARSER_FILE_EXTENSIONS:
@@ -2787,66 +2813,79 @@ def _collect_supported_folder_file_entries(folder_paths, kind_label, data_file_s
         branch_directories = defaultdict(set)
         branch_dir_ext_files = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
 
-        for current_root, _, files in os.walk(root):
-            rel_dir = os.path.relpath(current_root, root)
-            rel_dir_posix = _to_posix_relpath(rel_dir)
-            if rel_dir_posix == ".":
-                dir_depth = 0
-            else:
-                dir_depth = len([token for token in rel_dir_posix.split("/") if token])
-            if dir_depth > FEATURES_MAX_SUBFOLDER_DEPTH:
+        def _append_folder_entry(full_path, name, ext):
+            rel_path = _to_posix_relpath(os.path.relpath(full_path, root))
+            rel_parts = [token for token in rel_path.split("/") if token]
+            file_depth = max(0, len(rel_parts) - 1)
+            if file_depth > FEATURES_MAX_SUBFOLDER_DEPTH:
                 raise ValueError(
-                    f"{kind_label} folder '{folder_name}' exceeds the maximum supported nested depth "
-                    f"({FEATURES_MAX_SUBFOLDER_DEPTH}) at '{current_root}'."
+                    f"{kind_label} folder '{folder_name}' contains a data source deeper than the supported "
+                    f"{FEATURES_MAX_SUBFOLDER_DEPTH} nested levels: '{full_path}'."
                 )
-            if rel_dir_posix != ".":
-                parts = [token for token in rel_dir_posix.split("/") if token]
-                branch_name = parts[0]
-                branch_rel_dir = "/".join(parts[1:]) if len(parts) > 1 else "."
-                branch_directories[branch_name].add(branch_rel_dir or ".")
+            row = {
+                "path": full_path,
+                "name": str(name),
+                "extension": ext,
+                "folder_path": root,
+                "folder_name": folder_name,
+                "relative_path": rel_path,
+            }
+            if len(rel_parts) >= 2:
+                level1_subfolder = rel_parts[0]
+                subfolder_relative_path = "/".join(rel_parts[1:])
+                subfolder_relative_dir = _to_posix_relpath(os.path.dirname(subfolder_relative_path))
+                row["level1_subfolder"] = level1_subfolder
+                row["subfolder_relative_path"] = subfolder_relative_path
+                row["subfolder_relative_dir"] = subfolder_relative_dir
+                branch_directories[level1_subfolder].add(subfolder_relative_dir or ".")
+                branch_dir_ext_files[level1_subfolder][subfolder_relative_dir][ext].append(row)
+            else:
+                row["level1_subfolder"] = ""
+                row["subfolder_relative_path"] = rel_parts[0] if rel_parts else row["name"]
+                row["subfolder_relative_dir"] = "."
+            folder_entries.append(row)
+            extension_counts[ext] += 1
+            return row
 
-            for name in files:
-                ext = Path(name).suffix.lower()
-                if ext not in FEATURES_PARSER_FILE_EXTENSIONS:
-                    continue
-                full_path = os.path.join(current_root, name)
-                if not os.path.isfile(full_path):
-                    skipped_unreadable_paths[root].append(full_path)
-                    skipped_unreadable_by_ext[root][ext or "(no extension)"] += 1
-                    if os.path.islink(full_path):
-                        skipped_broken_symlink_paths[root].append(full_path)
-                    continue
-                rel_path = _to_posix_relpath(os.path.relpath(full_path, root))
-                rel_parts = [token for token in rel_path.split("/") if token]
-                file_depth = max(0, len(rel_parts) - 1)
-                if file_depth > FEATURES_MAX_SUBFOLDER_DEPTH:
-                    raise ValueError(
-                        f"{kind_label} folder '{folder_name}' contains a file deeper than the supported "
-                        f"{FEATURES_MAX_SUBFOLDER_DEPTH} nested levels: '{full_path}'."
-                    )
-                row = {
-                    "path": full_path,
-                    "name": str(name),
-                    "extension": ext,
-                    "folder_path": root,
-                    "folder_name": folder_name,
-                    "relative_path": rel_path,
-                }
-                if len(rel_parts) >= 2:
-                    level1_subfolder = rel_parts[0]
-                    subfolder_relative_path = "/".join(rel_parts[1:])
-                    subfolder_relative_dir = _to_posix_relpath(os.path.dirname(subfolder_relative_path))
-                    row["level1_subfolder"] = level1_subfolder
-                    row["subfolder_relative_path"] = subfolder_relative_path
-                    row["subfolder_relative_dir"] = subfolder_relative_dir
-                    branch_directories[level1_subfolder].add(subfolder_relative_dir or ".")
-                    branch_dir_ext_files[level1_subfolder][subfolder_relative_dir][ext].append(row)
+        if _is_supported_ctf_dataset_path(root):
+            _append_folder_entry(root, os.path.basename(root), ".ds")
+        else:
+            for current_root, dirnames, files in os.walk(root):
+                ctf_dirnames = [name for name in dirnames if Path(name).suffix.lower() == ".ds"]
+                dirnames[:] = [name for name in dirnames if Path(name).suffix.lower() != ".ds"]
+                rel_dir = os.path.relpath(current_root, root)
+                rel_dir_posix = _to_posix_relpath(rel_dir)
+                if rel_dir_posix == ".":
+                    dir_depth = 0
                 else:
-                    row["level1_subfolder"] = ""
-                    row["subfolder_relative_path"] = rel_parts[0] if rel_parts else row["name"]
-                    row["subfolder_relative_dir"] = "."
-                folder_entries.append(row)
-                extension_counts[ext] += 1
+                    dir_depth = len([token for token in rel_dir_posix.split("/") if token])
+                if dir_depth > FEATURES_MAX_SUBFOLDER_DEPTH:
+                    raise ValueError(
+                        f"{kind_label} folder '{folder_name}' exceeds the maximum supported nested depth "
+                        f"({FEATURES_MAX_SUBFOLDER_DEPTH}) at '{current_root}'."
+                    )
+                if rel_dir_posix != ".":
+                    parts = [token for token in rel_dir_posix.split("/") if token]
+                    branch_name = parts[0]
+                    branch_rel_dir = "/".join(parts[1:]) if len(parts) > 1 else "."
+                    branch_directories[branch_name].add(branch_rel_dir or ".")
+                for name in ctf_dirnames:
+                    full_path = os.path.join(current_root, name)
+                    if os.path.isdir(full_path):
+                        _append_folder_entry(full_path, name, ".ds")
+
+                for name in files:
+                    ext = Path(name).suffix.lower()
+                    if ext not in FEATURES_PARSER_FILE_EXTENSIONS:
+                        continue
+                    full_path = os.path.join(current_root, name)
+                    if not os.path.isfile(full_path):
+                        skipped_unreadable_paths[root].append(full_path)
+                        skipped_unreadable_by_ext[root][ext or "(no extension)"] += 1
+                        if os.path.islink(full_path):
+                            skipped_broken_symlink_paths[root].append(full_path)
+                        continue
+                    _append_folder_entry(full_path, name, ext)
 
         folder_entries.sort(key=lambda item: item["path"])
 
@@ -3036,6 +3075,20 @@ def _collect_supported_folder_file_entries(folder_paths, kind_label, data_file_s
                     and str(item.get("subfolder_relative_dir") or ".") == selected_dir
                     and str(item.get("extension") or "").lower() == selected_data_extension.lower()
                 ]
+                if not branch_rows and selected_data_extension.lower() == ".ds":
+                    branch_ds_rows = [
+                        item for item in folder_entries
+                        if str(item.get("level1_subfolder") or "") == branch
+                        and str(item.get("extension") or "").lower() == ".ds"
+                    ]
+                    if len(branch_ds_rows) == 1:
+                        branch_rows = branch_ds_rows
+                    elif len(branch_ds_rows) > 1:
+                        structure_warnings.append(
+                            f"Subfolder '{branch}' contains multiple '.ds' datasets and none matched "
+                            f"the reference directory '{selected_dir}' — skipped."
+                        )
+                        continue
                 if not branch_rows:
                     structure_warnings.append(
                         f"Subfolder '{branch}' has no data file at '{selected_dir}' with extension "
@@ -3216,7 +3269,7 @@ def _validate_simulation_file_path(file_path):
     candidate = os.path.realpath((file_path or "").strip())
     if not candidate:
         raise ValueError("Provide a simulation output file path.")
-    if not os.path.isfile(candidate):
+    if not _is_supported_parser_path(candidate):
         raise ValueError(f"Simulation output file does not exist: {candidate}")
     ext = Path(candidate).suffix.lower()
     if ext not in FEATURES_PARSER_FILE_EXTENSIONS:
@@ -8584,7 +8637,7 @@ def features_select_folder():
             if not picked or picked in seen:
                 continue
             seen.add(picked)
-            if not os.path.isfile(picked):
+            if not os.path.isfile(picked) and not _is_supported_ctf_dataset_path(picked):
                 return None, jsonify({"error": f"Selected path is not a file: {picked}"}), 400
             ext = Path(picked).suffix.lower()
             if allowed_exts:
@@ -9092,7 +9145,7 @@ def features_parser_inspect():
                 upload_entries.append({"path": temp_path, "name": upl_name, "folder_name": upl_name})
             for srv_path in metadata_server_paths:
                 real_path = os.path.realpath(srv_path)
-                if not os.path.isfile(real_path):
+                if not _is_supported_parser_path(real_path):
                     return jsonify({"error": f"Server file not found: {srv_path}"}), 400
                 srv_name = os.path.basename(real_path)
                 ext = Path(srv_name).suffix.lower()

--- a/webui/compute_utils.py
+++ b/webui/compute_utils.py
@@ -863,6 +863,12 @@ def _load_uploaded_source_bytes(name, ext, content):
                 except OSError:
                     pass
 
+    if ext == ".ds":
+        raise ValueError(
+            "CTF .ds datasets are directories and cannot be parsed from a single uploaded file. "
+            "Use Server upload/path selection and select the folder that contains the .ds dataset."
+        )
+
     raise ValueError(f"Unsupported empirical file extension '{ext}' for '{safe_name}'.")
 
 
@@ -878,10 +884,23 @@ def _load_uploaded_source_path(path, name=None, ext=None):
     safe_path = str(path or "")
     if not safe_path or not os.path.exists(safe_path):
         raise ValueError(f"Uploaded file path does not exist: '{safe_path}'.")
+    safe_name = str(name or os.path.basename(safe_path) or "uploaded_file")
+    ext = str(ext or os.path.splitext(safe_name)[1] or os.path.splitext(safe_path)[1]).lower()
+
+    if ext == ".ds":
+        if not os.path.isdir(safe_path):
+            raise ValueError(
+                f"CTF dataset path is not a .ds directory: '{safe_path}'. "
+                "Use server upload/path selection for CTF datasets."
+            )
+        try:
+            import mne
+        except Exception as exc:
+            raise ValueError(f"mne is required to parse .ds CTF datasets: {exc}")
+        return mne.io.read_raw_ctf(safe_path, preload=True, verbose=False)
+
     if not os.path.isfile(safe_path):
         raise ValueError(f"Uploaded path is not a regular file: '{safe_path}'.")
-    safe_name = str(name or os.path.basename(safe_path) or "uploaded_file")
-    ext = str(ext or os.path.splitext(safe_name)[1]).lower()
 
     if ext in {".pkl", ".pickle"}:
         try:

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -32,7 +32,7 @@
             }
         }
         const supportedParserFileExtensions = new Set([
-            '.mat', '.json', '.npy', '.csv', '.parquet', '.pkl', '.pickle', '.xlsx', '.xls', '.feather', '.set', '.fif', '.edf', '.tsv'
+            '.mat', '.json', '.npy', '.csv', '.parquet', '.pkl', '.pickle', '.xlsx', '.xls', '.feather', '.set', '.fif', '.edf', '.ds', '.tsv'
         ]);
         return {
             activeTab: initialActiveTab,


### PR DESCRIPTION
Fix .ds folder discovery across subject/session trees in Features pipeline

  ## Summary

  This PR fixes an issue where CTF .ds datasets were not fully included when computing features from nested folder structures (e.g., BIDS-like sub-*/ses-* trees).
  In some valid layouts, only one .ds dataset was selected and parsed, resulting in logs like Parsing 1 input file(s) even when multiple subjects/sessions were present.

  The selection logic now includes a .ds-specific fallback so each branch can contribute its dataset when structure matching is too strict for directory-based sources.

  ## Problem

  During Features computation from server folders, nested-folder selection relies on matching a reference file path/name pattern across first-level subfolders.
  For .ds (directory datasets), this could exclude valid branches if the expected relative location/name did not match exactly, even though each branch had a valid .ds dataset.

  ## Changes

  ### webui/app.py

  Updated _collect_supported_folder_file_entries in the branch-matching section:

  - Existing behavior:
      - Match entries by:
          - same first-level branch
          - same relative directory
          - same extension
      - If no match, branch was skipped.
  - New behavior for .ds only:
      - If no match is found in the reference directory and selected extension is .ds:
          - collect all .ds entries for that branch
          - if exactly one .ds exists, use it as fallback
          - if multiple .ds exist, mark branch as ambiguous and skip with warning

  This preserves strict matching for non-.ds file types and only relaxes matching for directory-based CTF datasets.

  ## Validation

  - Syntax check passed:
      - python -m py_compile webui/app.py
  - Expected runtime effect:
      - Multi-subject/session .ds folders now produce the correct input count (e.g., Parsing 2 input file(s) instead of Parsing 1 input file(s) when two valid branches exist).