### PR TITLE
Fixed automatic selection of dimensions in DMAP dataset

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -4186,6 +4186,52 @@ def _summarize_value_for_ui(value):
     return summary
 
 
+def _summarize_lazy_hdf5_key_for_ui(source_obj, key_name):
+    key = str(key_name or "").strip()
+    if not key:
+        return None
+
+    file_path = str(getattr(source_obj, "file_path", "") or "").strip()
+    group_path = str(getattr(source_obj, "group_path", "/") or "/").strip() or "/"
+    if not file_path:
+        return None
+
+    try:
+        import h5py  # type: ignore
+    except Exception:
+        return None
+
+    try:
+        with h5py.File(file_path, "r") as h5f:
+            if group_path not in h5f:
+                return None
+            group = h5f[group_path]
+            if key not in group:
+                return None
+            node = group[key]
+            if isinstance(node, h5py.Dataset):
+                shape = [int(dim) for dim in node.shape]
+                dtype = str(node.dtype)
+                return {
+                    "python_type": "HDF5 dataset",
+                    "dtype": dtype,
+                    "shape": shape,
+                    "detail": "Lazy-loaded MATLAB v7.3 dataset (metadata only).",
+                }
+            if isinstance(node, h5py.Group):
+                child_count = len(list(node.keys()))
+                return {
+                    "python_type": "HDF5 group",
+                    "dtype": "",
+                    "shape": [int(child_count)],
+                    "detail": f"Lazy-loaded MATLAB v7.3 group with {child_count} key(s).",
+                }
+    except Exception:
+        return None
+
+    return None
+
+
 def _describe_source_fields_for_ui(source_obj, candidate_fields, source_type):
     details = []
     lazy_mapping = bool(getattr(source_obj, "__lazy_hdf5__", False))
@@ -4195,6 +4241,17 @@ def _describe_source_fields_for_ui(source_obj, candidate_fields, source_type):
             continue
         origin = "dataframe" if source_type == "dataframe" else "field"
         if lazy_mapping and "." not in locator and "[" not in locator and locator != "__self__":
+            lazy_summary = _summarize_lazy_hdf5_key_for_ui(source_obj, locator)
+            if lazy_summary is not None:
+                details.append({
+                    "field": locator,
+                    "origin": origin,
+                    "python_type": lazy_summary.get("python_type") or "HDF5 key",
+                    "dtype": lazy_summary.get("dtype") or "",
+                    "shape": lazy_summary.get("shape"),
+                    "detail": lazy_summary.get("detail") or "Lazy-loaded MATLAB v7.3 key.",
+                })
+                continue
             details.append({
                 "field": locator,
                 "origin": origin,
@@ -5052,7 +5109,7 @@ def _safe_channel_name_count(value):
     return None
 
 
-def _infer_axis_defaults_from_values(data_value, ch_names_value=None):
+def _infer_axis_defaults_from_values(data_value, ch_names_value=None, ids_value=None):
     shape = _safe_array_shape(data_value)
     if not shape:
         return {
@@ -5083,10 +5140,22 @@ def _infer_axis_defaults_from_values(data_value, ch_names_value=None):
         if channel_matches:
             axis_channels = min(channel_matches)
 
-    remaining = [idx for idx in range(ndim) if idx not in {axis_samples, axis_channels}]
+    axis_ids = -1
+    ids_count = _safe_channel_name_count(ids_value)
+    if ids_count is not None and ids_count > 0:
+        id_matches = [
+            idx for idx, dim in enumerate(shape)
+            if dim == ids_count and idx not in {axis_samples, axis_channels}
+        ]
+        if id_matches:
+            axis_ids = min(id_matches)
+
+    remaining = [idx for idx in range(ndim) if idx not in {axis_samples, axis_channels, axis_ids}]
     remaining.sort()
-    axis_ids = remaining[0] if len(remaining) >= 1 else -1
-    axis_epochs = remaining[1] if len(remaining) >= 2 else -1
+    axis_epochs = remaining[0] if len(remaining) >= 1 else -1
+    if axis_ids < 0 and len(remaining) >= 2:
+        axis_ids = remaining[0]
+        axis_epochs = remaining[1]
 
     return {
         "axis_samples": int(axis_samples),
@@ -5474,7 +5543,10 @@ def _describe_parser_source(path):
                 ["ch_names", "channels", "channel_names", "channel", "labels", "sensors", "sensor", "ch"],
             ),
             "recording_type": _pick_field_guess(candidates, ["recording_type", "modality", "recording", "type"]),
-            "subject_id": _pick_field_guess(candidates, ["subject_id", "subject", "subj", "participant"]),
+            "subject_id": _pick_field_guess(
+                candidates,
+                ["subject_id", "sub_ids", "subid", "subject", "subj", "participant", "id", "ids"],
+            ),
             "group": _pick_field_guess(candidates, ["group", "cohort", "class"]),
             "species": _pick_field_guess(candidates, ["species", "animal", "organism"]),
             "condition": _pick_field_guess(candidates, ["condition", "state", "task"]),
@@ -5496,7 +5568,14 @@ def _describe_parser_source(path):
                 ch_for_axes = _extract_dataframe_channel_names(source_obj, defaults.get("ch_names"))
         except Exception:
             ch_for_axes = None
-        defaults.update(_infer_axis_defaults_from_values(data_for_axes, ch_for_axes))
+        ids_for_axes = None
+        try:
+            subj_col = str(defaults.get("subject_id") or "").strip()
+            if subj_col and subj_col in source_obj.columns:
+                ids_for_axes = [str(v) for v in source_obj[subj_col].dropna().tolist()]
+        except Exception:
+            ids_for_axes = None
+        defaults.update(_infer_axis_defaults_from_values(data_for_axes, ch_for_axes, ids_for_axes))
         if fs_hint_hz is None and defaults["fs"] and defaults["fs"] in source_obj.columns:
             fs_series = pd.to_numeric(source_obj[defaults["fs"]], errors="coerce").dropna()
             if not fs_series.empty:
@@ -5650,7 +5729,11 @@ def _describe_parser_source(path):
         resolved_data = _resolve_locator_value(source_obj, data_guess)
         ch_guess = defaults.get("ch_names")
         resolved_ch_names = _resolve_locator_value(source_obj, ch_guess) if ch_guess else None
-        defaults.update(_infer_axis_defaults_from_values(resolved_data, resolved_ch_names))
+        resolved_ids = None
+        subject_guess = str(defaults.get("subject_id") or "").strip()
+        if subject_guess:
+            resolved_ids = _resolve_locator_value(source_obj, subject_guess)
+        defaults.update(_infer_axis_defaults_from_values(resolved_data, resolved_ch_names, resolved_ids))
         sensor_count = _estimate_sensor_count(resolved_data) if resolved_data is not None else None
         source_format = str(source_obj.get("__source_format__") or "").strip().lower()
         if source_format == "edf":
@@ -5714,7 +5797,11 @@ def _describe_parser_source(path):
     resolved_data = _resolve_locator_value(source_obj, data_guess)
     ch_guess = defaults.get("ch_names")
     resolved_ch_names = _resolve_locator_value(source_obj, ch_guess) if ch_guess else None
-    defaults.update(_infer_axis_defaults_from_values(resolved_data, resolved_ch_names))
+    resolved_ids = None
+    subject_guess = str(defaults.get("subject_id") or "").strip()
+    if subject_guess:
+        resolved_ids = _resolve_locator_value(source_obj, subject_guess)
+    defaults.update(_infer_axis_defaults_from_values(resolved_data, resolved_ch_names, resolved_ids))
     sensor_count = _estimate_sensor_count(resolved_data) if resolved_data is not None else None
     payload = {
         "source_type": "object",
@@ -9301,7 +9388,10 @@ def features_parser_inspect():
                     ["ch_names", "channels", "channel_names", "channel", "labels", "sensors", "sensor", "ch"],
                 ),
                 "recording_type": _pick_field_guess(selected_data_candidates, ["recording_type", "modality", "recording", "type"]),
-                "subject_id": _pick_field_guess(selected_data_candidates, ["subject_id", "subject", "subj", "participant"]),
+                "subject_id": _pick_field_guess(
+                    selected_data_candidates,
+                    ["subject_id", "sub_ids", "subid", "subject", "subj", "participant", "id", "ids"],
+                ),
                 "group": _pick_field_guess(selected_data_candidates, ["group", "cohort", "class"]),
                 "species": _pick_field_guess(selected_data_candidates, ["species", "animal", "organism"]),
                 "condition": _pick_field_guess(selected_data_candidates, ["condition", "state", "task"]),

--- a/webui/compute_utils.py
+++ b/webui/compute_utils.py
@@ -1102,6 +1102,38 @@ def _try_resolve_additional_metadata_ch_names(ch_locator, additional_metadata_pa
     return values if values else None
 
 
+def _discover_neighbor_tabular_metadata_paths(source_path, max_files=64):
+    """Collect nearby tabular metadata files next to a source file/directory."""
+    base = str(source_path or "").strip()
+    if not base:
+        return []
+    base_dir = base if os.path.isdir(base) else os.path.dirname(base)
+    if not base_dir or not os.path.isdir(base_dir):
+        return []
+
+    allowed_exts = {".csv", ".tsv", ".xlsx", ".xls", ".parquet", ".feather"}
+    out = []
+    seen = set()
+    try:
+        for name in sorted(os.listdir(base_dir)):
+            full = os.path.join(base_dir, name)
+            if not os.path.isfile(full):
+                continue
+            ext = os.path.splitext(name)[1].lower()
+            if ext not in allowed_exts:
+                continue
+            real = os.path.realpath(full)
+            if real in seen:
+                continue
+            seen.add(real)
+            out.append({"path": real, "name": os.path.basename(real)})
+            if len(out) >= max_files:
+                break
+    except Exception:
+        return out
+    return out
+
+
 def _structure_signature_for_value(value, depth=0, max_depth=2):
     if depth > max_depth:
         return ("depth_limit", type(value).__name__)
@@ -2489,6 +2521,50 @@ def features_computation(job_id, job_status, params, temp_uploaded_files):
                 heartbeat = threading.Thread(target=_parse_heartbeat, daemon=True)
                 heartbeat.start()
                 try:
+                    parsed = parser.parse(source_obj)
+                except KeyError as exc:
+                    ch_locator = getattr(getattr(parse_cfg, "fields", None), "ch_names", None)
+                    ch_locator_str = str(ch_locator or "").strip()
+                    err_msg = str(exc)
+                    can_retry = (
+                        isinstance(ch_locator, str)
+                        and ch_locator_str not in {"", "__self__"}
+                        and f"Cannot resolve step '{ch_locator_str}'" in err_msg
+                    )
+                    if not can_retry:
+                        raise
+
+                    combined_paths = []
+                    seen_paths = set()
+                    for entry in list(params.get("additional_metadata_paths") or []) + _discover_neighbor_tabular_metadata_paths(source_path):
+                        p = str((entry or {}).get("path") or "").strip()
+                        if not p:
+                            continue
+                        rp = os.path.realpath(p)
+                        if rp in seen_paths:
+                            continue
+                        seen_paths.add(rp)
+                        combined_paths.append({
+                            "path": rp,
+                            "name": (entry or {}).get("name") or os.path.basename(rp),
+                        })
+
+                    recovered = _try_resolve_additional_metadata_ch_names(ch_locator_str, combined_paths)
+                    if not recovered:
+                        raise
+
+                    import dataclasses
+                    parse_cfg = dataclasses.replace(
+                        parse_cfg,
+                        fields=dataclasses.replace(parse_cfg.fields, ch_names=recovered),
+                    )
+                    parser = EphysDatasetParser(parse_cfg)
+                    _append_job_output(
+                        job_status,
+                        job_id,
+                        f"Auto-detected {len(recovered)} channel name(s) from nearby metadata files "
+                        f"for locator '{ch_locator_str}'. Retrying parse.",
+                    )
                     parsed = parser.parse(source_obj)
                 finally:
                     parse_running["flag"] = False

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -2341,6 +2341,73 @@
                     const num = Number.parseInt(String(value ?? ''), 10);
                     return Number.isFinite(num) ? num : fallback;
                 };
+                const findFieldDetail = (fieldName) => {
+                    const key = String(fieldName || '').trim();
+                    if (!key) return null;
+                    return fieldDetails.find((row) => String(row?.field || '').trim() === key) || null;
+                };
+                const inferCountFromShape = (shapeValue) => {
+                    if (!Array.isArray(shapeValue) || shapeValue.length === 0) return null;
+                    const dims = shapeValue
+                        .map((v) => Number.parseInt(String(v), 10))
+                        .filter((v) => Number.isFinite(v) && v > 0);
+                    if (!dims.length) return null;
+                    if (dims.length === 1) return dims[0];
+                    const nonSingleton = dims.filter((v) => v > 1);
+                    if (nonSingleton.length === 1) return nonSingleton[0];
+                    return Math.max(...dims);
+                };
+                const inferAxesFromShapes = (dataLocator, chLocator, idLocator) => {
+                    const dataDetail = findFieldDetail(dataLocator);
+                    const dataShape = Array.isArray(dataDetail?.shape) ? dataDetail.shape : null;
+                    if (!dataShape || dataShape.length < 2) return null;
+
+                    const dims = dataShape
+                        .map((v, idx) => ({ idx, size: Number.parseInt(String(v), 10) }))
+                        .filter((item) => Number.isFinite(item.size) && item.size > 0);
+                    if (dims.length < 2) return null;
+
+                    let axisSamples = dims[0].idx;
+                    let maxSize = dims[0].size;
+                    for (const item of dims) {
+                        if (item.size > maxSize) {
+                            maxSize = item.size;
+                            axisSamples = item.idx;
+                        }
+                    }
+
+                    const chCount = inferCountFromShape(findFieldDetail(chLocator)?.shape);
+                    const idCount = inferCountFromShape(findFieldDetail(idLocator)?.shape);
+
+                    const bySize = (count, excluded = new Set()) => {
+                        if (!Number.isFinite(count) || count <= 0) return -1;
+                        const matches = dims
+                            .filter((item) => item.size === count && !excluded.has(item.idx))
+                            .map((item) => item.idx);
+                        return matches.length ? Math.min(...matches) : -1;
+                    };
+
+                    let axisChannels = bySize(chCount, new Set([axisSamples]));
+                    let axisIds = bySize(idCount, new Set([axisSamples, axisChannels]));
+                    let axisEpochs = -1;
+
+                    const remaining = dims
+                        .map((item) => item.idx)
+                        .filter((idx) => !new Set([axisSamples, axisChannels, axisIds]).has(idx))
+                        .sort((a, b) => a - b);
+                    if (remaining.length > 0) axisEpochs = remaining[0];
+                    if (axisIds < 0 && remaining.length > 1) {
+                        axisIds = remaining[0];
+                        axisEpochs = remaining[1];
+                    }
+
+                    return {
+                        axis_samples: axisSamples,
+                        axis_channels: axisChannels,
+                        axis_ids: axisIds,
+                        axis_epochs: axisEpochs,
+                    };
+                };
                 const defaultData = String(sampleTableGuesses.data || '').trim() || String(defaults.data || '').trim();
                 const defaultDataAllowed = defaultData && dataCandidates.includes(defaultData);
                 const detailDataAllowed = detailData && dataCandidates.includes(detailData);
@@ -2457,10 +2524,27 @@
                 if (kind === 'new-simulation' || kind === 'new-empirical') {
                     this.parserArrayAxesEnabled = true;
                     if (!this.parserAxisUserEdited) {
-                        const axisSamples = parseAxis(defaults.axis_samples, 0);
-                        const axisChannels = parseAxis(defaults.axis_channels, -1);
-                        const axisIds = parseAxis(defaults.axis_ids, -1);
-                        const axisEpochs = parseAxis(defaults.axis_epochs, -1);
+                        const inferredAxes = inferAxesFromShapes(
+                            this.parserDataLocator,
+                            this.parserChNamesLocator,
+                            this.parserSubjectIdLocator,
+                        );
+                        const axisSamples = parseAxis(
+                            inferredAxes?.axis_samples ?? defaults.axis_samples,
+                            0
+                        );
+                        const axisChannels = parseAxis(
+                            inferredAxes?.axis_channels ?? defaults.axis_channels,
+                            -1
+                        );
+                        const axisIds = parseAxis(
+                            inferredAxes?.axis_ids ?? defaults.axis_ids,
+                            -1
+                        );
+                        const axisEpochs = parseAxis(
+                            inferredAxes?.axis_epochs ?? defaults.axis_epochs,
+                            -1
+                        );
                         this.parserAxisSamples = String(axisSamples < 0 ? 0 : axisSamples);
                         this.parserAxisChannels = String(axisChannels);
                         this.parserAxisIds = String(axisIds);


### PR DESCRIPTION
Improve parser auto-configuration for mixed data/metadata sources and robust axis assignment

  1. Automatic recovery of channel-name metadata from neighboring tabular files when the configured ch_names locator is not inside the main source object.
  2. Correct automatic axis assignment (samples, channels, ids, epochs) using detected shapes and metadata dimensions.

  Together, these changes make mixed-folder workflows (array data + companion metadata table in the same folder) work reliably without requiring manual metadata attachment.

  ## Problem

  Two issues were observed in parser-driven Features workflows:

  1. Channel-name locator resolution failure
     When ch_names (e.g., a label column) is stored in a companion table rather than in the main array source, parsing failed unless the metadata file was explicitly added through the
     Additional Metadata UI.
  2. Incomplete or incorrect axis auto-assignment
     Even when shapes were correctly detected in inspection, axis fields could remain under-assigned (e.g., only samples set), instead of inferring channels, ids, and assigning the remaining
     axis to epochs/trials.

  ## Changes

  ### 1) Auto-discover nearby metadata for ch_names resolution

  File: webui/compute_utils.py

  - Added helper:
      - _discover_neighbor_tabular_metadata_paths(source_path, max_files=64)
  - Behavior:
      - scans the source folder for nearby tabular metadata files:
          - .csv, .tsv, .xlsx, .xls, .parquet, .feather
      - returns normalized path entries.
  - In Features parsing flow:
      - if parse fails with unresolved ch_names locator,
      - combine explicitly provided metadata paths + auto-discovered nearby tabular files,
      - try recovering channel names via existing metadata-column resolver,
      - patch parser config with recovered channel list and retry parsing.

  This keeps existing behavior intact while adding robust fallback for colocated metadata.

  ———

  ### 2) Better backend defaults for subject ID and axis inference

  File: webui/app.py

  - Expanded subject-id field guessing patterns to include common variants like:
      - sub_ids, subid, ids, etc.
  - Extended _infer_axis_defaults_from_values(...) to accept ids_value and use its size to place axis_ids when possible.
  - Improved remaining-axis logic so unassigned dimensions are consistently mapped, with leftover axis assigned to epochs when appropriate.

  ———

  ### 3) Frontend axis inference from inspected shapes

  File: webui/templates/3.1.features_methods.html

  - Enhanced applyParserDefaults(...) with shape-based axis inference using field_details:
      - data locator shape → base dimensionality
      - channel locator shape → axis_channels
      - subject-id locator shape → axis_ids
      - remaining unmatched dimension → axis_epochs
  - This is applied when parser axes are auto-managed (not user-overridden), ensuring UI axis selectors are prefilled correctly from inspection output.

  ———

  ### 4) Consistent subject-id fallback in parser inspection defaults

  File: webui/app.py

  - Updated multi-folder combined defaults fallback to use the same expanded subject-id heuristics as the main parser source description path.