### PR TITLE
Improve specparam and parser configuration UI

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -5479,6 +5479,8 @@ def _copy_parse_config(base_cfg, *, fields):
         max_seconds=base_cfg.max_seconds,
         drop_bads=base_cfg.drop_bads,
         zscore=base_cfg.zscore,
+        zscore_after_epoch=getattr(base_cfg, "zscore_after_epoch", False),
+        exclude_last_epoch=getattr(base_cfg, "exclude_last_epoch", False),
         aggregate_over=base_cfg.aggregate_over,
         aggregate_method=base_cfg.aggregate_method,
         aggregate_labels=base_cfg.aggregate_labels,
@@ -5954,6 +5956,8 @@ def _build_parse_config_from_form(form):
 
     data_source_kind = (form.get("data_source_kind") or "").strip()
     zscore = str(form.get("parser_zscore", "")).lower() in {"1", "true", "on", "yes"}
+    zscore_after_epoch = str(form.get("parser_zscore_after_epoch", "")).lower() in {"1", "true", "on", "yes"}
+    exclude_last_epoch = str(form.get("parser_exclude_last_epoch", "")).lower() in {"1", "true", "on", "yes"}
     epoching_enabled = str(form.get("parser_enable_epoching", "")).lower() in {"1", "true", "on", "yes"}
     aggregate_enabled = str(form.get("parser_enable_aggregate", "")).lower() in {"1", "true", "on", "yes"}
     epoch_length_s = _optional_float(form.get("parser_epoch_length_s")) if epoching_enabled else None
@@ -5994,6 +5998,10 @@ def _build_parse_config_from_form(form):
         if aggregate_method not in {"sum", "mean", "median"}:
             raise ValueError("Aggregate method must be one of: sum, mean, median.")
         aggregate_labels = _parse_aggregate_labels(form.get("parser_aggregate_labels"))
+        if aggregate_labels is None:
+            aggregate_label_value = (form.get("parser_aggregate_label_value") or "").strip()
+            if aggregate_label_value:
+                aggregate_labels = {str(dim): aggregate_label_value for dim in aggregate_over}
 
     fs_locator = (form.get("parser_fs_locator") or "").strip() or None
     fs_source = (form.get("parser_fs_source") or "").strip()
@@ -6177,6 +6185,8 @@ def _build_parse_config_from_form(form):
             segment_t0_s=segment_t0_s,
             segment_t1_s=segment_t1_s,
             zscore=zscore,
+            zscore_after_epoch=zscore_after_epoch,
+            exclude_last_epoch=exclude_last_epoch,
             aggregate_over=aggregate_over,
             aggregate_method=aggregate_method,
             aggregate_labels=aggregate_labels if aggregate_labels is not None else {"sensor": "aggregate"},
@@ -6215,6 +6225,8 @@ def _build_parse_config_from_form(form):
         segment_t0_s=segment_t0_s,
         segment_t1_s=segment_t1_s,
         zscore=zscore,
+        zscore_after_epoch=zscore_after_epoch,
+        exclude_last_epoch=exclude_last_epoch,
         aggregate_over=aggregate_over,
         aggregate_method=aggregate_method,
         aggregate_labels=aggregate_labels if aggregate_labels is not None else {"sensor": "aggregate"},

--- a/webui/compute_utils.py
+++ b/webui/compute_utils.py
@@ -2312,14 +2312,58 @@ def _build_feature_method_params(method, params, df):
         welch_kwargs = _parse_dict_param(params, "specparam_welch_kwargs") or {}
         nperseg = _parse_int_param(params, "specparam_welch_nperseg", default=None)
         noverlap = _parse_int_param(params, "specparam_welch_noverlap", default=None)
+        nfft = _parse_int_param(params, "specparam_welch_nfft", default=None)
+        window = _get_param(params, "specparam_welch_window", None)
+        detrend = _get_param(params, "specparam_welch_detrend", None)
+        scaling = _get_param(params, "specparam_welch_scaling", None)
+        average = _get_param(params, "specparam_welch_average", None)
         if nperseg is not None:
             welch_kwargs["nperseg"] = int(nperseg)
         if noverlap is not None:
             welch_kwargs["noverlap"] = int(noverlap)
+        if nfft is not None:
+            welch_kwargs["nfft"] = int(nfft)
+        if window:
+            welch_kwargs["window"] = str(window)
+        if detrend:
+            welch_kwargs["detrend"] = False if str(detrend) == "none" else str(detrend)
+        if scaling:
+            welch_kwargs["scaling"] = str(scaling)
+        if average:
+            welch_kwargs["average"] = str(average)
         if welch_kwargs:
             method_params["welch_kwargs"] = welch_kwargs
 
-        model_kwargs = _parse_dict_param(params, "specparam_model_kwargs")
+        model_kwargs = _parse_dict_param(params, "specparam_model_kwargs") or {}
+        peak_threshold = _parse_float_param(params, "specparam_model_peak_threshold", default=None)
+        min_peak_height = _parse_float_param(params, "specparam_model_min_peak_height", default=None)
+        max_n_peaks = _parse_int_param(params, "specparam_model_max_n_peaks", default=None)
+        peak_width_limits = _parse_range_pair(
+            params,
+            "specparam_model_peak_width_min",
+            "specparam_model_peak_width_max",
+        )
+        aperiodic_mode = _get_param(params, "specparam_model_aperiodic_mode", None)
+        verbose_value = _get_param(params, "specparam_model_verbose", None)
+        requested_metrics = []
+        if _parse_bool_param(params, "specparam_model_metric_gof_adjrsquared", default=False):
+            requested_metrics.append("gof_adjrsquared")
+        if _parse_bool_param(params, "specparam_model_metric_error_mse", default=False):
+            requested_metrics.append("error_mse")
+        if peak_threshold is not None:
+            model_kwargs["peak_threshold"] = float(peak_threshold)
+        if min_peak_height is not None:
+            model_kwargs["min_peak_height"] = float(min_peak_height)
+        if max_n_peaks is not None:
+            model_kwargs["max_n_peaks"] = int(max_n_peaks)
+        if peak_width_limits is not None:
+            model_kwargs["peak_width_limits"] = tuple(peak_width_limits)
+        if aperiodic_mode:
+            model_kwargs["aperiodic_mode"] = str(aperiodic_mode)
+        if verbose_value:
+            model_kwargs["verbose"] = _parse_bool(verbose_value, default=False)
+        if requested_metrics:
+            model_kwargs["metrics"] = requested_metrics
         if model_kwargs:
             method_params["model_kwargs"] = model_kwargs
 
@@ -2331,6 +2375,11 @@ def _build_feature_method_params(method, params, df):
         gof_r2 = _parse_float_param(params, "specparam_threshold_gof_rsquared", default=None)
         if gof_r2 is not None:
             thresholds["gof_rsquared"] = float(gof_r2)
+        for idx in range(1, 4):
+            threshold_name = _get_param(params, f"specparam_threshold_metric_{idx}_name", None)
+            threshold_value = _parse_float_param(params, f"specparam_threshold_metric_{idx}_value", default=None)
+            if threshold_name and threshold_value is not None:
+                thresholds[str(threshold_name)] = float(threshold_value)
         if thresholds:
             method_params["metric_thresholds"] = thresholds
 
@@ -2344,6 +2393,171 @@ def _build_feature_method_params(method, params, df):
         "chunksize": chunksize,
         "start_method": start_method,
     }
+
+
+_SPECPARAM_OUTPUT_PATHS = {
+    "aperiodic_exponent": "aperiodic_params.1",
+    "aperiodic_offset": "aperiodic_params.0",
+    "peak_cf": "peak_cf",
+    "peak_pw": "peak_pw",
+    "peak_bw": "peak_bw",
+    "n_peaks": "n_peaks",
+    "gof_rsquared": "metrics.gof_rsquared",
+    "gof_adjrsquared": "metrics.gof_adjrsquared",
+    "error_mse": "metrics.error_mse",
+    "valid": "valid",
+}
+
+
+def _is_missing_feature_value(value):
+    if value is None:
+        return True
+    if isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, float):
+        return not np.isfinite(value)
+    if isinstance(value, np.ndarray):
+        arr = np.asarray(value)
+        if arr.ndim == 0:
+            return _is_missing_feature_value(arr.item())
+        return False
+    try:
+        missing = pd.isna(value)
+    except Exception:
+        return False
+    if isinstance(missing, (bool, np.bool_)):
+        return bool(missing)
+    return False
+
+
+def _coerce_feature_value(value):
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        arr = np.asarray(value).squeeze()
+        if arr.ndim == 0:
+            return arr.item()
+        return arr
+    return value
+
+
+def _get_specparam_path_value(feature, path):
+    if not isinstance(feature, MappingABC):
+        return np.nan
+    current = feature
+    for part in str(path or "").split("."):
+        if part == "":
+            return np.nan
+        if isinstance(current, MappingABC):
+            if part not in current:
+                return np.nan
+            current = current.get(part)
+            continue
+        if isinstance(current, (list, tuple, np.ndarray)) and part.isdigit():
+            arr = np.asarray(current).squeeze()
+            idx = int(part)
+            if idx < 0 or idx >= arr.size:
+                return np.nan
+            current = arr.reshape(-1)[idx]
+            continue
+        return np.nan
+    return _coerce_feature_value(current)
+
+
+def _get_specparam_exponent(feature):
+    value = _get_specparam_path_value(feature, "aperiodic_params.1")
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return np.nan
+    return value if np.isfinite(value) else np.nan
+
+
+def _is_valid_specparam_feature(feature):
+    if isinstance(feature, MappingABC):
+        if "valid" in feature:
+            return bool(feature.get("valid"))
+        return np.isfinite(_get_specparam_exponent(feature))
+    return not _is_missing_feature_value(feature)
+
+
+def _specparam_output_path_from_params(params):
+    output_key = str(_get_param(params, "specparam_output_key", "full_dict") or "full_dict").strip()
+    if output_key in {"", "full", "dict", "full_dict"}:
+        return "full_dict", None
+    if output_key == "custom":
+        custom_path = str(_get_param(params, "specparam_output_path", "") or "").strip()
+        if not custom_path:
+            raise ValueError("Custom specparam output requires a non-empty output path.")
+        return output_key, custom_path
+    if output_key not in _SPECPARAM_OUTPUT_PATHS:
+        raise ValueError(f"Unsupported specparam output value: {output_key}")
+    return output_key, _SPECPARAM_OUTPUT_PATHS[output_key]
+
+
+def _postprocess_specparam_output(output_df, params, job_status=None, job_id=None):
+    if "Features" not in output_df.columns:
+        return output_df
+
+    def _log(message):
+        if job_status is not None and job_id is not None:
+            _append_job_output(job_status, job_id, message)
+
+    output_key, output_path = _specparam_output_path_from_params(params)
+    drop_invalid = _parse_bool_param(params, "specparam_drop_invalid_rows", default=False)
+    reject_nonpositive_exponent = _parse_bool_param(
+        params,
+        "specparam_reject_nonpositive_exponent",
+        default=False,
+    )
+
+    features = list(output_df["Features"].tolist())
+    fit_valid = pd.Series(
+        [_is_valid_specparam_feature(feature) for feature in features],
+        index=output_df.index,
+        dtype=bool,
+    )
+    exponent = pd.Series(
+        [_get_specparam_exponent(feature) for feature in features],
+        index=output_df.index,
+        dtype="float64",
+    )
+
+    if output_path is not None:
+        values = [_get_specparam_path_value(feature, output_path) for feature in features]
+        if reject_nonpositive_exponent and output_path == "aperiodic_params.1":
+            values = [
+                np.nan if (not np.isfinite(exp_value) or exp_value <= 0.0) else value
+                for value, exp_value in zip(values, exponent.tolist())
+            ]
+        output_df = output_df.copy()
+        output_df["Features"] = values
+        _log(f"Specparam output field selected: {output_path}.")
+
+    if drop_invalid:
+        keep_mask = fit_valid.copy()
+        if output_path is not None:
+            output_missing = output_df["Features"].map(_is_missing_feature_value)
+            keep_mask &= ~output_missing
+        if reject_nonpositive_exponent:
+            keep_mask &= exponent.gt(0.0).fillna(False)
+        rows_before = int(len(output_df))
+        output_df = output_df.loc[keep_mask].reset_index(drop=True)
+        rows_after = int(len(output_df))
+        _log(f"Specparam post-processing dropped {rows_before - rows_after} invalid/NaN row(s).")
+    elif reject_nonpositive_exponent and output_path != "aperiodic_params.1":
+        _log(
+            "Specparam non-positive exponent rejection is only applied to row dropping, "
+            "or when the selected output is aperiodic exponent."
+        )
+
+    return output_df
+
+
+def _postprocess_features_output(method, output_df, params, job_status=None, job_id=None):
+    if method == "specparam":
+        return _postprocess_specparam_output(output_df, params, job_status, job_id)
+    return output_df
 
 
 
@@ -2898,6 +3112,7 @@ def features_computation(job_id, job_status, params, temp_uploaded_files):
 
         _append_job_output(job_status, job_id, "Attaching computed features to dataframe.")
         output_df["FeatureMethod"] = method
+        output_df = _postprocess_features_output(method, output_df, params, job_status, job_id)
 
         # By default, persist features into the same parsed dataframe pickle.
         input_df_path = params['file_paths'].get('data_file')

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -143,10 +143,13 @@
             parserSegmentT0S: '',
             parserSegmentT1S: '',
             parserZscore: false,
+            parserZscoreAfterEpoch: false,
+            parserExcludeLastEpoch: false,
             parserEnableAggregate: false,
             parserAggregateOverSelected: ['sensor'],
             parserAggregateMethod: 'sum',
             parserAggregateLabels: '',
+            parserAggregateLabelValue: '',
             selectedMethod: '',
             submitInProgress: false,
             uploadProgress: 0,
@@ -287,10 +290,13 @@
                     'parserSegmentT0S',
                     'parserSegmentT1S',
                     'parserZscore',
+                    'parserZscoreAfterEpoch',
+                    'parserExcludeLastEpoch',
                     'parserEnableAggregate',
                     'parserAggregateOverSelected',
                     'parserAggregateMethod',
                     'parserAggregateLabels',
+                    'parserAggregateLabelValue',
                     'submitError',
                 ];
             },
@@ -1895,10 +1901,13 @@
                 this.parserSegmentT0S = '';
                 this.parserSegmentT1S = '';
                 this.parserZscore = false;
+                this.parserZscoreAfterEpoch = false;
+                this.parserExcludeLastEpoch = false;
                 this.parserEnableAggregate = false;
                 this.parserAggregateOverSelected = ['sensor'];
                 this.parserAggregateMethod = 'sum';
                 this.parserAggregateLabels = '';
+                this.parserAggregateLabelValue = '';
                 this.parserAnalysisFolderPaths = [];
                 this.parserAnalysisFolderNames = [];
                 this.simulationFolderExtensionError = '';
@@ -3052,6 +3061,8 @@
                         lines.push(`    epoch_step_s=${epochStep},`);
                     }
                     lines.push(`    zscore=${this.parserZscore ? 'True' : 'False'},`);
+                    lines.push(`    zscore_after_epoch=${this.parserZscoreAfterEpoch ? 'True' : 'False'},`);
+                    lines.push(`    exclude_last_epoch=${this.parserExcludeLastEpoch ? 'True' : 'False'},`);
                     if (this.parserEnableAggregate) {
                         const aggDims = (this.parserAggregateOverSelected || [])
                             .map((item) => String(item || '').trim())
@@ -3059,7 +3070,11 @@
                         if (aggDims.length > 0) {
                             lines.push(`    aggregate_over=(${aggDims.map((d) => `'${d}'`).join(', ')}${aggDims.length === 1 ? ',' : ''}),`);
                             lines.push(`    aggregate_method='${this.parserAggregateMethod || 'sum'}',`);
-                            if ((this.parserAggregateLabels || '').trim()) {
+                            const aggregateLabelValue = String(this.parserAggregateLabelValue || '').trim();
+                            if (aggregateLabelValue) {
+                                const labelEntries = aggDims.map((d) => `${toPyString(d)}: ${toPyString(aggregateLabelValue)}`);
+                                lines.push(`    aggregate_labels={${labelEntries.join(', ')}},`);
+                            } else if ((this.parserAggregateLabels || '').trim()) {
                                 lines.push(`    aggregate_labels=${this.parserAggregateLabels},`);
                             }
                         }
@@ -3149,6 +3164,8 @@
                     lines.push(`    epoch_step_s=${epochStep},`);
                 }
                 lines.push(`    zscore=${zscoreFlag},`);
+                lines.push(`    zscore_after_epoch=${this.parserZscoreAfterEpoch ? 'True' : 'False'},`);
+                lines.push(`    exclude_last_epoch=${this.parserExcludeLastEpoch ? 'True' : 'False'},`);
                 if (this.parserEnableAggregate) {
                     const aggDims = (this.parserAggregateOverSelected || [])
                         .map((item) => String(item || '').trim())
@@ -3156,7 +3173,11 @@
                     if (aggDims.length > 0) {
                         lines.push(`    aggregate_over=(${aggDims.map((d) => `'${d}'`).join(', ')}${aggDims.length === 1 ? ',' : ''}),`);
                         lines.push(`    aggregate_method='${this.parserAggregateMethod || 'sum'}',`);
-                        if ((this.parserAggregateLabels || '').trim()) {
+                        const aggregateLabelValue = String(this.parserAggregateLabelValue || '').trim();
+                        if (aggregateLabelValue) {
+                            const labelEntries = aggDims.map((d) => `${toPyString(d)}: ${toPyString(aggregateLabelValue)}`);
+                            lines.push(`    aggregate_labels={${labelEntries.join(', ')}},`);
+                        } else if ((this.parserAggregateLabels || '').trim()) {
                             lines.push(`    aggregate_labels=${this.parserAggregateLabels},`);
                         }
                     }
@@ -4515,6 +4536,11 @@
                                             class="rounded border-gray-300 text-primary focus:ring-primary/50">
                                         Apply z-score normalization
                                     </label>
+                                    <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-300">
+                                        <input type="checkbox" x-model="parserZscoreAfterEpoch"
+                                            class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                        Apply z-score after epoching
+                                    </label>
 
                                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                         <label class="text-sm">
@@ -4779,6 +4805,11 @@
                                         class="rounded border-gray-300 text-primary focus:ring-primary/50">
                                     Apply z-score normalization
                                 </label>
+                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-300">
+                                    <input type="checkbox" x-model="parserZscoreAfterEpoch"
+                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                    Apply z-score after epoching
+                                </label>
 
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                     <label class="text-sm">
@@ -4870,10 +4901,10 @@
                                         </select>
                                     </label>
                                     <label class="text-sm">
-                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Aggregate labels (dict)</span>
-                                        <input type="text" name="parser_aggregate_labels" x-model="parserAggregateLabels"
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Aggregate output label</span>
+                                        <input type="text" name="parser_aggregate_label_value" x-model="parserAggregateLabelValue"
                                             class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                            placeholder="e.g. {'sensor': 'all'}">
+                                            placeholder="Optional, e.g. all">
                                     </label>
                                 </div>
 
@@ -4889,7 +4920,14 @@
                                             class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                     </label>
                                 </div>
+                                <label x-show="parserEnableEpoching" x-cloak class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-300">
+                                    <input type="checkbox" x-model="parserExcludeLastEpoch"
+                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                    Exclude last epoch
+                                </label>
                                 <input type="hidden" name="parser_zscore" :value="parserZscore ? '1' : '0'">
+                                <input type="hidden" name="parser_zscore_after_epoch" :value="parserZscoreAfterEpoch ? '1' : '0'">
+                                <input type="hidden" name="parser_exclude_last_epoch" :value="parserExcludeLastEpoch ? '1' : '0'">
                             </div>
                         </template>
                     </div>
@@ -5022,6 +5060,12 @@
 
                         <section x-show="selectedMethod === 'specparam'" class="bg-white dark:bg-[#111422] border border-gray-200 dark:border-[#323b67] rounded-xl p-6 space-y-5">
                             <h2 class="text-lg font-semibold text-[#34495E] dark:text-white">specparam options</h2>
+                            <div class="space-y-4">
+                                <div class="flex items-center gap-2 border-b border-slate-200 dark:border-[#323b67] pb-2">
+                                    <span class="material-symbols-outlined text-base text-primary">tune</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Core setup</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Set the signal sampling rate, peak selection strategy, and frequency band used for fitting.</p>
                             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 <label class="text-sm">
                                     <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Sampling frequency (Hz)</span>
@@ -5052,7 +5096,14 @@
                                         class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                 </label>
                             </div>
+                            </div>
 
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5 pl-4 border-l-2 border-l-cyan-500/70">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-cyan-600 dark:text-cyan-300">graphic_eq</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Welch setup</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Configure how the power spectrum is estimated from each time-series sample before specparam fitting.</p>
                             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 <label class="text-sm">
                                     <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Welch nperseg</span>
@@ -5068,21 +5119,143 @@
                                 </label>
                             </div>
 
-                            <div class="grid grid-cols-1 gap-4">
+                            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                                 <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Welch kwargs (JSON/dict)</span>
-                                    <textarea name="specparam_welch_kwargs" rows="2"
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Welch nfft</span>
+                                    <input type="number" step="1" min="1" name="specparam_welch_nfft"
                                         class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="e.g. {'detrend': 'constant'}"></textarea>
+                                        placeholder="Optional">
                                 </label>
                                 <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">SpectralModel kwargs (JSON/dict)</span>
-                                    <textarea name="specparam_model_kwargs" rows="2"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="e.g. {'peak_width_limits': [1, 8], 'max_n_peaks': 6}"></textarea>
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Welch window</span>
+                                    <select name="specparam_welch_window"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <option value="">Default</option>
+                                        <option value="hann">hann</option>
+                                        <option value="hamming">hamming</option>
+                                        <option value="blackman">blackman</option>
+                                        <option value="bartlett">bartlett</option>
+                                        <option value="boxcar">boxcar</option>
+                                        <option value="flattop">flattop</option>
+                                    </select>
+                                </label>
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Welch detrend</span>
+                                    <select name="specparam_welch_detrend"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <option value="">Default</option>
+                                        <option value="constant">constant</option>
+                                        <option value="linear">linear</option>
+                                        <option value="none">none</option>
+                                    </select>
                                 </label>
                             </div>
 
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Welch scaling</span>
+                                    <select name="specparam_welch_scaling"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <option value="">Default</option>
+                                        <option value="density">density</option>
+                                        <option value="spectrum">spectrum</option>
+                                    </select>
+                                </label>
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Welch average</span>
+                                    <select name="specparam_welch_average"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <option value="">Default</option>
+                                        <option value="mean">mean</option>
+                                        <option value="median">median</option>
+                                    </select>
+                                </label>
+                            </div>
+                            </div>
+
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-indigo-600 dark:text-indigo-300">stacked_line_chart</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">SpectralModel</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Control peak detection, aperiodic mode, and optional fit metrics reported by the model.</p>
+                            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Peak threshold</span>
+                                    <input type="number" step="any" name="specparam_model_peak_threshold"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                        placeholder="Optional">
+                                </label>
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Min peak height</span>
+                                    <input type="number" step="any" name="specparam_model_min_peak_height"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                        placeholder="Optional">
+                                </label>
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Max number of peaks</span>
+                                    <input type="number" step="1" min="0" name="specparam_model_max_n_peaks"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                        placeholder="Optional">
+                                </label>
+                            </div>
+
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Peak width min</span>
+                                    <input type="number" step="any" min="0" name="specparam_model_peak_width_min"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                        placeholder="Optional">
+                                </label>
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Peak width max</span>
+                                    <input type="number" step="any" min="0" name="specparam_model_peak_width_max"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                        placeholder="Optional">
+                                </label>
+                            </div>
+
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Aperiodic mode</span>
+                                    <select name="specparam_model_aperiodic_mode"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <option value="">Default</option>
+                                        <option value="fixed">fixed</option>
+                                        <option value="knee">knee</option>
+                                    </select>
+                                </label>
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Model verbose</span>
+                                    <select name="specparam_model_verbose"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <option value="">Default</option>
+                                        <option value="false">false</option>
+                                        <option value="true">true</option>
+                                    </select>
+                                </label>
+                            </div>
+
+                            <div class="flex flex-wrap gap-5">
+                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
+                                    <input type="checkbox" name="specparam_model_metric_gof_adjrsquared" value="1"
+                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                    Include gof_adjrsquared
+                                </label>
+                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
+                                    <input type="checkbox" name="specparam_model_metric_error_mse" value="1"
+                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                    Include error_mse
+                                </label>
+                            </div>
+                            </div>
+
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-emerald-600 dark:text-emerald-300">rule</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Quality filters</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Choose which fit-quality thresholds mark results as invalid or remove them from the final dataframe.</p>
                             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 <label class="text-sm">
                                     <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Metric policy</span>
@@ -5100,12 +5273,57 @@
                                 </label>
                             </div>
 
-                            <label class="text-sm block">
-                                <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Additional metric thresholds (JSON/dict)</span>
-                                <textarea name="specparam_metric_thresholds" rows="2"
-                                    class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                    placeholder="e.g. {'gof_rsquared': 0.95}"></textarea>
-                            </label>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Additional threshold metric</span>
+                                    <select name="specparam_threshold_metric_1_name"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <option value="">None</option>
+                                        <option value="gof_adjrsquared">gof_adjrsquared</option>
+                                        <option value="error_mse">error_mse</option>
+                                    </select>
+                                </label>
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Additional threshold value</span>
+                                    <input type="number" step="any" name="specparam_threshold_metric_1_value"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                        placeholder="Optional">
+                                </label>
+                            </div>
+                            </div>
+
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-violet-600 dark:text-violet-300">save</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Saved output</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Select whether to store the full specparam dictionary or one extracted value in the Features column.</p>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Saved output value</span>
+                                    <select name="specparam_output_key"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <option value="full_dict">Full specparam dictionary</option>
+                                        <option value="aperiodic_exponent">Aperiodic exponent</option>
+                                        <option value="aperiodic_offset">Aperiodic offset</option>
+                                        <option value="peak_cf">Selected peak CF</option>
+                                        <option value="peak_pw">Selected peak PW</option>
+                                        <option value="peak_bw">Selected peak BW</option>
+                                        <option value="n_peaks">Number of peaks</option>
+                                        <option value="gof_rsquared">Metric: gof_rsquared</option>
+                                        <option value="gof_adjrsquared">Metric: gof_adjrsquared</option>
+                                        <option value="error_mse">Metric: error_mse</option>
+                                        <option value="valid">Valid flag</option>
+                                        <option value="custom">Custom path</option>
+                                    </select>
+                                </label>
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Custom output path</span>
+                                    <input type="text" name="specparam_output_path"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                        placeholder="e.g. metrics.gof_rsquared or aperiodic_params.1">
+                                </label>
+                            </div>
 
                             <div class="flex flex-wrap gap-5">
                                 <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
@@ -5118,6 +5336,17 @@
                                         class="rounded border-gray-300 text-primary focus:ring-primary/50">
                                     Normalize each sample
                                 </label>
+                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
+                                    <input type="checkbox" name="specparam_drop_invalid_rows" value="1"
+                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                    Drop invalid/NaN feature rows
+                                </label>
+                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
+                                    <input type="checkbox" name="specparam_reject_nonpositive_exponent" value="1"
+                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                    Reject non-positive exponent
+                                </label>
+                            </div>
                             </div>
                         </section>
 


### PR DESCRIPTION
This PR improves the web UI configuration for parser and specparam feature extraction.

  ## Changes

  - Added parser options for:
    - z-score after epoching
    - excluding the last epoch

  - Expanded specparam configuration with explicit UI controls for:
    - Welch setup
    - SpectralModel parameters
    - fit-quality filters
    - saved output selection

  - Added support for saving selected specparam outputs directly in `Features`, including:
    - aperiodic exponent
    - aperiodic offset
    - selected peak values
    - number of peaks
    - fit metrics
    - validity flag

  - Added post-processing options for:
    - dropping invalid or NaN feature rows
    - rejecting non-positive aperiodic exponents

  - Replaced dictionary-style inputs in the UI with clearer form fields for common parameters.

  - Improved the visual organization of the specparam configuration panel.
