### PR TITLE
Fix parser grouping with list data

### DIFF
--- a/ncpi/EphysDatasetParser.py
+++ b/ncpi/EphysDatasetParser.py
@@ -2803,7 +2803,8 @@ class EphysDatasetParser:
             ]
             if col in df.columns and not df[col].isna().all()
         ]
-        grouped = df.groupby(group_cols, sort=False, dropna=False) if group_cols else [(None, df)]
+        grouped_df, group_cols = self._with_hashable_group_columns(df, group_cols)
+        grouped = grouped_df.groupby(group_cols, sort=False, dropna=False) if group_cols else [(None, df)]
         any_incomplete_group = False
         drop_indices = []
         for _, frame in grouped:
@@ -2852,6 +2853,7 @@ class EphysDatasetParser:
             ]
             if col in df.columns and not df[col].isna().all()
         ]
+        grouped_df, group_cols = self._with_hashable_group_columns(df, group_cols)
 
         # Fast numeric path for common epoch labels produced by parser epoching.
         # This avoids per-group Python loops on large non-aggregated datasets.
@@ -2872,7 +2874,9 @@ class EphysDatasetParser:
             # clipping by the smallest per-group max epoch index.
             if group_cols:
                 per_group_max = (
-                    df_fast.groupby(group_cols, sort=False, dropna=False)["_epoch_num"].max()
+                    df_fast.assign(**grouped_df[group_cols])
+                    .groupby(group_cols, sort=False, dropna=False)["_epoch_num"]
+                    .max()
                 )
             else:
                 per_group_max = pd.Series([float(df_fast["_epoch_num"].max())])
@@ -2925,7 +2929,7 @@ class EphysDatasetParser:
                 values.append(value)
             return sorted(values, key=epoch_sort_key)
 
-        grouped = df.groupby(group_cols, sort=False, dropna=False) if group_cols else [(None, df)]
+        grouped = grouped_df.groupby(group_cols, sort=False, dropna=False) if group_cols else [(None, df)]
         num_groups_with_epochs = 0
         min_count = None
         max_count = 0
@@ -2947,7 +2951,7 @@ class EphysDatasetParser:
             return df
 
         drop_indices = []
-        grouped = df.groupby(group_cols, sort=False, dropna=False) if group_cols else [(None, df)]
+        grouped = grouped_df.groupby(group_cols, sort=False, dropna=False) if group_cols else [(None, df)]
         for _, frame in grouped:
             values = ordered_epoch_values(frame)
             if not values:
@@ -2968,6 +2972,36 @@ class EphysDatasetParser:
             RuntimeWarning,
         )
         return df.drop(index=list(set(drop_indices))).reset_index(drop=True)
+
+    def _with_hashable_group_columns(self, df: "Any", group_cols: list[str]) -> tuple["Any", list[str]]:
+        """Return a view-like copy whose group columns can be used by pandas.groupby."""
+        if not group_cols:
+            return df, group_cols
+
+        def make_hashable(value):
+            if self._is_missing_value(value):
+                return value
+            if isinstance(value, np.ndarray):
+                return tuple(make_hashable(v) for v in value.tolist())
+            if isinstance(value, list):
+                return tuple(make_hashable(v) for v in value)
+            if isinstance(value, tuple):
+                return tuple(make_hashable(v) for v in value)
+            if isinstance(value, dict):
+                return tuple(
+                    (make_hashable(k), make_hashable(v))
+                    for k, v in sorted(value.items(), key=lambda item: str(item[0]))
+                )
+            try:
+                hash(value)
+            except TypeError:
+                return repr(value)
+            return value
+
+        out = df.copy()
+        for col in group_cols:
+            out[col] = out[col].map(make_hashable)
+        return out, group_cols
 
     def _is_missing_value(self, value: Any) -> bool:
         if value is None:

--- a/tests/EphysDatasetParser/test_EphysDatasetParser.py
+++ b/tests/EphysDatasetParser/test_EphysDatasetParser.py
@@ -495,6 +495,30 @@ def test_aggregation_over_sensor_mean() -> None:
     assert np.allclose(x, np.array([5.5, 11.0, 16.5]))
 
 
+@pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
+def test_exclude_incomplete_final_epoch_accepts_list_metadata() -> None:
+    parser = EphysDatasetParser(ParseConfig())
+    df = pd.DataFrame(
+        {
+            "source_file": ["sample.mat"] * 3,
+            "subject_id": ["S01"] * 3,
+            "group": [["AD"], ["AD"], ["AD"]],
+            "condition": [["eyes_closed"], ["eyes_closed"], ["eyes_closed"]],
+            "sensor": ["Cz", "Cz", "Cz"],
+            "fs": [250.0, 250.0, 250.0],
+            "data_domain": ["time", "time", "time"],
+            "epoch": [0, 1, 2],
+            "data": [np.arange(100), np.arange(100), np.arange(40)],
+        }
+    )
+
+    out = parser._exclude_incomplete_final_epoch(df)
+
+    assert out["epoch"].tolist() == [0, 1]
+    assert out["group"].tolist() == [["AD"], ["AD"]]
+    assert out["condition"].tolist() == [["eyes_closed"], ["eyes_closed"]]
+
+
 # -------------------------
 # MNE smoke (if installed)
 # -------------------------


### PR DESCRIPTION
## Summary

- Fix parser failure when grouping metadata columns contain list values.
- Convert non-hashable grouping values only during internal `groupby` operations.
- Add a regression test for list metadata with incomplete final epoch detection.
