### PR TITLE
bug fix: keep parser folder path/name selections exclusive

### DIFF
--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -1734,12 +1734,19 @@ def custom_feature(sample, params):
                 const currentPath = availablePaths.find((path) => currentPaths.includes(path)) || '';
                 const currentName = availableNames.find((name) => currentNames.includes(name)) || '';
 
-                this.parserAnalysisFolderPaths = currentPath
-                    ? [currentPath]
-                    : (availablePaths.length > 0 ? [availablePaths[0]] : []);
-                this.parserAnalysisFolderNames = currentName
-                    ? [currentName]
-                    : (availableNames.length > 0 ? [availableNames[0]] : []);
+                const selectedToken = currentPath
+                    ? { type: 'path', value: currentPath }
+                    : (currentName
+                        ? { type: 'name', value: currentName }
+                        : (availablePaths.length > 0
+                            ? { type: 'path', value: availablePaths[0] }
+                            : (availableNames.length > 0
+                                ? { type: 'name', value: availableNames[0] }
+                                : null)));
+
+                // Path and name tokens must stay mutually exclusive when data folders are mixed with metadata files.
+                this.parserAnalysisFolderPaths = selectedToken?.type === 'path' ? [selectedToken.value] : [];
+                this.parserAnalysisFolderNames = selectedToken?.type === 'name' ? [selectedToken.value] : [];
                 this.ensureDataLocatorMatchesSelectedFolder();
                 this.syncAdditionalFileSourceModeWithDataSource();
             },


### PR DESCRIPTION
Fixes a WebUI Features parser state bug where folder selections could retain both path-based and name-based tokens after changing data/metadata sources.

## Changes

- Keeps `parserAnalysisFolderPaths` and `parserAnalysisFolderNames` mutually exclusive.
- Preserves the current valid selection when possible.
- Falls back to the first available path or name token when no current selection is valid.
- Prevents stale mixed folder state from affecting parser configuration.