### PR TITLE
Improve WebUI DFA and fEI configuration

### DIFF
--- a/webui/compute_utils.py
+++ b/webui/compute_utils.py
@@ -2451,6 +2451,15 @@ def _parse_range_pair(params, min_key, max_key):
     return [float(lo), float(hi)]
 
 
+def _validate_fit_interval_inside_compute(label, fit_interval, compute_interval):
+    if fit_interval is None or compute_interval is None:
+        return
+    fit_lo, fit_hi = fit_interval
+    compute_lo, compute_hi = compute_interval
+    if fit_lo < compute_lo or fit_hi > compute_hi:
+        raise ValueError(f"{label}: fit interval must be inside compute interval.")
+
+
 def _parse_optional_bool_param(params, key):
     raw = _get_param(params, key, None)
     if raw is None:
@@ -2779,21 +2788,28 @@ def _build_feature_method_params(method, params, df):
         method_params["normalize"] = _parse_bool_param(params, "dfa_normalize", default=False)
         method_params["sampling_frequency"] = _resolve_sampling_frequency(params, "dfa_fs", df, "dfa")
 
+        input_is_envelope = _parse_optional_bool_param(params, "dfa_input_is_envelope")
+        input_is_envelope = False if input_is_envelope is None else bool(input_is_envelope)
         fit_interval = _parse_range_pair(params, "dfa_fit_interval_min", "dfa_fit_interval_max")
         compute_interval = _parse_range_pair(params, "dfa_compute_interval_min", "dfa_compute_interval_max")
-        frequency_range = _parse_range_pair(params, "dfa_frequency_min", "dfa_frequency_max")
-        spectrum_range = _parse_range_pair(params, "dfa_spectrum_min", "dfa_spectrum_max")
-        if frequency_range is not None and spectrum_range is not None:
-            raise ValueError("DFA: provide only one of band frequency range or spectrum range.")
-        if frequency_range is None and spectrum_range is None:
-            frequency_range = (5.0, 45.0)
+        _validate_fit_interval_inside_compute("DFA", fit_interval, compute_interval)
+
+        if input_is_envelope:
+            frequency_range = None
+            spectrum_range = None
+        else:
+            frequency_range = _parse_range_pair(params, "dfa_frequency_min", "dfa_frequency_max")
+            spectrum_range = _parse_range_pair(params, "dfa_spectrum_min", "dfa_spectrum_max")
+            if frequency_range is not None and spectrum_range is not None:
+                raise ValueError("DFA: provide only one of band frequency range or spectrum range.")
+            if frequency_range is None and spectrum_range is None:
+                raise ValueError("DFA: raw-signal mode requires band frequency range or spectrum range.")
 
         overlap = _parse_optional_bool_param(params, "dfa_overlap")
-        input_is_envelope = _parse_optional_bool_param(params, "dfa_input_is_envelope")
         bad_idxes = _parse_idx_list_param(params, "dfa_bad_idxes")
-        filter_kwargs = _parse_dict_param(params, "dfa_filter_kwargs")
+        filter_kwargs = None if input_is_envelope else _parse_dict_param(params, "dfa_filter_kwargs")
         trim_seconds = _parse_float_param(params, "dfa_trim_seconds", default=None)
-        hilbert_n_fft = _parse_int_param(params, "dfa_hilbert_n_fft", default=None)
+        hilbert_n_fft = None if input_is_envelope else _parse_int_param(params, "dfa_hilbert_n_fft", default=None)
 
         if fit_interval is not None:
             method_params["fit_interval"] = tuple(fit_interval)
@@ -2805,8 +2821,7 @@ def _build_feature_method_params(method, params, df):
             method_params["spectrum_range"] = tuple(spectrum_range)
         if overlap is not None:
             method_params["overlap"] = bool(overlap)
-        if input_is_envelope is not None:
-            method_params["input_is_envelope"] = bool(input_is_envelope)
+        method_params["input_is_envelope"] = bool(input_is_envelope)
         if bad_idxes is not None:
             method_params["bad_idxes"] = bad_idxes
         if filter_kwargs:
@@ -2822,23 +2837,31 @@ def _build_feature_method_params(method, params, df):
         method_params["normalize"] = _parse_bool_param(params, "fei_normalize", default=False)
         method_params["sampling_frequency"] = _resolve_sampling_frequency(params, "fei_fs", df, "fEI")
 
-        frequency_range = _parse_range_pair(params, "fei_frequency_min", "fei_frequency_max")
-        spectrum_range = _parse_range_pair(params, "fei_spectrum_min", "fei_spectrum_max")
-        if frequency_range is not None and spectrum_range is not None:
-            raise ValueError("fEI: provide only one of band frequency range or spectrum range.")
+        input_is_envelope = _parse_optional_bool_param(params, "fei_input_is_envelope")
+        input_is_envelope = False if input_is_envelope is None else bool(input_is_envelope)
+        if input_is_envelope:
+            frequency_range = None
+            spectrum_range = None
+        else:
+            frequency_range = _parse_range_pair(params, "fei_frequency_min", "fei_frequency_max")
+            spectrum_range = _parse_range_pair(params, "fei_spectrum_min", "fei_spectrum_max")
+            if frequency_range is not None and spectrum_range is not None:
+                raise ValueError("fEI: provide only one of band frequency range or spectrum range.")
+            if frequency_range is None and spectrum_range is None:
+                raise ValueError("fEI: raw-signal mode requires band frequency range or spectrum range.")
 
         dfa_fit_interval = _parse_range_pair(params, "fei_dfa_fit_interval_min", "fei_dfa_fit_interval_max")
         dfa_compute_interval = _parse_range_pair(params, "fei_dfa_compute_interval_min", "fei_dfa_compute_interval_max")
+        _validate_fit_interval_inside_compute("fEI DFA", dfa_fit_interval, dfa_compute_interval)
+
         window_size_sec = _parse_float_param(params, "fei_window_size_sec", default=None)
         window_overlap = _parse_float_param(params, "fei_window_overlap", default=None)
-        dfa_value = _parse_float_param(params, "fei_dfa_value", default=None)
         dfa_threshold = _parse_float_param(params, "fei_dfa_threshold", default=None)
         dfa_overlap = _parse_optional_bool_param(params, "fei_dfa_overlap")
-        input_is_envelope = _parse_optional_bool_param(params, "fei_input_is_envelope")
         bad_idxes = _parse_idx_list_param(params, "fei_bad_idxes")
-        filter_kwargs = _parse_dict_param(params, "fei_filter_kwargs")
+        filter_kwargs = None if input_is_envelope else _parse_dict_param(params, "fei_filter_kwargs")
         trim_seconds = _parse_float_param(params, "fei_trim_seconds", default=None)
-        hilbert_n_fft = _parse_int_param(params, "fei_hilbert_n_fft", default=None)
+        hilbert_n_fft = None if input_is_envelope else _parse_int_param(params, "fei_hilbert_n_fft", default=None)
 
         if frequency_range is not None:
             method_params["frequency_range"] = tuple(frequency_range)
@@ -2848,22 +2871,20 @@ def _build_feature_method_params(method, params, df):
             method_params["dfa_fit_interval"] = tuple(dfa_fit_interval)
         if dfa_compute_interval is not None:
             method_params["dfa_compute_interval"] = tuple(dfa_compute_interval)
-        if window_size_sec is not None:
-            if float(window_size_sec) <= 0:
-                raise ValueError("fEI window_size_sec must be > 0.")
-            method_params["window_size_sec"] = float(window_size_sec)
+        if window_size_sec is None:
+            raise ValueError("fEI window_size_sec is required.")
+        if float(window_size_sec) <= 0:
+            raise ValueError("fEI window_size_sec must be > 0.")
+        method_params["window_size_sec"] = float(window_size_sec)
         if window_overlap is not None:
             if float(window_overlap) < 0 or float(window_overlap) >= 1:
                 raise ValueError("fEI window_overlap must be in [0, 1).")
             method_params["window_overlap"] = float(window_overlap)
-        if dfa_value is not None:
-            method_params["dfa_value"] = float(dfa_value)
         if dfa_threshold is not None:
             method_params["dfa_threshold"] = float(dfa_threshold)
         if dfa_overlap is not None:
             method_params["dfa_overlap"] = bool(dfa_overlap)
-        if input_is_envelope is not None:
-            method_params["input_is_envelope"] = bool(input_is_envelope)
+        method_params["input_is_envelope"] = bool(input_is_envelope)
         if bad_idxes is not None:
             method_params["bad_idxes"] = bad_idxes
         if filter_kwargs:
@@ -2919,6 +2940,8 @@ _FEI_OUTPUT_PATHS = {
     "fei_val": "fEI_val",
     "dfa": "DFA",
     "num_outliers": "num_outliers",
+    "w_amp": "wAmp",
+    "w_dnf": "wDNF",
 }
 
 
@@ -3130,7 +3153,7 @@ def _postprocess_dfa_output(output_df, params, job_status=None, job_id=None):
 
 def _fei_output_path_from_params(params):
     output_key = str(_get_param(params, "fei_output_key", "fei") or "fei").strip()
-    if output_key in {"", "fei", "fEI", "fei_outliers_removed"}:
+    if output_key in {"", "fei", "fEI"}:
         return "fei", _FEI_OUTPUT_PATHS["fei"]
     if output_key in {"full", "dict", "full_dict"}:
         return "full_dict", None
@@ -3163,7 +3186,7 @@ def _postprocess_fei_output(output_df, params, job_status=None, job_id=None):
             if _is_missing_feature_value(value) else value
             for feature, value in zip(output_df["Features"].tolist(), values)
         ]
-    if output_key != "custom":
+    if output_key not in {"custom", "w_amp", "w_dnf"}:
         values = [_as_numeric_scalar(value) for value in values]
     output_df = output_df.copy()
     output_df["Features"] = values

--- a/webui/compute_utils.py
+++ b/webui/compute_utils.py
@@ -2913,6 +2913,14 @@ _DFA_OUTPUT_PATHS = {
     "dfa_intercept": "dfa_intercept",
 }
 
+_FEI_OUTPUT_PATHS = {
+    "fei": "fEI",
+    "fei_outliers_removed": "fEI_outliers_removed",
+    "fei_val": "fEI_val",
+    "dfa": "DFA",
+    "num_outliers": "num_outliers",
+}
+
 
 def _is_missing_feature_value(value):
     if value is None:
@@ -3120,11 +3128,56 @@ def _postprocess_dfa_output(output_df, params, job_status=None, job_id=None):
     return output_df
 
 
+def _fei_output_path_from_params(params):
+    output_key = str(_get_param(params, "fei_output_key", "fei") or "fei").strip()
+    if output_key in {"", "fei", "fEI", "fei_outliers_removed"}:
+        return "fei", _FEI_OUTPUT_PATHS["fei"]
+    if output_key in {"full", "dict", "full_dict"}:
+        return "full_dict", None
+    if output_key == "custom":
+        custom_path = str(_get_param(params, "fei_output_path", "") or "").strip()
+        if not custom_path:
+            raise ValueError("Custom fEI output requires a non-empty output path.")
+        return output_key, custom_path
+    if output_key not in _FEI_OUTPUT_PATHS:
+        raise ValueError(f"Unsupported fEI output value: {output_key}")
+    return output_key, _FEI_OUTPUT_PATHS[output_key]
+
+
+def _postprocess_fei_output(output_df, params, job_status=None, job_id=None):
+    if "Features" not in output_df.columns:
+        return output_df
+
+    def _log(message):
+        if job_status is not None and job_id is not None:
+            _append_job_output(job_status, job_id, message)
+
+    output_key, output_path = _fei_output_path_from_params(params)
+    if output_path is None:
+        return output_df
+
+    values = [_get_mapping_path_value(feature, output_path) for feature in output_df["Features"].tolist()]
+    if output_key == "fei":
+        values = [
+            _get_mapping_path_value(feature, "fEI_outliers_removed")
+            if _is_missing_feature_value(value) else value
+            for feature, value in zip(output_df["Features"].tolist(), values)
+        ]
+    if output_key != "custom":
+        values = [_as_numeric_scalar(value) for value in values]
+    output_df = output_df.copy()
+    output_df["Features"] = values
+    _log(f"fEI output field selected: {output_path}.")
+    return output_df
+
+
 def _postprocess_features_output(method, output_df, params, job_status=None, job_id=None):
     if method == "specparam":
         return _postprocess_specparam_output(output_df, params, job_status, job_id)
     if method == "dfa":
         return _postprocess_dfa_output(output_df, params, job_status, job_id)
+    if method == "fEI":
+        return _postprocess_fei_output(output_df, params, job_status, job_id)
     return output_df
 
 

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -5452,6 +5452,27 @@ def custom_feature(sample, params):
                                     class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
                                     placeholder='Optional, e.g. {"fir_design":"firwin"}'>
                             </label>
+
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Saved output value</span>
+                                    <select name="fei_output_key"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <option value="fei" selected>fEI (scalar)</option>
+                                        <option value="fei_val">fEI with outliers</option>
+                                        <option value="dfa">DFA value</option>
+                                        <option value="num_outliers">Number of outliers</option>
+                                        <option value="full_dict">Full fEI dictionary</option>
+                                        <option value="custom">Custom path</option>
+                                    </select>
+                                </label>
+                                <label class="text-sm">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Custom output path</span>
+                                    <input type="text" name="fei_output_path"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                        placeholder="e.g. fEI_outliers_removed, DFA, wAmp">
+                                </label>
+                            </div>
                             </fieldset>
                         </section>
 

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -150,6 +150,26 @@
             parserAggregateLabels: '',
             parserAggregateLabelValue: '',
             selectedMethod: '',
+            dfaInputIsEnvelope: 'false',
+            dfaFrequencyMin: '5',
+            dfaFrequencyMax: '45',
+            dfaSpectrumMin: '',
+            dfaSpectrumMax: '',
+            dfaFitIntervalMin: '',
+            dfaFitIntervalMax: '',
+            dfaComputeIntervalMin: '',
+            dfaComputeIntervalMax: '',
+            feiInputIsEnvelope: 'false',
+            feiFrequencyMin: '5',
+            feiFrequencyMax: '45',
+            feiSpectrumMin: '',
+            feiSpectrumMax: '',
+            feiWindowSizeSec: '',
+            feiWindowOverlap: '0.0',
+            feiDfaFitIntervalMin: '',
+            feiDfaFitIntervalMax: '',
+            feiDfaComputeIntervalMin: '',
+            feiDfaComputeIntervalMax: '',
             customFeatureScript: `import numpy as np
 
 def custom_feature(sample, params):
@@ -1774,6 +1794,105 @@ def custom_feature(sample, params):
                 this.parserDataLocator = preferred || allowed[0] || '';
                 this.syncParserSelectDom();
             },
+            hasFeatureFieldValue(value) {
+                return String(value ?? '').trim().length > 0;
+            },
+            hasFeatureRange(minValue, maxValue) {
+                return this.hasFeatureFieldValue(minValue) || this.hasFeatureFieldValue(maxValue);
+            },
+            dfaUsesEnvelope() {
+                return String(this.dfaInputIsEnvelope || '').toLowerCase() === 'true';
+            },
+            dfaHasBandRange() {
+                return this.hasFeatureRange(this.dfaFrequencyMin, this.dfaFrequencyMax);
+            },
+            dfaHasSpectrumRange() {
+                return this.hasFeatureRange(this.dfaSpectrumMin, this.dfaSpectrumMax);
+            },
+            dfaFilteringEnabled() {
+                return !this.dfaUsesEnvelope() && (this.dfaHasBandRange() || this.dfaHasSpectrumRange());
+            },
+            feiUsesEnvelope() {
+                return String(this.feiInputIsEnvelope || '').toLowerCase() === 'true';
+            },
+            feiHasBandRange() {
+                return this.hasFeatureRange(this.feiFrequencyMin, this.feiFrequencyMax);
+            },
+            feiHasSpectrumRange() {
+                return this.hasFeatureRange(this.feiSpectrumMin, this.feiSpectrumMax);
+            },
+            feiFilteringEnabled() {
+                return !this.feiUsesEnvelope() && (this.feiHasBandRange() || this.feiHasSpectrumRange());
+            },
+            numericFeatureValue(value) {
+                const text = String(value ?? '').trim();
+                if (!text) return null;
+                const parsed = Number(text);
+                return Number.isFinite(parsed) ? parsed : NaN;
+            },
+            featureRangeBlockReason(label, minValue, maxValue) {
+                const hasMin = this.hasFeatureFieldValue(minValue);
+                const hasMax = this.hasFeatureFieldValue(maxValue);
+                if (hasMin !== hasMax) return `${label}: provide both minimum and maximum values.`;
+                if (!hasMin) return '';
+                const minNum = this.numericFeatureValue(minValue);
+                const maxNum = this.numericFeatureValue(maxValue);
+                if (!Number.isFinite(minNum) || !Number.isFinite(maxNum)) return `${label}: values must be numeric.`;
+                if (minNum >= maxNum) return `${label}: minimum must be lower than maximum.`;
+                return '';
+            },
+            featureNestedRangeBlockReason(label, fitMin, fitMax, computeMin, computeMax) {
+                const hasFit = this.hasFeatureRange(fitMin, fitMax);
+                const hasCompute = this.hasFeatureRange(computeMin, computeMax);
+                if (!hasFit || !hasCompute) return '';
+                const fitLo = this.numericFeatureValue(fitMin);
+                const fitHi = this.numericFeatureValue(fitMax);
+                const computeLo = this.numericFeatureValue(computeMin);
+                const computeHi = this.numericFeatureValue(computeMax);
+                if (![fitLo, fitHi, computeLo, computeHi].every(Number.isFinite)) return '';
+                if (fitLo < computeLo || fitHi > computeHi) return `${label}: fit interval must be inside compute interval.`;
+                return '';
+            },
+            dfaWindowBlockReason() {
+                return this.featureRangeBlockReason('DFA fit interval', this.dfaFitIntervalMin, this.dfaFitIntervalMax)
+                    || this.featureRangeBlockReason('DFA compute interval', this.dfaComputeIntervalMin, this.dfaComputeIntervalMax)
+                    || this.featureNestedRangeBlockReason('DFA', this.dfaFitIntervalMin, this.dfaFitIntervalMax, this.dfaComputeIntervalMin, this.dfaComputeIntervalMax);
+            },
+            feiDfaWindowBlockReason() {
+                return this.featureRangeBlockReason('fEI DFA fit interval', this.feiDfaFitIntervalMin, this.feiDfaFitIntervalMax)
+                    || this.featureRangeBlockReason('fEI DFA compute interval', this.feiDfaComputeIntervalMin, this.feiDfaComputeIntervalMax)
+                    || this.featureNestedRangeBlockReason('fEI DFA', this.feiDfaFitIntervalMin, this.feiDfaFitIntervalMax, this.feiDfaComputeIntervalMin, this.feiDfaComputeIntervalMax);
+            },
+            dfaConfigurationBlockReason() {
+                if (!this.dfaUsesEnvelope() && this.dfaHasBandRange() && this.dfaHasSpectrumRange()) {
+                    return 'DFA: use either Band frequency or Spectrum range, not both.';
+                }
+                if (!this.dfaUsesEnvelope() && !this.dfaHasBandRange() && !this.dfaHasSpectrumRange()) {
+                    return 'DFA: raw-signal mode requires Band frequency or Spectrum range.';
+                }
+                return (!this.dfaUsesEnvelope() && this.featureRangeBlockReason('DFA band frequency', this.dfaFrequencyMin, this.dfaFrequencyMax))
+                    || (!this.dfaUsesEnvelope() && this.featureRangeBlockReason('DFA spectrum range', this.dfaSpectrumMin, this.dfaSpectrumMax))
+                    || this.dfaWindowBlockReason();
+            },
+            feiConfigurationBlockReason() {
+                if (!this.feiUsesEnvelope() && this.feiHasBandRange() && this.feiHasSpectrumRange()) {
+                    return 'fEI: use either Band frequency or Spectrum range, not both.';
+                }
+                if (!this.feiUsesEnvelope() && !this.feiHasBandRange() && !this.feiHasSpectrumRange()) {
+                    return 'fEI: raw-signal mode requires Band frequency or Spectrum range.';
+                }
+                const windowSize = this.numericFeatureValue(this.feiWindowSizeSec);
+                if (!Number.isFinite(windowSize) || windowSize <= 0) {
+                    return 'fEI: set Window size to a value greater than 0 seconds.';
+                }
+                const windowOverlap = this.numericFeatureValue(this.feiWindowOverlap);
+                if (windowOverlap !== null && (!Number.isFinite(windowOverlap) || windowOverlap < 0 || windowOverlap >= 1)) {
+                    return 'fEI: Window overlap must be in [0, 1).';
+                }
+                return (!this.feiUsesEnvelope() && this.featureRangeBlockReason('fEI band frequency', this.feiFrequencyMin, this.feiFrequencyMax))
+                    || (!this.feiUsesEnvelope() && this.featureRangeBlockReason('fEI spectrum range', this.feiSpectrumMin, this.feiSpectrumMax))
+                    || this.feiDfaWindowBlockReason();
+            },
             canSubmitFeatures() {
                 return !this.computeSubmitBlockReason();
             },
@@ -1783,6 +1902,14 @@ def custom_feature(sample, params):
                 if (!this.selectedMethod) return 'Select a feature method in "Select Method".';
                 if (this.selectedMethod === 'custom' && !String(this.customFeatureScript || '').trim()) {
                     return 'Provide a custom feature extraction script.';
+                }
+                if (this.selectedMethod === 'dfa') {
+                    const dfaIssue = this.dfaConfigurationBlockReason();
+                    if (dfaIssue) return dfaIssue;
+                }
+                if (this.selectedMethod === 'fEI') {
+                    const feiIssue = this.feiConfigurationBlockReason();
+                    if (feiIssue) return feiIssue;
                 }
                 if (!this.parserDataLocator) return 'Select a Data locator in EphysDatasetParser configuration.';
                 if (this.segmentBoundsInvalid()) return this.segmentValidationError();
@@ -5163,143 +5290,199 @@ def custom_feature(sample, params):
                         <section x-show="selectedMethod === 'dfa'" class="bg-white dark:bg-[#111422] border border-gray-200 dark:border-[#323b67] rounded-xl p-6 space-y-5">
                             <h2 class="text-lg font-semibold text-[#34495E] dark:text-white">DFA options</h2>
                             <fieldset :disabled="selectedMethod !== 'dfa'" class="space-y-5">
-
-                            <div class="flex flex-wrap gap-5">
-                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
-                                    <input type="checkbox" name="dfa_normalize" value="1"
-                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
-                                    Normalize each sample
-                                </label>
-                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
-                                    <input type="checkbox" name="dfa_overlap" value="1" checked
-                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
-                                    50% overlapping DFA windows
-                                </label>
+                            <div class="space-y-4">
+                                <div class="flex items-center gap-2 border-b border-slate-200 dark:border-[#323b67] pb-2">
+                                    <span class="material-symbols-outlined text-base text-primary">tune</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Core setup</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Set the sampling rate and optional per-sample normalization used before DFA is computed.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Sampling frequency (Hz)</span>
+                                        <input type="number" step="any" name="dfa_fs"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional: fallback to parsed dataframe fs">
+                                        <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Required unless the parsed dataframe already contains a sampling frequency.</span>
+                                    </label>
+                                    <div class="flex items-center pt-5">
+                                        <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
+                                            <input type="checkbox" name="dfa_normalize" value="1"
+                                                class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                            Normalize each sample before DFA
+                                        </label>
+                                    </div>
+                                </div>
                             </div>
 
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Sampling frequency (Hz)</span>
-                                    <input type="number" step="any" name="dfa_fs"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional: fallback to parsed dataframe fs">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Input is envelope</span>
-                                    <select name="dfa_input_is_envelope"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                        <option value="true" selected>true</option>
-                                        <option value="false">false</option>
-                                    </select>
-                                </label>
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5 pl-4 border-l-2 border-l-cyan-500/70">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-cyan-600 dark:text-cyan-300">waves</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Input / preprocessing</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Choose whether the provided samples are already amplitude envelopes or raw signals that must be filtered and Hilbert-transformed.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Input is envelope</span>
+                                        <select name="dfa_input_is_envelope" x-model="dfaInputIsEnvelope"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                            <option value="false" selected>false</option>
+                                            <option value="true">true</option>
+                                        </select>
+                                        <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Use false for raw EEG/MEG/LFP. Use true only when every sample is already a band-limited amplitude envelope.</span>
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Trim seconds</span>
+                                        <input type="number" step="any" min="0" name="dfa_trim_seconds" value="1.0"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Removes edge samples after filtering/envelope extraction to reduce boundary artifacts.</span>
+                                    </label>
+                                </div>
+                                <p x-show="dfaUsesEnvelope()" class="text-xs text-amber-700 dark:text-amber-300">Envelope input skips frequency filtering, spectrum bands, Hilbert n_fft, and filter kwargs.</p>
                             </div>
 
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Fit interval min (s)</span>
-                                    <input type="number" step="any" name="dfa_fit_interval_min"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="e.g. 5">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Fit interval max (s)</span>
-                                    <input type="number" step="any" name="dfa_fit_interval_max"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="e.g. 30">
-                                </label>
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-indigo-600 dark:text-indigo-300">stacked_line_chart</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">DFA windows</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Compute interval controls which window sizes are evaluated; fit interval controls the subset used for the log-log slope. Fit should sit inside compute.</p>
+                                <p x-show="dfaWindowBlockReason()" x-text="dfaWindowBlockReason()"
+                                    class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs font-medium text-red-700 dark:border-red-500/40 dark:bg-red-950/30 dark:text-red-300"></p>
+                                <div class="flex flex-wrap gap-5">
+                                    <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
+                                        <input type="checkbox" name="dfa_overlap" value="1" checked
+                                            class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                        50% overlapping DFA windows
+                                    </label>
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Fit interval min (s)</span>
+                                        <input type="number" step="any" name="dfa_fit_interval_min" x-model="dfaFitIntervalMin"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="e.g. 5">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Fit interval max (s)</span>
+                                        <input type="number" step="any" name="dfa_fit_interval_max" x-model="dfaFitIntervalMax"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="e.g. 30">
+                                    </label>
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Compute interval min (s)</span>
+                                        <input type="number" step="any" name="dfa_compute_interval_min" x-model="dfaComputeIntervalMin"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Compute interval max (s)</span>
+                                        <input type="number" step="any" name="dfa_compute_interval_max" x-model="dfaComputeIntervalMax"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                </div>
                             </div>
 
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Compute interval min (s)</span>
-                                    <input type="number" step="any" name="dfa_compute_interval_min"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Compute interval max (s)</span>
-                                    <input type="number" step="any" name="dfa_compute_interval_max"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-emerald-600 dark:text-emerald-300">filter_alt</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Frequency selection</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Band frequency computes DFA for one filtered band. Spectrum range asks crosci-style logic to create several bands inside the requested range. Use only one.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4" :class="{ 'opacity-50': dfaUsesEnvelope() || dfaHasSpectrumRange() }">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Band frequency min (Hz)</span>
+                                        <input type="number" step="any" name="dfa_frequency_min" x-model="dfaFrequencyMin" value="5"
+                                            :disabled="dfaUsesEnvelope() || dfaHasSpectrumRange()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Band frequency max (Hz)</span>
+                                        <input type="number" step="any" name="dfa_frequency_max" x-model="dfaFrequencyMax" value="45"
+                                            :disabled="dfaUsesEnvelope() || dfaHasSpectrumRange()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                </div>
+                                <p x-show="!dfaUsesEnvelope() && dfaHasSpectrumRange()" class="text-xs text-amber-700 dark:text-amber-300">Band frequency is disabled because Spectrum range is filled.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4" :class="{ 'opacity-50': dfaUsesEnvelope() || dfaHasBandRange() }">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Spectrum range min (Hz)</span>
+                                        <input type="number" step="any" name="dfa_spectrum_min" x-model="dfaSpectrumMin"
+                                            :disabled="dfaUsesEnvelope() || dfaHasBandRange()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Spectrum range max (Hz)</span>
+                                        <input type="number" step="any" name="dfa_spectrum_max" x-model="dfaSpectrumMax"
+                                            :disabled="dfaUsesEnvelope() || dfaHasBandRange()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                </div>
+                                <p x-show="!dfaUsesEnvelope() && dfaHasBandRange()" class="text-xs text-amber-700 dark:text-amber-300">Spectrum range is disabled because Band frequency is filled.</p>
                             </div>
 
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Band frequency min (Hz)</span>
-                                    <input type="number" step="any" name="dfa_frequency_min" value="5"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Band frequency max (Hz)</span>
-                                    <input type="number" step="any" name="dfa_frequency_max" value="45"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Spectrum range min (Hz)</span>
-                                    <input type="number" step="any" name="dfa_spectrum_min"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Spectrum range max (Hz)</span>
-                                    <input type="number" step="any" name="dfa_spectrum_max"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Bad channel indexes</span>
-                                    <input type="text" name="dfa_bad_idxes"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional, e.g. 0,2,5">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Trim seconds</span>
-                                    <input type="number" step="any" min="0" name="dfa_trim_seconds" value="1.0"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Hilbert n_fft</span>
-                                    <input type="number" step="1" min="1" name="dfa_hilbert_n_fft"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                                <label class="text-sm">
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-slate-600 dark:text-slate-300">settings</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Advanced options</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Exclude bad channels or override the Hilbert/filter implementation used when raw signals are converted to envelopes.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Bad channel indexes</span>
+                                        <input type="text" name="dfa_bad_idxes"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional, e.g. 0,2,5">
+                                    </label>
+                                    <label class="text-sm" :class="{ 'opacity-50': dfaUsesEnvelope() }">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Hilbert n_fft</span>
+                                        <input type="number" step="1" min="1" name="dfa_hilbert_n_fft"
+                                            :disabled="dfaUsesEnvelope()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                        <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Only used when raw signals are filtered and transformed to envelopes.</span>
+                                    </label>
+                                </div>
+                                <label class="text-sm block" :class="{ 'opacity-50': dfaUsesEnvelope() }">
                                     <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Filter kwargs (dict)</span>
                                     <input type="text" name="dfa_filter_kwargs"
+                                        :disabled="dfaUsesEnvelope()"
                                         class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
                                         placeholder='Optional, e.g. {"fir_design":"firwin"}'>
+                                    <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Optional keyword arguments passed to the filtering step before Hilbert envelope extraction.</span>
                                 </label>
                             </div>
 
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Saved output value</span>
-                                    <select name="dfa_output_key"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                        <option value="dfa_value" selected>DFA value (scalar)</option>
-                                        <option value="dfa_intercept">DFA intercept</option>
-                                        <option value="full_dict">Full DFA dictionary</option>
-                                        <option value="custom">Custom path</option>
-                                    </select>
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Custom output path</span>
-                                    <input type="text" name="dfa_output_path"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="e.g. DFA or dfa_intercept">
-                                </label>
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-violet-600 dark:text-violet-300">save</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Saved output</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Select which value from the DFA result dictionary is stored in the Features column.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Saved output value</span>
+                                        <select name="dfa_output_key"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                            <option value="dfa_value" selected>DFA value (scalar)</option>
+                                            <option value="dfa_intercept">DFA intercept</option>
+                                            <option value="full_dict">Full DFA dictionary</option>
+                                            <option value="custom">Custom path</option>
+                                        </select>
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Custom output path</span>
+                                        <input type="text" name="dfa_output_path"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="e.g. DFA or dfa_intercept">
+                                    </label>
+                                </div>
                             </div>
                             </fieldset>
                         </section>
@@ -5307,171 +5490,231 @@ def custom_feature(sample, params):
                         <section x-show="selectedMethod === 'fEI'" class="bg-white dark:bg-[#111422] border border-gray-200 dark:border-[#323b67] rounded-xl p-6 space-y-5">
                             <h2 class="text-lg font-semibold text-[#34495E] dark:text-white">fEI options</h2>
                             <fieldset :disabled="selectedMethod !== 'fEI'" class="space-y-5">
+                            <div class="space-y-4">
+                                <div class="flex items-center gap-2 border-b border-slate-200 dark:border-[#323b67] pb-2">
+                                    <span class="material-symbols-outlined text-base text-primary">tune</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Core setup</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Set the sampling rate and optional per-sample normalization used before DFA is computed as part of fEI.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Sampling frequency (Hz)</span>
+                                        <input type="number" step="any" name="fei_fs"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional: fallback to parsed dataframe fs">
+                                        <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Required unless the parsed dataframe already contains a sampling frequency.</span>
+                                    </label>
+                                    <div class="flex items-center pt-5">
+                                        <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
+                                            <input type="checkbox" name="fei_normalize" value="1"
+                                                class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                            Normalize each sample before fEI
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
 
-                            <div class="flex flex-wrap gap-5">
-                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
-                                    <input type="checkbox" name="fei_normalize" value="1"
-                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
-                                    Normalize each sample
-                                </label>
-                                <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
-                                    <input type="checkbox" name="fei_dfa_overlap" value="1" checked
-                                        class="rounded border-gray-300 text-primary focus:ring-primary/50">
-                                    Use overlap when estimating DFA
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5 pl-4 border-l-2 border-l-cyan-500/70">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-cyan-600 dark:text-cyan-300">waves</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Input / preprocessing</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Choose whether the provided samples are already amplitude envelopes or raw signals that must be filtered and Hilbert-transformed.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Input is envelope</span>
+                                        <select name="fei_input_is_envelope" x-model="feiInputIsEnvelope"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                            <option value="false" selected>false</option>
+                                            <option value="true">true</option>
+                                        </select>
+                                        <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Use false for raw EEG/MEG/LFP. Use true only when every sample is already a band-limited amplitude envelope.</span>
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Trim seconds</span>
+                                        <input type="number" step="any" min="0" name="fei_trim_seconds" value="1.0"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Removes edge samples after filtering/envelope extraction to reduce boundary artifacts.</span>
+                                    </label>
+                                </div>
+                                <p x-show="feiUsesEnvelope()" class="text-xs text-amber-700 dark:text-amber-300">Envelope input skips frequency filtering, spectrum bands, Hilbert n_fft, and filter kwargs.</p>
+                            </div>
+
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-rose-600 dark:text-rose-300">view_timeline</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">fEI windows</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">fEI is estimated across amplitude windows. Window size is required; overlap is the fraction shared by consecutive windows.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Window size (s)</span>
+                                        <input type="number" step="any" min="0" name="fei_window_size_sec" x-model="feiWindowSizeSec"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Required, e.g. 5">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Window overlap [0,1)</span>
+                                        <input type="number" step="any" min="0" max="0.99" name="fei_window_overlap" x-model="feiWindowOverlap" value="0.0"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA threshold</span>
+                                        <input type="number" step="any" name="fei_dfa_threshold" value="0.6"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                        <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Minimum DFA value used to keep windows in the fEI estimate.</span>
+                                    </label>
+                                </div>
+                            </div>
+
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-indigo-600 dark:text-indigo-300">stacked_line_chart</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">DFA windows</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Compute interval controls which DFA window sizes are evaluated; fit interval controls the subset used for the log-log slope. Fit should sit inside compute.</p>
+                                <p x-show="feiDfaWindowBlockReason()" x-text="feiDfaWindowBlockReason()"
+                                    class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs font-medium text-red-700 dark:border-red-500/40 dark:bg-red-950/30 dark:text-red-300"></p>
+                                <div class="flex flex-wrap gap-5">
+                                    <label class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-100">
+                                        <input type="checkbox" name="fei_dfa_overlap" value="1" checked
+                                            class="rounded border-gray-300 text-primary focus:ring-primary/50">
+                                        50% overlapping DFA windows
+                                    </label>
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA fit interval min (s)</span>
+                                        <input type="number" step="any" name="fei_dfa_fit_interval_min" x-model="feiDfaFitIntervalMin"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA fit interval max (s)</span>
+                                        <input type="number" step="any" name="fei_dfa_fit_interval_max" x-model="feiDfaFitIntervalMax"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA compute interval min (s)</span>
+                                        <input type="number" step="any" name="fei_dfa_compute_interval_min" x-model="feiDfaComputeIntervalMin"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA compute interval max (s)</span>
+                                        <input type="number" step="any" name="fei_dfa_compute_interval_max" x-model="feiDfaComputeIntervalMax"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                </div>
+                            </div>
+
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-emerald-600 dark:text-emerald-300">filter_alt</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Frequency selection</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Band frequency computes fEI for one filtered band. Spectrum range asks crosci-style logic to create several bands inside the requested range. Use only one.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4" :class="{ 'opacity-50': feiUsesEnvelope() || feiHasSpectrumRange() }">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Band frequency min (Hz)</span>
+                                        <input type="number" step="any" name="fei_frequency_min" x-model="feiFrequencyMin" value="5"
+                                            :disabled="feiUsesEnvelope() || feiHasSpectrumRange()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Band frequency max (Hz)</span>
+                                        <input type="number" step="any" name="fei_frequency_max" x-model="feiFrequencyMax" value="45"
+                                            :disabled="feiUsesEnvelope() || feiHasSpectrumRange()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                </div>
+                                <p x-show="!feiUsesEnvelope() && feiHasSpectrumRange()" class="text-xs text-amber-700 dark:text-amber-300">Band frequency is disabled because Spectrum range is filled.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4" :class="{ 'opacity-50': feiUsesEnvelope() || feiHasBandRange() }">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Spectrum range min (Hz)</span>
+                                        <input type="number" step="any" name="fei_spectrum_min" x-model="feiSpectrumMin"
+                                            :disabled="feiUsesEnvelope() || feiHasBandRange()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Spectrum range max (Hz)</span>
+                                        <input type="number" step="any" name="fei_spectrum_max" x-model="feiSpectrumMax"
+                                            :disabled="feiUsesEnvelope() || feiHasBandRange()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                    </label>
+                                </div>
+                                <p x-show="!feiUsesEnvelope() && feiHasBandRange()" class="text-xs text-amber-700 dark:text-amber-300">Spectrum range is disabled because Band frequency is filled.</p>
+                            </div>
+
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-slate-600 dark:text-slate-300">settings</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Advanced options</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Exclude bad channels or override the Hilbert/filter implementation used when raw signals are converted to envelopes.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Bad channel indexes</span>
+                                        <input type="text" name="fei_bad_idxes"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional, e.g. 0,2,5">
+                                    </label>
+                                    <label class="text-sm" :class="{ 'opacity-50': feiUsesEnvelope() }">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Hilbert n_fft</span>
+                                        <input type="number" step="1" min="1" name="fei_hilbert_n_fft"
+                                            :disabled="feiUsesEnvelope()"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="Optional">
+                                        <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Only used when raw signals are filtered and transformed to envelopes.</span>
+                                    </label>
+                                </div>
+                                <label class="text-sm block" :class="{ 'opacity-50': feiUsesEnvelope() }">
+                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Filter kwargs (dict)</span>
+                                    <input type="text" name="fei_filter_kwargs"
+                                        :disabled="feiUsesEnvelope()"
+                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                        placeholder='Optional, e.g. {"fir_design":"firwin"}'>
+                                    <span class="mt-1 block text-xs text-slate-500 dark:text-slate-300">Optional keyword arguments passed to the filtering step before Hilbert envelope extraction.</span>
                                 </label>
                             </div>
 
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Sampling frequency (Hz)</span>
-                                    <input type="number" step="any" name="fei_fs"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional: fallback to parsed dataframe fs">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Input is envelope</span>
-                                    <select name="fei_input_is_envelope"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                        <option value="true" selected>true</option>
-                                        <option value="false">false</option>
-                                    </select>
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Window size (s)</span>
-                                    <input type="number" step="any" min="0" name="fei_window_size_sec"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="e.g. 5">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Window overlap [0,1)</span>
-                                    <input type="number" step="any" min="0" max="0.99" name="fei_window_overlap" value="0.0"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA threshold</span>
-                                    <input type="number" step="any" name="fei_dfa_threshold" value="0.6"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Provided DFA value</span>
-                                    <input type="number" step="any" name="fei_dfa_value"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional, envelope-only mode">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Trim seconds</span>
-                                    <input type="number" step="any" min="0" name="fei_trim_seconds" value="1.0"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA fit interval min (s)</span>
-                                    <input type="number" step="any" name="fei_dfa_fit_interval_min"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA fit interval max (s)</span>
-                                    <input type="number" step="any" name="fei_dfa_fit_interval_max"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA compute interval min (s)</span>
-                                    <input type="number" step="any" name="fei_dfa_compute_interval_min"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">DFA compute interval max (s)</span>
-                                    <input type="number" step="any" name="fei_dfa_compute_interval_max"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Band frequency min (Hz)</span>
-                                    <input type="number" step="any" name="fei_frequency_min"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Band frequency max (Hz)</span>
-                                    <input type="number" step="any" name="fei_frequency_max"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Spectrum range min (Hz)</span>
-                                    <input type="number" step="any" name="fei_spectrum_min"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Spectrum range max (Hz)</span>
-                                    <input type="number" step="any" name="fei_spectrum_max"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Bad channel indexes</span>
-                                    <input type="text" name="fei_bad_idxes"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional, e.g. 0,2,5">
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Hilbert n_fft</span>
-                                    <input type="number" step="1" min="1" name="fei_hilbert_n_fft"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="Optional">
-                                </label>
-                            </div>
-
-                            <label class="text-sm block">
-                                <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Filter kwargs (dict)</span>
-                                <input type="text" name="fei_filter_kwargs"
-                                    class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                    placeholder='Optional, e.g. {"fir_design":"firwin"}'>
-                            </label>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Saved output value</span>
-                                    <select name="fei_output_key"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                        <option value="fei" selected>fEI (scalar)</option>
-                                        <option value="fei_val">fEI with outliers</option>
-                                        <option value="dfa">DFA value</option>
-                                        <option value="num_outliers">Number of outliers</option>
-                                        <option value="full_dict">Full fEI dictionary</option>
-                                        <option value="custom">Custom path</option>
-                                    </select>
-                                </label>
-                                <label class="text-sm">
-                                    <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Custom output path</span>
-                                    <input type="text" name="fei_output_path"
-                                        class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
-                                        placeholder="e.g. fEI_outliers_removed, DFA, wAmp">
-                                </label>
+                            <div class="space-y-4 border-t border-slate-200 dark:border-[#323b67] pt-5">
+                                <div class="flex items-center gap-2">
+                                    <span class="material-symbols-outlined text-base text-violet-600 dark:text-violet-300">save</span>
+                                    <h3 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Saved output</h3>
+                                </div>
+                                <p class="text-xs text-slate-500 dark:text-slate-300">Select which fEI result is stored in the Features column. The default stores the scalar fEI value used for analysis.</p>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Saved output value</span>
+                                        <select name="fei_output_key"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
+                                            <option value="fei" selected>fEI (scalar)</option>
+                                            <option value="fei_outliers_removed">fEI outliers removed</option>
+                                            <option value="fei_val">fEI with outliers</option>
+                                            <option value="dfa">DFA value</option>
+                                            <option value="num_outliers">Number of outliers</option>
+                                            <option value="w_amp">Window amplitudes</option>
+                                            <option value="w_dnf">Window detrended fluctuations</option>
+                                            <option value="full_dict">Full fEI dictionary</option>
+                                            <option value="custom">Custom path</option>
+                                        </select>
+                                    </label>
+                                    <label class="text-sm">
+                                        <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Custom output path</span>
+                                        <input type="text" name="fei_output_path"
+                                            class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
+                                            placeholder="e.g. fEI_outliers_removed, DFA, wAmp">
+                                    </label>
+                                </div>
                             </div>
                             </fieldset>
                         </section>


### PR DESCRIPTION
## Summary

This PR improves the DFA and fEI configuration panels in the WebUI to make the available options clearer and harder to misconfigure.

## Changes

- Reorganized DFA and fEI options into clearer sections, following the style used by the specparam configuration.
- Added descriptions for key fields such as input type, frequency selection, DFA windows, fEI windows, advanced options, and saved output.
- Changed the default input mode to raw signal:
  - `Input is envelope = false`
  - default band: `5-45 Hz`
- Disabled frequency/filter-related fields when `Input is envelope = true`.
- Made `Band frequency` and `Spectrum range` mutually exclusive in the UI.
- Added inline error messages when DFA fit intervals are not valid or are outside the compute interval.
- Removed the confusing `Provided DFA value` field from fEI configuration.
- Updated backend parameter handling so envelope input does not send frequency ranges to `Features.py`.
- Added fEI saved-output selection, with `fEI` scalar as the default output.
