### PR TITLE
Update ee gtopomap

### DIFF
--- a/ncpi/Analysis.py
+++ b/ncpi/Analysis.py
@@ -803,7 +803,7 @@ class Analysis:
             df_pair = df[df[group_col].isin([control_group, g])]
 
             out_rows: List[Tuple[str, float]] = []
-            for sensor, df_s in df_pair.groupby(sensor_col):
+            for sensor, df_s in df_pair.groupby(sensor_col, sort=False):
                 x = df_s.loc[df_s[group_col] == g, data_col].to_numpy(dtype=float)
                 y = df_s.loc[df_s[group_col] == control_group, data_col].to_numpy(dtype=float)
 
@@ -826,149 +826,187 @@ class Analysis:
     # ------------------------------------------------------------------
     # EEG plotting using MNE
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_eeg_info(
+        ch_names: List[str],
+        montage: str,
+        position_offset: Tuple[float, float],
+        ch_type: str = "eeg",
+    ) -> Any:
+        mne = tools.dynamic_import("mne")
+
+        if len(position_offset) != 2:
+            raise ValueError("position_offset must be a tuple/list of length 2: (y_offset, z_offset).")
+
+        info = mne.create_info(ch_names=ch_names, sfreq=250, ch_types=[ch_type] * len(ch_names))
+        std_montage = mne.channels.make_standard_montage(montage)
+
+        ch_pos = {
+            ch: std_montage.get_positions()["ch_pos"][ch]
+            for ch in ch_names
+            if ch in std_montage.get_positions()["ch_pos"]
+        }
+
+        if not ch_pos:
+            raise ValueError(f"None of the channels {ch_names} found in montage '{montage}'.")
+
+        y_off, z_off = position_offset
+        for ch in ch_pos:
+            ch_pos[ch] = ch_pos[ch].copy()
+            ch_pos[ch][1] += y_off
+            ch_pos[ch][2] += z_off
+
+        new_montage = mne.channels.make_dig_montage(ch_pos=ch_pos, coord_frame="head")
+        info.set_montage(new_montage)
+        return info
+    
     def eeg_topomap(
         self,
-        values: Union[Sequence[float], np.ndarray, Mapping[str, float], pd.Series],
+        values=None,
+        ch_names=None,
         *,
-        ch_names: Optional[Sequence[str]] = None,
-        montage: Union[str, Any] = "standard_1020",
-        info: Optional[Any] = None,
-        ch_type: str = "eeg",
-        units: Optional[str] = None,
-        vmin: Optional[float] = None,
-        vmax: Optional[float] = None,
-        cmap: Optional[str] = None,
-        sensors: bool = True,
-        outlines: Union[str, dict] = "head",
-        sphere: Union[str, Tuple[float, float, float, float]] = "auto",
-        axes: Optional[Any] = None,
-        show: bool = True,
-        colorbar: bool = True,
-        colorbar_label_fontsize: Optional[float] = None,
-        colorbar_tick_fontsize: Optional[float] = None,
-        res: int = 64,
-        extrapolate: str = "auto",
-        image_interp: str = "cubic",
+        position_offset,
+        sensor_col="sensor",
+        data_col="data",
+        data_index=-1,
+        montage="standard_1005",
+        ch_type="eeg",
+        sphere=0.28,
+        cmap="jet",
+        vmin=None,
+        vmax=None,
+        colorbar=True,
+        colorbar_fmt="%0.2f",
+        colorbar_label=None,
+        colorbar_label_fontsize=None,
+        colorbar_tick_fontsize=8,
+        sensors=None,
+        outlines=None,
+        contours=None,
+        res=300,
+        extrapolate=None,
+        image_interp=None,
+        axes=None,
+        show=True,
+        title=None,
+        names=None,
     ):
-        """Plot an EEG topomap using MNE, adapting to any montage / channel configuration.
-        """
-
         if not tools.ensure_module("mne"):
             raise ImportError("mne is required for eeg_topomap but is not installed.")
 
-        mne = tools.dynamic_import("mne")
+        import matplotlib.pyplot as plt
         mne_viz = tools.dynamic_import("mne", "viz")
 
-        # Normalize values + channel names
-        if isinstance(values, pd.Series):
-            ch_names_in = list(values.index.astype(str))
-            data = values.to_numpy(dtype=float)
-        elif isinstance(values, Mapping):
-            ch_names_in = [str(k) for k in values.keys()]
-            data = np.asarray(list(values.values()), dtype=float)
-        else:
-            data = np.asarray(values, dtype=float)
-            if ch_names is None:
-                raise ValueError("When `values` is array-like, you must provide `ch_names`.")
-            ch_names_in = [str(c) for c in ch_names]
-
-        if data.ndim != 1:
-            raise ValueError(f"values must be 1D (n_channels,), got shape {data.shape}.")
-        if len(ch_names_in) != data.shape[0]:
-            raise ValueError(f"Length mismatch: {len(ch_names_in)} channel names vs {data.shape[0]} values.")
-
-        # Build or validate Info
-        if info is None:
-            info_use = mne.create_info(ch_names=ch_names_in, sfreq=1.0, ch_types=[ch_type] * len(ch_names_in))
-        else:
-            missing = [c for c in ch_names_in if c not in info["ch_names"]]
-            if missing:
-                raise ValueError(f"Provided info is missing channels: {missing}")
-            info_use = info.copy()
-
-        # Apply montage
-        if montage is not None:
-            try:
-                if isinstance(montage, str):
-                    mont = mne.channels.make_standard_montage(montage)
+        # Paso A — Resolver datos y nombres de canales
+        if values is None:
+            df = self._as_dataframe()
+            if sensor_col not in df.columns:
+                raise ValueError(f"Column '{sensor_col}' not found in data.")
+            if data_col not in df.columns:
+                raise ValueError(f"Column '{data_col}' not found in data.")
+            if df.empty:
+                raise ValueError("DataFrame is empty.")
+            ch_names_in = []
+            data_vals = []
+            for sensor, group in df.groupby(sensor_col, sort=False):
+                raw = group[data_col].values
+                if data_index == -1:
+                    if len(raw) != 1:
+                        raise ValueError(
+                            f"data_index=-1 expects a scalar per sensor, but sensor '{sensor}' has {len(raw)} rows."
+                        )
+                    val = float(raw[0])
+                elif data_index is None:
+                    val = float(np.mean(raw))
                 else:
-                    mont = montage
-                info_use.set_montage(mont, match_case=False, on_missing="ignore")
-            except Exception as e:
-                raise ValueError(f"Failed to set montage {montage!r}: {e}") from e
+                    if data_index >= len(raw):
+                        raise IndexError(
+                            f"data_index={data_index} out of range for sensor '{sensor}' with {len(raw)} rows."
+                        )
+                    val = float(raw[data_index])
+                ch_names_in.append(str(sensor))
+                data_vals.append(val)
+            data_arr = np.asarray(data_vals, dtype=float)
+        else:
+            if isinstance(values, pd.Series):
+                ch_names_in = list(values.index.astype(str))
+                data_arr = values.to_numpy(dtype=float)
+            elif isinstance(values, Mapping):
+                ch_names_in = [str(k) for k in values.keys()]
+                data_arr = np.asarray(list(values.values()), dtype=float)
+            else:
+                data_arr = np.asarray(values, dtype=float)
+                if ch_names is None:
+                    raise ValueError("When values is array-like, ch_names is required.")
+                ch_names_in = [str(c) for c in ch_names]
 
-        # Ensure channel order matches data
-        if info_use["ch_names"] != ch_names_in:
-            info_tmp = mne.create_info(
-                ch_names=ch_names_in, sfreq=info_use["sfreq"], ch_types=[ch_type] * len(ch_names_in)
-            )
-            try:
-                info_tmp.set_montage(info_use.get_montage(), match_case=False, on_missing="ignore")
-            except Exception:
-                pass
-            info_use = info_tmp
+        if data_arr.ndim != 1:
+            raise ValueError(f"values must be 1D, got shape {data_arr.shape}.")
+        if len(ch_names_in) != data_arr.shape[0]:
+            raise ValueError(f"Length mismatch: {len(ch_names_in)} channel names vs {data_arr.shape[0]} values.")
 
-        # MNE has changed the topomap API across versions.
-        # We therefore build keyword arguments dynamically based on the installed MNE.
-        import inspect
+        # Paso B — Validar position_offset
+        if len(position_offset) != 2 or not all(isinstance(v, (int, float)) for v in position_offset):
+            raise ValueError("position_offset must be a tuple/list of two numbers: (y_offset, z_offset).")
 
-        sig = inspect.signature(mne_viz.plot_topomap)
-        supported = set(sig.parameters.keys())
+        # Paso C — Crear Info
+        info_use = self._make_eeg_info(ch_names_in, montage, position_offset, ch_type)
 
-        kwargs = dict(
-            axes=axes,
-            show=show,
-            cmap=cmap,
-            sensors=sensors,
-            outlines=outlines,
-            sphere=sphere,
-            res=res,
-            extrapolate=extrapolate,
-            image_interp=image_interp,
+        # Paso D — All-zeros
+        if np.all(data_arr == 0):
+            cmap = "Greys"
+            colorbar = False
+            vmin = vmax = 0.0
+
+        # Paso E — vmin/vmax
+        if vmin is None:
+            vmin = float(np.nanmin(data_arr))
+        if vmax is None:
+            vmax = float(np.nanmax(data_arr))
+        if vmin > vmax:
+            raise ValueError(f"vmin ({vmin}) must be <= vmax ({vmax}).")
+
+        # Paso F — Plot
+        # Match the legacy plots.py call by default. Optional MNE kwargs are
+        # forwarded only when explicitly provided, because forcing them can
+        # change interpolation/contours across MNE versions.
+        topomap_kwargs = {"sphere": sphere, "res": res}
+        if sensors is not None:
+            topomap_kwargs["sensors"] = sensors
+        if outlines is not None:
+            topomap_kwargs["outlines"] = outlines
+        if contours is not None:
+            topomap_kwargs["contours"] = contours
+        if extrapolate is not None:
+            topomap_kwargs["extrapolate"] = extrapolate
+        if image_interp is not None:
+            topomap_kwargs["image_interp"] = image_interp
+
+        im, _ = mne_viz.plot_topomap(
+            data_arr, info_use, axes=axes, cmap=cmap, show=False,
+            **topomap_kwargs,
         )
+        im.set_clim(vmin, vmax)
 
-        # Optional colorbar support (older MNE may not accept it)
-        needs_manual_colorbar = colorbar and "colorbar" not in supported
-        if "colorbar" in supported:
-            kwargs["colorbar"] = colorbar
+        # Paso G — Colorbar manual
+        if colorbar:
+            mid = vmin + (vmax - vmin) / 2
+            cbar = plt.colorbar(
+                im, ax=axes if axes is not None else im.axes,
+                fraction=0.046, pad=0.0, format=colorbar_fmt, ticks=[vmin, mid, vmax],
+            )
+            cbar.ax.tick_params(labelsize=colorbar_tick_fontsize)
+            if colorbar_label:
+                cbar.set_label(colorbar_label, fontsize=colorbar_label_fontsize)
 
-        # If we need to add the colorbar manually, defer show so the figure
-        # is not rendered yet when we modify its layout.
-        if needs_manual_colorbar:
-            kwargs["show"] = False
+        # Paso H — Título y show
+        if title:
+            (axes if axes is not None else im.axes).set_title(title)
+        if show:
+            plt.show()
 
-        # Value range support differs across versions: either (vmin, vmax) or vlim
-        if "vmin" in supported or "vmax" in supported:
-            if "vmin" in supported:
-                kwargs["vmin"] = vmin
-            if "vmax" in supported:
-                kwargs["vmax"] = vmax
-        elif "vlim" in supported:
-            kwargs["vlim"] = (vmin, vmax)
-
-        im, cn = mne_viz.plot_topomap(data, info_use, **kwargs)
-
-        if needs_manual_colorbar:
-            ax_used = axes if axes is not None else im.axes
-            cb = ax_used.figure.colorbar(im, ax=ax_used)
-            if units is not None:
-                cb.set_label(units, fontsize=colorbar_label_fontsize)
-            if colorbar_tick_fontsize is not None:
-                cb.ax.tick_params(labelsize=colorbar_tick_fontsize)
-            if show:
-                import matplotlib.pyplot as plt
-                plt.show()
-        elif colorbar:
-            # MNE native colorbar: find the colorbar axes matplotlib added
-            fig = (axes if axes is not None else im.axes).figure
-            for cb_ax in fig.axes:
-                if cb_ax.get_label() == "<colorbar>":
-                    if units is not None:
-                        cb_ax.set_ylabel(units, fontsize=colorbar_label_fontsize)
-                    if colorbar_tick_fontsize is not None:
-                        cb_ax.tick_params(labelsize=colorbar_tick_fontsize)
-
-        return im, cn
+        return im
 
     # --------------
     # MEG plotting

--- a/webui/app.py
+++ b/webui/app.py
@@ -10094,6 +10094,10 @@ def _analysis_selected_keys_path(create=False):
     return os.path.join(_analysis_data_dir(create=create), ".selected_simulation_keys.json")
 
 
+def _analysis_plot_config_path(create=False):
+    return os.path.join(_analysis_data_dir(create=create), ".plot_config.json")
+
+
 def _set_analysis_selected_simulation_keys(keys):
     selected = [
         str(key).strip()
@@ -10194,6 +10198,89 @@ def _clear_analysis_data_files():
     return removed_files
 
 
+def _analysis_data_signature(data_path=None):
+    path = data_path or _analysis_data_path()
+    if not path or not os.path.isfile(path):
+        return None
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    return {
+        "path": os.path.realpath(path),
+        "name": os.path.basename(path),
+        "size": int(stat.st_size),
+        "mtime_ns": int(stat.st_mtime_ns),
+    }
+
+
+def _clear_analysis_plot_config():
+    path = _analysis_plot_config_path()
+    if os.path.isfile(path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    _remove_dir_if_empty(_analysis_data_dir(create=False))
+
+
+def _save_analysis_plot_config(plot_action, form, data_path=None):
+    signature = _analysis_data_signature(data_path)
+    if not signature:
+        return
+    values = {}
+    for key in form.keys():
+        clean_key = str(key or "").strip()
+        if not clean_key:
+            continue
+        values[clean_key] = [str(value) for value in form.getlist(key)]
+    payload = {
+        "plot_action": str(plot_action or "").strip(),
+        "data_signature": signature,
+        "values": values,
+    }
+    path = _analysis_plot_config_path(create=True)
+    tmp_path = f"{path}.tmp"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        os.replace(tmp_path, path)
+    except OSError:
+        try:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except OSError:
+            pass
+
+
+def _load_analysis_plot_config():
+    path = _analysis_plot_config_path()
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("data_signature") != _analysis_data_signature():
+        return None
+    values = payload.get("values")
+    if not isinstance(values, dict):
+        return None
+    normalized_values = {}
+    for key, raw_values in values.items():
+        if isinstance(raw_values, list):
+            normalized_values[str(key)] = [str(value) for value in raw_values]
+        else:
+            normalized_values[str(key)] = [str(raw_values)]
+    return {
+        "plot_action": str(payload.get("plot_action") or ""),
+        "values": normalized_values,
+    }
+
+
 @app.route("/analysis")
 def analysis():
     analysis_data_files = _list_analysis_data_files()
@@ -10263,6 +10350,15 @@ def analysis():
         simulation_model=simulation_model,
         simulation_welch_defaults=simulation_welch_defaults,
         meg_topomap_atlases=MEG_TOPO_ATLAS_OPTIONS,
+        topomap_montage_options=_topomap_montage_options(),
+        topomap_channel_type_options=TOPO_MAP_CHANNEL_TYPE_OPTIONS,
+        topomap_colormap_options=_topomap_colormap_options(),
+        topomap_contour_options=TOPO_MAP_CONTOUR_OPTIONS,
+        topomap_outline_options=TOPO_MAP_OUTLINE_OPTIONS,
+        topomap_extrapolate_options=TOPO_MAP_EXTRAPOLATE_OPTIONS,
+        topomap_image_interp_options=TOPO_MAP_IMAGE_INTERP_OPTIONS,
+        boxplot_colormap_options=_boxplot_colormap_options(),
+        analysis_plot_config=_load_analysis_plot_config(),
     )
 
 
@@ -12002,6 +12098,148 @@ MEG_TOPO_ATLAS_OPTIONS = [
 ]
 MEG_TOPO_ATLAS_VALUES = {item["value"] for item in MEG_TOPO_ATLAS_OPTIONS}
 
+MNE_BUILTIN_MONTAGE_FALLBACK = [
+    "standard_1005",
+    "standard_1020",
+    "standard_alphabetic",
+    "standard_postfixed",
+    "standard_prefixed",
+    "standard_primed",
+    "biosemi16",
+    "biosemi32",
+    "biosemi64",
+    "biosemi128",
+    "biosemi160",
+    "biosemi256",
+    "easycap-M1",
+    "easycap-M10",
+    "EGI_256",
+    "GSN-HydroCel-32",
+    "GSN-HydroCel-64_1.0",
+    "GSN-HydroCel-65_1.0",
+    "GSN-HydroCel-128",
+    "GSN-HydroCel-129",
+    "GSN-HydroCel-256",
+    "GSN-HydroCel-257",
+    "mgh60",
+    "mgh70",
+    "artinis-octamon",
+    "artinis-brite23",
+]
+
+COMMON_MATPLOTLIB_COLORMAPS = [
+    "viridis",
+    "plasma",
+    "inferno",
+    "magma",
+    "cividis",
+    "turbo",
+    "jet",
+    "coolwarm",
+    "bwr",
+    "seismic",
+    "RdBu_r",
+    "Spectral",
+    "PiYG",
+    "PRGn",
+    "BrBG",
+    "Blues",
+    "Greens",
+    "Reds",
+    "Purples",
+    "Greys",
+    "YlOrRd",
+    "YlGnBu",
+]
+
+TOPO_MAP_CHANNEL_TYPE_OPTIONS = [
+    {"value": "eeg", "label": "EEG"},
+    {"value": "seeg", "label": "sEEG"},
+    {"value": "ecog", "label": "ECoG"},
+    {"value": "dbs", "label": "DBS"},
+    {"value": "hbo", "label": "fNIRS HbO"},
+    {"value": "hbr", "label": "fNIRS HbR"},
+]
+TOPO_MAP_CONTOUR_OPTIONS = [
+    {"value": "", "label": "MNE default"},
+    {"value": "0", "label": "None (0)"},
+    {"value": "3", "label": "3"},
+    {"value": "6", "label": "6"},
+    {"value": "10", "label": "10"},
+    {"value": "15", "label": "15"},
+]
+TOPO_MAP_OUTLINE_OPTIONS = [
+    {"value": "", "label": "MNE default"},
+    {"value": "head", "label": "head"},
+    {"value": "skirt", "label": "skirt"},
+]
+TOPO_MAP_EXTRAPOLATE_OPTIONS = [
+    {"value": "", "label": "MNE default"},
+    {"value": "auto", "label": "auto"},
+    {"value": "local", "label": "local"},
+    {"value": "head", "label": "head"},
+    {"value": "box", "label": "box"},
+]
+TOPO_MAP_IMAGE_INTERP_OPTIONS = [
+    {"value": "", "label": "MNE default"},
+    {"value": "cubic", "label": "cubic"},
+    {"value": "linear", "label": "linear"},
+    {"value": "nearest", "label": "nearest"},
+]
+
+
+@functools.lru_cache(maxsize=1)
+def _topomap_montage_options():
+    try:
+        import mne
+
+        names = list(mne.channels.get_builtin_montages())
+    except Exception:
+        names = list(MNE_BUILTIN_MONTAGE_FALLBACK)
+
+    seen = set()
+    cleaned = []
+    for name in names:
+        text = str(name or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        cleaned.append(text)
+    if "standard_1005" not in seen:
+        cleaned.insert(0, "standard_1005")
+        seen.add("standard_1005")
+
+    preferred = [name for name in ("standard_1005", "standard_1020") if name in seen]
+    rest = sorted((name for name in cleaned if name not in preferred), key=str.lower)
+    return [{"value": name, "label": name} for name in [*preferred, *rest]]
+
+
+@functools.lru_cache(maxsize=1)
+def _common_colormap_options():
+    names = list(COMMON_MATPLOTLIB_COLORMAPS)
+    try:
+        import matplotlib
+
+        available = set(matplotlib.colormaps)
+        names = [name for name in names if name in available]
+    except Exception:
+        pass
+    return [{"value": name, "label": name} for name in names]
+
+
+def _topomap_colormap_options():
+    return [
+        {"value": "auto", "label": "Auto (bwr for comparisons, jet otherwise)"},
+        *_common_colormap_options(),
+    ]
+
+
+def _boxplot_colormap_options():
+    return [
+        {"value": "none", "label": "None"},
+        *_common_colormap_options(),
+    ]
+
 
 def _normalize_meg_atlas_name(atlas):
     atlas_norm = str(atlas or "").strip().lower()
@@ -12220,6 +12458,7 @@ def analysis_plot_boxplot():
     data_path = _analysis_data_path()
     if data_path is None:
         return _plot_error("No analysis dataframe found. Upload a .pkl file first.")
+    _save_analysis_plot_config("boxplot", request.form, data_path=data_path)
 
     group_col = request.form.get("boxplot_group_by")
     if not group_col:
@@ -12734,6 +12973,7 @@ def analysis_plot_topomap():
     data_path = _analysis_data_path()
     if data_path is None:
         return _plot_error("No analysis dataframe found. Upload a .pkl file first.")
+    _save_analysis_plot_config("topomap", request.form, data_path=data_path)
 
     group_col = request.form.get("topomap_group_by")
     if not group_col:
@@ -12753,12 +12993,18 @@ def analysis_plot_topomap():
     if group_col not in df.columns:
         return _plot_error(f'Grouping column "{group_col}" not found in the dataframe.')
 
-    sensor_col = _find_column(df, ["sensor", "Sensor", "channel", "Channel", "ch", "Ch", "electrode", "Electrode"])
-    if sensor_col is None:
-        return _plot_error(
-            "Sensor/channel column not found. Expected a column like 'sensor', 'channel', or 'electrode'.",
-            popup_redirect_url=url_for("analysis"),
-        )
+    requested_sensor_col = str(request.form.get("topomap_sensor_col", "") or "").strip()
+    if requested_sensor_col:
+        if requested_sensor_col not in df.columns:
+            return _plot_error(f'Sensor column "{requested_sensor_col}" not found in the dataframe.')
+        sensor_col = requested_sensor_col
+    else:
+        sensor_col = _find_column(df, ["sensor", "Sensor", "channel", "Channel", "ch", "Ch", "electrode", "Electrode"])
+        if sensor_col is None:
+            return _plot_error(
+                "Sensor/channel column not found. Expected a column like 'sensor', 'channel', or 'electrode'.",
+                popup_redirect_url=url_for("analysis"),
+            )
 
     value_col = request.form.get("topomap_value_col")
     if not value_col:
@@ -12832,19 +13078,73 @@ def analysis_plot_topomap():
         return _plot_error(f"ncpi is required for topomap plotting: {exc}", status=500)
     _log("ncpi loaded.")
 
-    # Parse numeric inputs for plotting
+    # Parse user-configurable plotting inputs.
     def _parse_float(value):
         try:
-            return float(value)
+            text = str(value).strip()
+            if text == "":
+                return None
+            return float(text)
         except (TypeError, ValueError):
             return None
 
-    head_radius = _parse_float(request.form.get("head-radius"))
-    head_pos_x = _parse_float(request.form.get("head-pos-x"))
+    def _parse_float_default(name, default):
+        parsed = _parse_float(request.form.get(name))
+        return default if parsed is None else parsed
+
+    def _parse_int(value):
+        try:
+            text = str(value).strip()
+            if text == "":
+                return None
+            return int(text)
+        except (TypeError, ValueError):
+            return None
+
+    def _parse_int_default(name, default):
+        parsed = _parse_int(request.form.get(name))
+        return default if parsed is None else parsed
+
+    def _parse_optional_text(name):
+        value = str(request.form.get(name, "") or "").strip()
+        if value.lower() in {"", "none", "null", "default"}:
+            return None
+        return value
+
     show_colorbar = request.form.get("show-colorbar") is not None
     scale_mode = request.form.get("topomap_scale_mode", "section")
     use_diverging = grouping_mode == "compare_categories"
     compare_cmap = "bwr" if use_diverging else None
+    cohend_abs_threshold = _parse_float(request.form.get("topomap_cohend_abs_threshold"))
+    if cohend_abs_threshold is not None and cohend_abs_threshold < 0:
+        return _plot_error("Cohen's d filter threshold must be greater than or equal to 0.")
+    if grouping_mode == "compare_categories" and compare_method == "cohen_d" and cohend_abs_threshold:
+        _log(f"Cohen's d filter enabled: |d| >= {cohend_abs_threshold}.")
+
+    eeg_montage = _parse_optional_text("topomap_eeg_montage") or "standard_1005"
+    eeg_ch_type = _parse_optional_text("topomap_eeg_ch_type") or "eeg"
+    eeg_position_offset = (
+        _parse_float_default("topomap_position_y", 0.01),
+        _parse_float_default("topomap_position_z", -0.1),
+    )
+    eeg_sphere = _parse_float_default("topomap_sphere", 0.28)
+    eeg_res = _parse_int_default("topomap_res", 300)
+    eeg_contours = _parse_int(request.form.get("topomap_contours"))
+    eeg_outlines = _parse_optional_text("topomap_outlines")
+    eeg_extrapolate = _parse_optional_text("topomap_extrapolate")
+    eeg_image_interp = _parse_optional_text("topomap_image_interp")
+    eeg_show_sensors = request.form.get("topomap_show_sensors") is not None
+    eeg_vmin_user = _parse_float(request.form.get("topomap_vmin"))
+    eeg_vmax_user = _parse_float(request.form.get("topomap_vmax"))
+    if eeg_vmin_user is not None and eeg_vmax_user is not None and eeg_vmin_user > eeg_vmax_user:
+        return _plot_error("EEG topomap vmin must be <= vmax.")
+
+    eeg_cmap_raw = str(request.form.get("topomap_cmap", "auto") or "auto").strip()
+    eeg_cmap = (compare_cmap or "jet") if eeg_cmap_raw.lower() == "auto" else eeg_cmap_raw
+    eeg_colorbar_fmt = str(request.form.get("topomap_colorbar_fmt", "%0.2f") or "%0.2f").strip() or "%0.2f"
+    eeg_colorbar_label = _parse_optional_text("topomap_colorbar_label")
+    eeg_colorbar_label_fontsize = _parse_float(request.form.get("topomap_colorbar_label_fontsize"))
+    eeg_colorbar_tick_fontsize = _parse_float_default("topomap_colorbar_tick_fontsize", 8.0)
     meg_expected_count = None
     if topomap_signal_type == "meg":
         try:
@@ -12852,11 +13152,6 @@ def analysis_plot_topomap():
         except Exception as exc:
             return _plot_error(f"Unable to prepare MEG atlas '{meg_atlas}': {exc}")
         _log(f"MEG atlas '{meg_atlas}' expects {meg_expected_count} regions.")
-
-    sphere = "auto"
-    if head_radius is not None:
-        x = head_pos_x if head_pos_x is not None else 0.0
-        sphere = (x, 0.0, 0.0, head_radius)
 
     analysis = ncpi.Analysis(df_use)
 
@@ -12941,8 +13236,19 @@ def analysis_plot_topomap():
                 for label, comp_df in compare_results.items():
                     if comp_df.empty:
                         continue
-                    series = comp_df.set_index(sensor_col)["d"]
-                    items_local.append((label, series))
+                    series = pd.to_numeric(comp_df.set_index(sensor_col)["d"], errors="coerce")
+                    if cohend_abs_threshold:
+                        valid_values = series.dropna()
+                        retained = int((valid_values.abs() >= cohend_abs_threshold).sum())
+                        total = int(valid_values.size)
+                        series = series.where(series.abs() >= cohend_abs_threshold, 0.0)
+                        _log(
+                            f"Cohen's d filter for {label}, data_index={dim}: "
+                            f"retained {retained}/{total} sensors."
+                        )
+                    series = series.dropna()
+                    if not series.empty:
+                        items_local.append((label, series))
             else:
                 control_df = df_use[df_use[group_col] == control_group]
                 if dim == -1:
@@ -13112,18 +13418,32 @@ def analysis_plot_topomap():
                         hcp_accept=True,
                     )
                 else:
-                    im, _ = analysis.eeg_topomap(
+                    if eeg_vmin_user is not None:
+                        plot_vmin = eeg_vmin_user
+                    if eeg_vmax_user is not None:
+                        plot_vmax = eeg_vmax_user
+                    im = analysis.eeg_topomap(
                         series,
                         axes=ax,
                         show=False,
                         vmin=plot_vmin,
                         vmax=plot_vmax,
-                        cmap=compare_cmap,
-                        colorbar=False,
-                        sensors=True,
-                        montage="standard_1020",
-                        extrapolate="local",
-                        sphere=sphere,
+                        cmap=eeg_cmap,
+                        colorbar=show_colorbar,
+                        colorbar_fmt=eeg_colorbar_fmt,
+                        colorbar_label=eeg_colorbar_label,
+                        colorbar_label_fontsize=eeg_colorbar_label_fontsize,
+                        colorbar_tick_fontsize=eeg_colorbar_tick_fontsize,
+                        sensors=eeg_show_sensors,
+                        montage=eeg_montage,
+                        ch_type=eeg_ch_type,
+                        position_offset=eeg_position_offset,
+                        sphere=eeg_sphere,
+                        contours=eeg_contours,
+                        outlines=eeg_outlines,
+                        res=eeg_res,
+                        extrapolate=eeg_extrapolate,
+                        image_interp=eeg_image_interp,
                     )
             except Exception as exc:
                 plt.close(fig)
@@ -13145,8 +13465,6 @@ def analysis_plot_topomap():
                     message,
                     popup_redirect_url=url_for("analysis") if sensor_info_missing else None,
                 )
-            if show_colorbar and topomap_signal_type == "eeg" and im is not None:
-                fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
             ax.set_title(label)
         row_cursor += rows_needed
 
@@ -14660,6 +14978,7 @@ def clear_analysis_data():
     removed_files = _clear_analysis_data_files()
     _clear_analysis_selection_mode()
     _clear_analysis_selected_simulation_keys()
+    _clear_analysis_plot_config()
     accept_header = (request.headers.get("Accept") or "").lower()
     is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
     if is_ajax or "application/json" in accept_header:

--- a/webui/templates/5.1.0.analysis.html
+++ b/webui/templates/5.1.0.analysis.html
@@ -33,6 +33,7 @@
     window.__preselectedSimulationItems = {{ preselected_simulation_items | tojson }};
     window.__simulationWelchDefaults = {{ simulation_welch_defaults | tojson }};
     window.__megTopomapAtlases = {{ meg_topomap_atlases | tojson }};
+    window.__analysisPlotConfig = {{ analysis_plot_config | tojson }};
     window.__webuiRuntime = {{ webui_runtime | tojson }};
 </script>
 <style>
@@ -70,6 +71,7 @@
             serverFileBrowserSelectedPath: '',
             analysisServerSelectedPath: '',
             analysisLastLoadedSource: '',
+            savedPlotConfig: (window.__analysisPlotConfig || null),
             analysisBrowseRequestId: 0,
             detectedSimulationSyncTimer: null,
             detectedSimulationSyncPending: false,
@@ -95,7 +97,9 @@
             topomapLastGroupColumn: '',
             topomapGroupBy: '',
             topomapValueCol: '',
+            topomapSensorCol: '',
             topomapMode: 'per_sensor',
+            topomapCompareMethod: 'raw',
             topomapSignalType: 'eeg',
             topomapMegAtlas: 'dk',
             topomapMegAtlasOptions: (window.__megTopomapAtlases || []),
@@ -580,6 +584,8 @@
                 this.boxplotLastGroupColumn = '';
                 this.topomapGroupBy = '';
                 this.topomapValueCol = '';
+                this.topomapSensorCol = '';
+                this.topomapCompareMethod = 'raw';
                 this.topomapControlGroup = '';
                 this.topomapGroupValues = [];
                 this.topomapGroupValuesError = '';
@@ -625,6 +631,98 @@
                     this.activeTab = this.tabOrder[idx - 1];
                 }
             },
+            restoreSavedPlotConfig() {
+                const config = this.savedPlotConfig || {};
+                const values = config && typeof config.values === 'object' && config.values !== null ? config.values : {};
+                if (!Object.keys(values).length) {
+                    return;
+                }
+                const first = (name, fallback = '') => {
+                    const raw = values[name];
+                    if (Array.isArray(raw)) {
+                        return raw.length ? String(raw[0] ?? '') : fallback;
+                    }
+                    if (raw === undefined || raw === null) {
+                        return fallback;
+                    }
+                    return String(raw);
+                };
+                const has = (name) => Object.prototype.hasOwnProperty.call(values, name);
+
+                const plotAction = String(config.plot_action || '').trim();
+                if (plotAction === 'boxplot' || plotAction === 'topomap') {
+                    this.activeTab = plotAction;
+                }
+
+                this.boxplotGroupBy = first('boxplot_group_by', this.boxplotGroupBy);
+                this.boxplotValueCol = first('boxplot_value_col', this.boxplotValueCol);
+                this.boxplotShowCohen = has('boxplot_show_cohend');
+                this.boxplotControlGroup = first('boxplot_control_group', this.boxplotControlGroup);
+
+                this.topomapSignalType = first('topomap_signal_type', this.topomapSignalType);
+                this.topomapMegAtlas = first('topomap_meg_atlas', this.topomapMegAtlas);
+                this.topomapMode = first('topomap_grouping_mode', this.topomapMode);
+                this.topomapCompareMethod = first('topomap_compare_method', this.topomapCompareMethod);
+                this.topomapGroupBy = first('topomap_group_by', this.topomapGroupBy);
+                this.topomapControlGroup = first('topomap_control_group', this.topomapControlGroup);
+                this.topomapValueCol = first('topomap_value_col', this.topomapValueCol);
+                this.topomapSensorCol = first('topomap_sensor_col', this.topomapSensorCol);
+
+                const applyDomValues = () => {
+                    const root = this.$root || document;
+                    const form = root.querySelector ? root.querySelector('form') : null;
+                    if (!form) {
+                        return;
+                    }
+                    const checkboxNames = [
+                        'boxplot_showfliers',
+                        'boxplot_show_cohend',
+                        'topomap_show_sensors',
+                        'show-colorbar',
+                    ];
+                    const fieldNames = new Set([...Object.keys(values), ...checkboxNames]);
+                    for (const name of fieldNames) {
+                        const controls = Array.from(form.elements).filter((el) => el && el.name === name);
+                        if (!controls.length) {
+                            continue;
+                        }
+                        const raw = values[name];
+                        const selectedValues = Array.isArray(raw)
+                            ? raw.map((value) => String(value ?? ''))
+                            : (raw === undefined || raw === null ? [] : [String(raw)]);
+                        const firstValue = selectedValues.length ? selectedValues[0] : '';
+                        for (const el of controls) {
+                            const type = String(el.type || '').toLowerCase();
+                            if (type === 'checkbox') {
+                                el.checked = selectedValues.length > 0
+                                    && (controls.length === 1 || selectedValues.includes(String(el.value || 'on')));
+                            } else if (type === 'radio') {
+                                el.checked = selectedValues.includes(String(el.value || ''));
+                            } else if (el.multiple && el.options) {
+                                for (const option of el.options) {
+                                    option.selected = selectedValues.includes(String(option.value));
+                                }
+                            } else {
+                                el.value = firstValue;
+                            }
+                            el.dispatchEvent(new Event('input', { bubbles: true }));
+                            el.dispatchEvent(new Event('change', { bubbles: true }));
+                        }
+                    }
+                    if (this.boxplotGroupBy) {
+                        this.fetchGroupValues(this.boxplotGroupBy, 'boxplot');
+                    }
+                    if (this.topomapGroupBy) {
+                        this.fetchGroupValues(this.topomapGroupBy, 'topomap');
+                    }
+                };
+
+                if (typeof this.$nextTick === 'function') {
+                    this.$nextTick(applyDomValues);
+                } else {
+                    setTimeout(applyDomValues, 0);
+                }
+            },
             init() {
                 if (this.hasExistingData) {
                     const name = this.currentDataFile();
@@ -634,7 +732,7 @@
                         this.uploads['dataframe-upload'] = { name: name, uploaded: true, persisted: true };
                         this.setAnalysisUploadKind('dataframe');
                     }
-                    this.loadColumnsFromServer();
+                    this.loadColumnsFromServer().then(() => this.restoreSavedPlotConfig());
                     return;
                 }
 
@@ -861,6 +959,8 @@
                     this.boxplotLastGroupColumn = '';
                     this.topomapGroupBy = '';
                     this.topomapValueCol = '';
+                    this.topomapSensorCol = '';
+                    this.topomapCompareMethod = 'raw';
                     this.topomapControlGroup = '';
                     this.topomapGroupValues = [];
                     this.topomapGroupValuesError = '';
@@ -891,6 +991,8 @@
                 this.boxplotLastGroupColumn = '';
                 this.topomapGroupBy = '';
                 this.topomapValueCol = '';
+                this.topomapSensorCol = '';
+                this.topomapCompareMethod = 'raw';
                 this.topomapControlGroup = '';
                 this.topomapGroupValues = [];
                 this.topomapGroupValuesError = '';
@@ -1172,6 +1274,8 @@
                 this.boxplotLastGroupColumn = '';
                 this.topomapGroupBy = '';
                 this.topomapValueCol = '';
+                this.topomapSensorCol = '';
+                this.topomapCompareMethod = 'raw';
                 this.topomapControlGroup = '';
                 this.topomapGroupValues = [];
                 this.topomapGroupValuesError = '';
@@ -1794,8 +1898,12 @@
                                             <div class="sm:col-span-2">
                                                 <label class="block text-xs font-medium text-slate-700 dark:text-slate-300"
                                                     for="boxplot-colormap">Colormap</label>
-                                                <input id="boxplot-colormap" name="boxplot_colormap" type="text" value="viridis"
-                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                                <select id="boxplot-colormap" name="boxplot_colormap"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary">
+                                                    {% for opt in boxplot_colormap_options %}
+                                                        <option value="{{ opt.value }}" {% if opt.value == 'viridis' %}selected{% endif %}>{{ opt.label }}</option>
+                                                    {% endfor %}
+                                                </select>
                                             </div>
                                             <div class="sm:col-span-2">
                                                 <label class="block text-xs font-medium text-slate-700 dark:text-slate-300"
@@ -1942,7 +2050,7 @@
                                                 <input
                                                     class="h-4 w-4 rounded-full border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-primary focus:ring-primary dark:checked:bg-primary dark:checked:border-primary"
                                                     id="topomap-compare-raw" name="topomap_compare_method" type="radio" value="raw"
-                                                    checked />
+                                                    x-model="topomapCompareMethod" />
                                             </div>
                                             <div class="ml-3 text-sm leading-6">
                                                 <label class="font-medium text-slate-900 dark:text-slate-300" for="topomap-compare-raw">Subtract raw values</label>
@@ -1953,13 +2061,24 @@
                                             <div class="flex h-6 items-center">
                                                 <input
                                                     class="h-4 w-4 rounded-full border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-primary focus:ring-primary dark:checked:bg-primary dark:checked:border-primary"
-                                                    id="topomap-compare-cohen" name="topomap_compare_method" type="radio" value="cohen_d" />
+                                                    id="topomap-compare-cohen" name="topomap_compare_method" type="radio" value="cohen_d"
+                                                    x-model="topomapCompareMethod" />
                                             </div>
                                             <div class="ml-3 text-sm leading-6">
                                                 <label class="font-medium text-slate-900 dark:text-slate-300" for="topomap-compare-cohen">Cohen's d</label>
                                                 <p class="text-slate-500 dark:text-slate-400">Plot Cohen's d effect sizes vs the control group.</p>
                                             </div>
                                         </div>
+                                    </div>
+                                </div>
+                                <div class="sm:col-span-3" x-show="topomapMode === 'compare_categories' && topomapCompareMethod === 'cohen_d'" x-cloak>
+                                    <label class="block text-sm font-medium leading-6 text-slate-900 dark:text-slate-300"
+                                        for="topomap-cohend-abs-threshold">Minimum |Cohen's d|</label>
+                                    <div class="mt-2">
+                                        <input
+                                            class="block w-full rounded-md border-0 py-1.5 text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:ring-2 focus:ring-inset focus:ring-primary sm:text-sm sm:leading-6"
+                                            id="topomap-cohend-abs-threshold" name="topomap_cohend_abs_threshold"
+                                            type="number" min="0" step="any" placeholder="No filter" />
                                     </div>
                                 </div>
                                 <div class="sm:col-span-3">
@@ -2017,31 +2136,134 @@
 
                                 <div class="sm:col-span-3" x-show="topomapSignalType === 'eeg'" x-cloak>
                                     <label class="block text-sm font-medium leading-6 text-slate-900 dark:text-slate-300"
-                                        for="head-radius">Radius of the head circumference</label>
+                                        for="topomap-sensor-col">Sensor column</label>
                                     <div class="mt-2">
-                                        <input
-                                            class="block w-full rounded-md border-0 py-1.5 text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:ring-2 focus:ring-inset focus:ring-primary sm:text-sm sm:leading-6"
-                                            id="head-radius" name="head-radius" type="text" value="0.095" />
+                                        <select
+                                            class="block w-full rounded-md border-0 py-1.5 text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary sm:text-sm sm:leading-6"
+                                            id="topomap-sensor-col" name="topomap_sensor_col" x-model="topomapSensorCol"
+                                            :disabled="!dfColumns.length || columnsLoading">
+                                            <option value="">Auto-detect sensor/channel</option>
+                                            <template x-for="col in dfColumns" :key="col">
+                                                <option :value="col" x-text="col"></option>
+                                            </template>
+                                        </select>
+                                    </div>
+                                    <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                        Leave empty to auto-detect sensor, channel, ch, or electrode.
+                                    </p>
+                                </div>
+
+                                <div class="sm:col-span-6" x-show="topomapSignalType === 'eeg'" x-cloak>
+                                    <div class="mt-2 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+                                        <h4 class="text-sm font-semibold text-slate-900 dark:text-slate-200">EEG topomap options</h4>
+                                        <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                            These options are passed to ncpi.Analysis.eeg_topomap.
+                                        </p>
+                                        <div class="mt-3 grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-6">
+                                            <div class="sm:col-span-3">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-eeg-montage">Montage</label>
+                                                <select id="topomap-eeg-montage" name="topomap_eeg_montage"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary">
+                                                    {% for opt in topomap_montage_options %}
+                                                        <option value="{{ opt.value }}" {% if opt.value == 'standard_1005' %}selected{% endif %}>{{ opt.label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                            <div class="sm:col-span-3">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-eeg-ch-type">Channel type</label>
+                                                <select id="topomap-eeg-ch-type" name="topomap_eeg_ch_type"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary">
+                                                    {% for opt in topomap_channel_type_options %}
+                                                        <option value="{{ opt.value }}" {% if opt.value == 'eeg' %}selected{% endif %}>{{ opt.label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-position-y">Position offset Y</label>
+                                                <input id="topomap-position-y" name="topomap_position_y" type="text" value="0.01"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-position-z">Position offset Z</label>
+                                                <input id="topomap-position-z" name="topomap_position_z" type="text" value="-0.1"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-sphere">Sphere</label>
+                                                <input id="topomap-sphere" name="topomap_sphere" type="text" value="0.28"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-cmap">Colormap</label>
+                                                <select id="topomap-cmap" name="topomap_cmap"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary">
+                                                    {% for opt in topomap_colormap_options %}
+                                                        <option value="{{ opt.value }}" {% if opt.value == 'auto' %}selected{% endif %}>{{ opt.label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-vmin">vmin</label>
+                                                <input id="topomap-vmin" name="topomap_vmin" type="text" placeholder="auto"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-vmax">vmax</label>
+                                                <input id="topomap-vmax" name="topomap_vmax" type="text" placeholder="auto"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-res">Resolution</label>
+                                                <input id="topomap-res" name="topomap_res" type="text" value="300"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-contours">Contours</label>
+                                                <select id="topomap-contours" name="topomap_contours"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary">
+                                                    {% for opt in topomap_contour_options %}
+                                                        <option value="{{ opt.value }}">{{ opt.label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-outlines">Outlines</label>
+                                                <select id="topomap-outlines" name="topomap_outlines"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary">
+                                                    {% for opt in topomap_outline_options %}
+                                                        <option value="{{ opt.value }}">{{ opt.label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-extrapolate">Extrapolate</label>
+                                                <select id="topomap-extrapolate" name="topomap_extrapolate"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary">
+                                                    {% for opt in topomap_extrapolate_options %}
+                                                        <option value="{{ opt.value }}">{{ opt.label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                            <div class="sm:col-span-2">
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-image-interp">Image interpolation</label>
+                                                <select id="topomap-image-interp" name="topomap_image_interp"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary">
+                                                    {% for opt in topomap_image_interp_options %}
+                                                        <option value="{{ opt.value }}">{{ opt.label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                            <div class="sm:col-span-2 flex items-end">
+                                                <label class="flex items-center gap-2 text-xs font-medium text-slate-700 dark:text-slate-300">
+                                                    <input checked id="topomap-show-sensors" name="topomap_show_sensors" type="checkbox"
+                                                        class="h-4 w-4 rounded border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-primary focus:ring-primary dark:checked:bg-primary dark:checked:border-primary" />
+                                                    Show sensors
+                                                </label>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="sm:col-span-3" x-show="topomapSignalType === 'eeg'" x-cloak>
-                                    <label class="block text-sm font-medium leading-6 text-slate-900 dark:text-slate-300"
-                                        for="head-pos-x">Position of the head on the x-axis</label>
-                                    <div class="mt-2">
-                                        <input
-                                            class="block w-full rounded-md border-0 py-1.5 text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:ring-2 focus:ring-inset focus:ring-primary sm:text-sm sm:leading-6"
-                                            id="head-pos-x" name="head-pos-x" type="text" value="0.0" />
-                                    </div>
-                                </div>
-                                <div class="sm:col-span-3" x-show="topomapSignalType === 'eeg'" x-cloak>
-                                    <label class="block text-sm font-medium leading-6 text-slate-900 dark:text-slate-300"
-                                        for="electrode-size">Size of the electrodes</label>
-                                    <div class="mt-2">
-                                        <input
-                                            class="block w-full rounded-md border-0 py-1.5 text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:ring-2 focus:ring-inset focus:ring-primary sm:text-sm sm:leading-6"
-                                            id="electrode-size" name="electrode-size" type="text" value="0.6" />
-                                    </div>
-                                </div>
+
                                 <div class="sm:col-span-6">
                                     <div class="mt-2 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
                                         <h4 class="text-sm font-semibold text-slate-900 dark:text-slate-200">Colorbar options</h4>
@@ -2064,6 +2286,26 @@
                                                     <option value="section" selected>Same scale per column index</option>
                                                     <option value="plot">Independent scale per plot</option>
                                                 </select>
+                                            </div>
+                                            <div class="sm:col-span-2" x-show="topomapSignalType === 'eeg'" x-cloak>
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-colorbar-fmt">Tick format</label>
+                                                <input id="topomap-colorbar-fmt" name="topomap_colorbar_fmt" type="text" value="%0.2f"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                            </div>
+                                            <div class="sm:col-span-2" x-show="topomapSignalType === 'eeg'" x-cloak>
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-colorbar-label">Colorbar label</label>
+                                                <input id="topomap-colorbar-label" name="topomap_colorbar_label" type="text" placeholder="optional"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                            </div>
+                                            <div class="sm:col-span-1" x-show="topomapSignalType === 'eeg'" x-cloak>
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-colorbar-label-fontsize">Label size</label>
+                                                <input id="topomap-colorbar-label-fontsize" name="topomap_colorbar_label_fontsize" type="text" placeholder="auto"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
+                                            </div>
+                                            <div class="sm:col-span-1" x-show="topomapSignalType === 'eeg'" x-cloak>
+                                                <label class="block text-xs font-medium text-slate-700 dark:text-slate-300" for="topomap-colorbar-tick-fontsize">Tick size</label>
+                                                <input id="topomap-colorbar-tick-fontsize" name="topomap_colorbar_tick_fontsize" type="text" value="8"
+                                                    class="mt-2 block w-full rounded-md border-0 py-1.5 text-xs text-slate-900 dark:text-slate-300 dark:bg-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 dark:ring-slate-700 focus:ring-2 focus:ring-inset focus:ring-primary" />
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
This PR adds EEG topomap plotting support to the graphical Analysis interface and extends the topomap workflow with configurable plotting parameters, Cohen's d filtering, dropdown-based
  options, and plot configuration persistence.

  ## Changes

  ### `ncpi.Analysis.eeg_topomap`

  - Added `_make_eeg_info()` to build an MNE `Info` object from channel names and a standard montage.
  - Reworked `eeg_topomap()` to support:
    - direct values via `Series`, mapping, or array + channel names
    - dataframe-backed plotting through `sensor_col` and `data_col`
    - configurable `montage`, `ch_type`, `position_offset`, `sphere`, `res`, `cmap`, `vmin`, `vmax`, sensors, contours, outlines, extrapolation, and interpolation
    - manual colorbar handling with configurable format, label, and font sizes
    - all-zero plots using a greyscale map without colorbar
  - Preserved sensor ordering in `cohend()` by using `groupby(..., sort=False)`.

  ### Topomap backend route

  - Extended `/analysis/plot/topomap` to support EEG-specific options from the UI.
  - Added explicit sensor/channel column selection with auto-detection fallback.
  - Added support for user-provided `vmin`/`vmax`.
  - Added configurable colorbar options.
  - Added configurable montage, channel type, position offset, sphere, resolution, contours, outlines, extrapolate, interpolation, and sensor markers.
  - Added Cohen's d threshold filtering for group comparisons:
    - UI sends `topomap_cohend_abs_threshold`
    - backend applies `abs(d) >= threshold`
    - sensors below threshold are set to `0.0` so montage alignment is preserved
    - logs retained sensor counts per comparison/dimension
  - Avoids plotting empty Cohen's d series when all values are invalid.

  ### Analysis UI

  - Added topomap sensor column selector.
  - Added EEG topomap options panel.
  - Replaced free-text categorical parameters with dropdowns:
    - MNE montage list from `mne.channels.get_builtin_montages()`
    - channel type
    - colormap
    - contours
    - outlines
    - extrapolate
    - image interpolation
  - Added common Matplotlib colormap dropdowns, filtered against the installed Matplotlib colormaps.
  - Added Cohen's d threshold input, visible only for `Compare categories` + `Cohen's d`.
  - Added state binding for topomap comparison method.
  - Converted boxplot colormap to a dropdown for consistency.

  ### Plot configuration persistence

  - Added server-side plot configuration persistence for analysis plots.
  - Saves the submitted plot form together with the current dataframe signature:
    - real path
    - filename
    - file size
    - `mtime_ns`
  - Restores the previous plot configuration when returning with `Back to analysis`, but only if the same dataframe is still loaded.
  - Restores active tab, selected columns, comparison mode, topomap options, checkboxes, radios, selects, and text inputs.
  - Clears saved plot configuration when analysis data is cleared.
  - Fixed an Alpine `x-data` escaping issue caused by double quotes inside an attribute selector.
