### PR TITLE
Mantain configuration form after error in configuration

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -1111,11 +1111,48 @@ def _coerce_grid_candidate(value, default, key):
     return value
 
 
+SIMULATION_FIELD_LABELS = {
+    "tstop": "Simulation time tstop",
+    "dt": "Time step dt",
+    "local_num_threads": "Number of threads",
+    "N_X": "Population sizes Nₓ",
+    "C_YX": "Connection probability matrix C_YX",
+    "P": "Connection probability P",
+    "tau_m_X": "Membrane time constant tau_m_X",
+    "delay_YX": "Synaptic delay matrix delay_YX",
+    "tau_syn_YX": "Synaptic time constants tau_syn_YX",
+    "inter_area.C_YX": "Inter-area C_YX",
+    "inter_area.delay_YX": "Inter-area delay_YX",
+    "OU_tau": "Ornstein-Uhlenbeck tau",
+    "t_ref_X": "Refractory period t_ref_X",
+    "tau_rise_AMPA_X": "AMPA rise time tau_rise_AMPA_X",
+    "tau_decay_AMPA_X": "AMPA decay time tau_decay_AMPA_X",
+    "tau_rise_GABA_A_X": "GABA rise time tau_rise_GABA_A_X",
+    "tau_decay_GABA_A_X": "GABA decay time tau_decay_GABA_A_X",
+    "J_ext": "External weight J_ext",
+    "nu_ext": "External rate nu_ext",
+}
+
+
+def _simulation_field_display_name(name):
+    raw_name = str(name or "").strip()
+    area_match = re.match(r"^area_(\d+)\.(.+)$", raw_name)
+    if area_match:
+        area_number = int(area_match.group(1)) + 1
+        base_name = area_match.group(2)
+        base_label = SIMULATION_FIELD_LABELS.get(base_name, base_name)
+        if base_label:
+            base_label = base_label[0].lower() + base_label[1:]
+        return f"Area {area_number} {base_label}"
+    return SIMULATION_FIELD_LABELS.get(raw_name, raw_name)
+
+
 def _expand_numeric_range(spec, key):
+    field_label = _simulation_field_display_name(key)
     parts = [p.strip() for p in spec.split(":")]
     if len(parts) != 3:
         raise ValueError(
-            f"Invalid grid range for '{key}'. Use 'grid=start:stop:step'."
+            f"Invalid grid range for {field_label}. Use 'grid=start:stop:step'."
         )
     try:
         start = float(parts[0])
@@ -1123,10 +1160,18 @@ def _expand_numeric_range(spec, key):
         step = float(parts[2])
     except ValueError as exc:
         raise ValueError(
-            f"Invalid grid range for '{key}'. Use numeric values in 'start:stop:step'."
+            f"Invalid grid range for {field_label}. Use numeric values in 'start:stop:step'."
         ) from exc
     if step == 0:
-        raise ValueError(f"Invalid grid range for '{key}': step cannot be 0.")
+        raise ValueError(f"Invalid grid range for {field_label}: step cannot be 0.")
+    if step > 0 and stop <= start:
+        raise ValueError(
+            f"Invalid grid range for {field_label}: end must be greater than start when step is positive."
+        )
+    if step < 0 and stop >= start:
+        raise ValueError(
+            f"Invalid grid range for {field_label}: end must be less than start when step is negative."
+        )
 
     values = []
     current = start
@@ -6702,6 +6747,143 @@ def _ensure_matrix(value, name, rows, cols):
             raise ValueError(f"'{name}' row {idx} must have length {cols}.")
 
 
+def _iter_simulation_numeric_values(value, name):
+    if isinstance(value, np.ndarray):
+        value = value.tolist()
+    if isinstance(value, (list, tuple)):
+        for idx, item in enumerate(value):
+            yield from _iter_simulation_numeric_values(item, f"{name}[{idx}]")
+        return
+    if isinstance(value, bool) or not _is_number_like(value):
+        raise ValueError(f"'{name}' must contain numeric values.")
+    yield name, float(value)
+
+
+def _validate_simulation_numeric_values(value, name, predicate, requirement, display_name=None):
+    field_label = display_name or _simulation_field_display_name(name)
+    for _, numeric_value in _iter_simulation_numeric_values(value, name):
+        if not predicate(numeric_value):
+            raise ValueError(f"Invalid simulation configuration: {field_label} must be {requirement}.")
+
+
+def _validate_simulation_time_values(form, defaults, keys):
+    for key in keys:
+        if key not in defaults:
+            continue
+        default = defaults[key]
+        if isinstance(default, float):
+            value = _parse_float(form, key, default)
+        elif isinstance(default, int) and not isinstance(default, bool):
+            value = _parse_int(form, key, default)
+        else:
+            value = _parse_literal(form, key, default)
+        _validate_simulation_numeric_values(value, key, lambda item: item > 0, "> 0")
+
+
+def _validate_simulation_population_sizes(form, defaults, keys):
+    for key in keys:
+        if key not in defaults:
+            continue
+        value = _parse_literal(form, key, defaults[key])
+        _validate_simulation_numeric_values(value, key, lambda item: item >= 0, ">= 0")
+
+
+def _validate_simulation_connection_probabilities(form, defaults, keys):
+    for key in keys:
+        if key not in defaults:
+            continue
+        default = defaults[key]
+        if isinstance(default, float):
+            value = _parse_float(form, key, default)
+        elif isinstance(default, int) and not isinstance(default, bool):
+            value = _parse_int(form, key, default)
+        else:
+            value = _parse_literal(form, key, default)
+        _validate_simulation_numeric_values(value, key, lambda item: item >= 0, ">= 0")
+
+
+def _validate_predefined_simulation_configuration(model_type, form):
+    model_defaults = _simulation_grid_defaults(model_type)
+    _validate_simulation_time_values(
+        form,
+        model_defaults,
+        ["tstop", "dt"],
+    )
+
+    if model_type == "hagen":
+        _validate_simulation_time_values(
+            form,
+            HAGEN_DEFAULTS,
+            ["tau_m_X", "delay_YX", "tau_syn_YX"],
+        )
+        _validate_simulation_population_sizes(form, HAGEN_DEFAULTS, ["N_X"])
+        _validate_simulation_connection_probabilities(form, HAGEN_DEFAULTS, ["C_YX"])
+        return
+
+    if model_type == "cavallari":
+        _validate_simulation_time_values(
+            form,
+            CAVALLARI_DEFAULTS,
+            [
+                "OU_tau",
+                "t_ref_X",
+                "tau_rise_AMPA_X",
+                "tau_decay_AMPA_X",
+                "tau_rise_GABA_A_X",
+                "tau_decay_GABA_A_X",
+                "tau_m_X",
+            ],
+        )
+        _validate_simulation_population_sizes(form, CAVALLARI_DEFAULTS, ["N_X"])
+        _validate_simulation_connection_probabilities(form, CAVALLARI_DEFAULTS, ["P"])
+        return
+
+    if model_type == "four_area":
+        defaults = _simulation_grid_defaults("four_area")
+        _validate_simulation_time_values(
+            form,
+            defaults,
+            ["tau_m_X", "delay_YX", "tau_syn_YX"],
+        )
+        inter_area_delay = _parse_literal(
+            form,
+            "inter_area.delay_YX",
+            defaults["inter_area.delay_YX"],
+        )
+        _validate_simulation_numeric_values(
+            inter_area_delay,
+            "inter_area.delay_YX",
+            lambda item: item >= 0,
+            ">= 0",
+        )
+        _validate_simulation_population_sizes(form, defaults, ["N_X"])
+        _validate_simulation_connection_probabilities(form, defaults, ["C_YX"])
+        _validate_simulation_connection_probabilities(
+            form,
+            defaults,
+            ["inter_area.C_YX"],
+        )
+        for area_index in range(len(FOUR_AREA_DEFAULTS["areas"])):
+            area_defaults = {
+                f"area_{area_index}.N_X": FOUR_AREA_DEFAULTS["N_X"],
+                f"area_{area_index}.tau_m_X": FOUR_AREA_DEFAULTS["tau_m_X"],
+                f"area_{area_index}.delay_YX": FOUR_AREA_DEFAULTS["delay_YX"],
+                f"area_{area_index}.tau_syn_YX": FOUR_AREA_DEFAULTS["tau_syn_YX"],
+                f"area_{area_index}.C_YX": FOUR_AREA_DEFAULTS["C_YX"],
+            }
+            _validate_simulation_time_values(
+                form,
+                area_defaults,
+                [
+                    f"area_{area_index}.tau_m_X",
+                    f"area_{area_index}.delay_YX",
+                    f"area_{area_index}.tau_syn_YX",
+                ],
+            )
+            _validate_simulation_population_sizes(form, area_defaults, [f"area_{area_index}.N_X"])
+            _validate_simulation_connection_probabilities(form, area_defaults, [f"area_{area_index}.C_YX"])
+
+
 def _estimate_duration_seconds(form, defaults, model_type):
     tstop = _parse_float(form, "tstop", defaults["tstop"])
     dt = _parse_float(form, "dt", defaults["dt"])
@@ -7847,23 +8029,53 @@ def _run_job_with_post_success_cleanup(job_id, module_key, func, *func_args):
 def new_sim():
     return render_template("1.2.0.new_sim.html")
 
+
+def _remember_simulation_restore_form(model_type, form):
+    session["simulation_restore_form"] = {
+        "model_type": str(model_type or "").strip().lower(),
+        "form": dict(form or {}),
+    }
+
+
+def _pop_simulation_restore_form(model_type):
+    payload = session.pop("simulation_restore_form", None)
+    if not isinstance(payload, dict):
+        return {}
+    expected_model = str(model_type or "").strip().lower()
+    payload_model = str(payload.get("model_type") or "").strip().lower()
+    if payload_model != expected_model:
+        return {}
+    form = payload.get("form")
+    return form if isinstance(form, dict) else {}
+
+
 @app.route("/simulation/new_sim/hagen")
 def new_sim_hagen():
-    return render_template("1.2.2.new_sim_hagen.html")
+    restore_form = _pop_simulation_restore_form("hagen")
+    return render_template(
+        "1.2.2.new_sim_hagen.html",
+        simulation_restore_form=restore_form,
+    )
 
 @app.route("/simulation/new_sim/cavallari")
 def new_sim_cavallari():
     neuron_model_dir = os.path.join(
         _repo_root, "examples", "simulation", "Cavallari_model", "neuron_model"
     )
+    restore_form = _pop_simulation_restore_form("cavallari")
     return render_template(
         "1.2.4.new_sim_cavallari.html",
         cavallari_neuron_model_dir=neuron_model_dir,
+        simulation_restore_form=restore_form,
     )
 
 @app.route("/simulation/new_sim/four_area")
 def new_sim_four_area():
-    return render_template("1.2.3.new_sim_four_area.html")
+    restore_form = _pop_simulation_restore_form("four_area")
+    return render_template(
+        "1.2.3.new_sim_four_area.html",
+        simulation_restore_form=restore_form,
+    )
 
 @app.route("/simulation/new_sim/custom")
 def new_sim_custom():
@@ -8253,7 +8465,10 @@ def run_trial_simulation(model_type):
 
     try:
         run_mode, run_forms = _expand_simulation_forms(model_type, form)
+        for run_form in run_forms:
+            _validate_predefined_simulation_configuration(model_type, run_form)
     except ValueError as exc:
+        _remember_simulation_restore_form(model_type, form)
         flash(str(exc), "error")
         return redirect(url_for(ref_page))
 
@@ -8270,8 +8485,10 @@ def run_trial_simulation(model_type):
             for run_form in run_forms
         )
     except Exception as exc:
+        _remember_simulation_restore_form(model_type, form)
         flash(f"Invalid simulation parameters: {exc}", "error")
         return redirect(url_for(ref_page))
+
     estimated_duration = max(60.0, min(24 * 3600.0, float(estimated_duration)))
 
     job_id = str(uuid.uuid4())

--- a/webui/static/js/simulation_Hagen.js
+++ b/webui/static/js/simulation_Hagen.js
@@ -41,6 +41,47 @@ document.addEventListener('DOMContentLoaded', function() {
         useNumpySeedInput: document.getElementById('sim-use-numpy-seed'),
         numpySeedInput: document.getElementById('sim-numpy-seed')
     };
+    const restoreForm = readSimulationRestoreForm();
+
+    function readSimulationRestoreForm() {
+        const node = document.getElementById('simulation-restore-form');
+        if (!node) {
+            return {};
+        }
+        try {
+            const parsed = JSON.parse(node.textContent || '{}');
+            return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+        } catch (_err) {
+            return {};
+        }
+    }
+
+    function hasRestoredValue(name) {
+        return Object.prototype.hasOwnProperty.call(restoreForm, name);
+    }
+
+    function restoredValueOrPreset(name, preset) {
+        return hasRestoredValue(name) ? restoreForm[name] : preset;
+    }
+
+    function parseSimpleGridRangeSpec(value) {
+        const text = String(value ?? '').trim();
+        if (!text.toLowerCase().startsWith('grid=')) {
+            return null;
+        }
+        const spec = text.slice(5).trim();
+        if (!spec || /[\[\]{}(),]/.test(spec)) {
+            return null;
+        }
+        const parts = spec.split(':').map(part => part.trim());
+        if (parts.length !== 3) {
+            return null;
+        }
+        if (!parts.every(part => Number.isFinite(Number(part)))) {
+            return null;
+        }
+        return { start: parts[0], stop: parts[1], step: parts[2] };
+    }
 
     function ensureInputCanCarryValue(input, value) {
         if (!input) {
@@ -52,7 +93,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const originalType = input.dataset.originalType;
         const textValue = String(value ?? '');
         const wantsGridSpec = textValue.toLowerCase().startsWith('grid=');
-        if (wantsGridSpec && originalType === 'number') {
+        const wantsInvalidNumericText = originalType === 'number' && textValue !== '' && !Number.isFinite(Number(textValue));
+        if ((wantsGridSpec || wantsInvalidNumericText) && originalType === 'number') {
             input.type = 'text';
             input.inputMode = 'decimal';
             return;
@@ -555,7 +597,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function addGridControls(input, preset) {
         const initial = (preset !== undefined && preset !== null) ? preset : (input.value || '');
-        const parsed = parseStructured(initial);
+        const simpleGridRange = parseSimpleGridRangeSpec(initial);
+        const parsed = simpleGridRange ? Number(simpleGridRange.start) : parseStructured(initial);
         const controls = document.createElement('div');
         controls.className = 'grid-parameter-controls hidden mt-2 flex flex-col gap-2';
         const paramName = input.dataset.param || input.name || '';
@@ -568,6 +611,8 @@ document.addEventListener('DOMContentLoaded', function() {
         leaves.forEach((leaf, index) => {
             const label = describeLeafLabel(paramName, leaf.path, index, controls.dataset.gridKind === 'array');
             const startValue = String(leaf.value ?? '');
+            const stepValue = simpleGridRange && leaves.length === 1 ? simpleGridRange.step : '0';
+            const endValue = simpleGridRange && leaves.length === 1 ? simpleGridRange.stop : startValue;
             controls.insertAdjacentHTML('beforeend', `
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-2" data-grid-row="1" data-path="${escapeHtml(JSON.stringify(leaf.path))}" data-param-name="${escapeHtml(paramName)}" data-template-type="${typeof leaf.value}">
                     <div class="text-xs text-slate-600 dark:text-slate-300 md:pt-2" data-param-leaf-label="1">${escapeHtml(label)}</div>
@@ -577,11 +622,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     </label>
                     <label class="flex flex-col gap-1">
                         <span class="text-xs text-slate-600 dark:text-slate-300">Step</span>
-                        <input type="text" data-grid-role="step" class="${baseClass}" value="0" />
+                        <input type="text" data-grid-role="step" class="${baseClass}" value="${escapeHtml(stepValue)}" />
                     </label>
                     <label class="flex flex-col gap-1">
                         <span class="text-xs text-slate-600 dark:text-slate-300">End</span>
-                        <input type="text" data-grid-role="end" class="${baseClass}" value="${escapeHtml(startValue)}" />
+                        <input type="text" data-grid-role="end" class="${baseClass}" value="${escapeHtml(endValue)}" />
                     </label>
                 </div>
             `);
@@ -817,7 +862,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const inputs = section.querySelectorAll('.param-input');
         inputs.forEach(input => {
             const paramName = input.dataset.param;
-            const preset = ncpiPresets[paramName];
+            const preset = restoredValueOrPreset(paramName, ncpiPresets[paramName]);
             if (!input.name) {
                 input.name = paramName;
             }
@@ -831,6 +876,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (!input.dataset.originalType) {
                     input.dataset.originalType = input.type || 'text';
                 }
+                ensureInputCanCarryValue(input, preset);
                 input.value = preset;
             }
 
@@ -846,9 +892,46 @@ document.addEventListener('DOMContentLoaded', function() {
         
         return section;
     }
+
+    function restoreSimulationFormControls() {
+        const restoredMode = hasRestoredValue('sim_run_mode') ? String(restoreForm.sim_run_mode || '') : '';
+        if (restoredMode) {
+            const modeInput = Array.from(elements.runModeInputs).find(input => input.value === restoredMode);
+            if (modeInput) {
+                modeInput.checked = true;
+            }
+        }
+        if (elements.repetitionsInput && hasRestoredValue('sim_repetitions')) {
+            elements.repetitionsInput.value = String(restoreForm.sim_repetitions ?? '');
+        }
+        if (elements.useNumpySeedInput && Object.keys(restoreForm).length > 0) {
+            elements.useNumpySeedInput.checked = hasRestoredValue('sim_use_numpy_seed');
+        }
+        if (elements.numpySeedInput && hasRestoredValue('sim_numpy_seed')) {
+            elements.numpySeedInput.value = String(restoreForm.sim_numpy_seed ?? '');
+        }
+        if (elements.jointGroupsContainer && hasRestoredValue('sim_joint_groups')) {
+            let groups = [];
+            try {
+                const rawGroups = restoreForm.sim_joint_groups;
+                groups = Array.isArray(rawGroups) ? rawGroups : JSON.parse(String(rawGroups || '[]'));
+            } catch (_err) {
+                groups = [];
+            }
+            if (Array.isArray(groups)) {
+                elements.jointGroupsContainer.replaceChildren();
+                groups.forEach(group => {
+                    if (Array.isArray(group) && group.length > 0) {
+                        addJointGroupCard(group.map(value => String(value)));
+                    }
+                });
+            }
+        }
+    }
     
     // Initialize UI
     createParameterSection();
+    restoreSimulationFormControls();
     refreshLeafLabels();
     refreshJointGroupsUi();
 

--- a/webui/static/js/simulation_cavallari.js
+++ b/webui/static/js/simulation_cavallari.js
@@ -73,6 +73,47 @@ document.addEventListener('DOMContentLoaded', function() {
         useNumpySeedInput: document.getElementById('sim-use-numpy-seed'),
         numpySeedInput: document.getElementById('sim-numpy-seed')
     };
+    const restoreForm = readSimulationRestoreForm();
+
+    function readSimulationRestoreForm() {
+        const node = document.getElementById('simulation-restore-form');
+        if (!node) {
+            return {};
+        }
+        try {
+            const parsed = JSON.parse(node.textContent || '{}');
+            return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+        } catch (_err) {
+            return {};
+        }
+    }
+
+    function hasRestoredValue(name) {
+        return Object.prototype.hasOwnProperty.call(restoreForm, name);
+    }
+
+    function restoredValueOrPreset(name, preset) {
+        return hasRestoredValue(name) ? restoreForm[name] : preset;
+    }
+
+    function parseSimpleGridRangeSpec(value) {
+        const text = String(value ?? '').trim();
+        if (!text.toLowerCase().startsWith('grid=')) {
+            return null;
+        }
+        const spec = text.slice(5).trim();
+        if (!spec || /[\[\]{}(),]/.test(spec)) {
+            return null;
+        }
+        const parts = spec.split(':').map(part => part.trim());
+        if (parts.length !== 3) {
+            return null;
+        }
+        if (!parts.every(part => Number.isFinite(Number(part)))) {
+            return null;
+        }
+        return { start: parts[0], stop: parts[1], step: parts[2] };
+    }
 
     function ensureInputCanCarryValue(input, value) {
         if (!input) {
@@ -84,7 +125,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const originalType = input.dataset.originalType;
         const textValue = String(value ?? '');
         const wantsGridSpec = textValue.toLowerCase().startsWith('grid=');
-        if (wantsGridSpec && originalType === 'number') {
+        const wantsInvalidNumericText = originalType === 'number' && textValue !== '' && !Number.isFinite(Number(textValue));
+        if ((wantsGridSpec || wantsInvalidNumericText) && originalType === 'number') {
             input.type = 'text';
             input.inputMode = 'decimal';
             return;
@@ -590,7 +632,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function addGridControls(input, preset) {
         const initial = (preset !== undefined && preset !== null) ? preset : (input.value || '');
-        const parsed = parseStructured(initial);
+        const simpleGridRange = parseSimpleGridRangeSpec(initial);
+        const parsed = simpleGridRange ? Number(simpleGridRange.start) : parseStructured(initial);
         const controls = document.createElement('div');
         controls.className = 'grid-parameter-controls hidden mt-2 flex flex-col gap-2';
         const paramName = input.dataset.param || input.name || '';
@@ -603,6 +646,8 @@ document.addEventListener('DOMContentLoaded', function() {
         leaves.forEach((leaf, index) => {
             const label = describeLeafLabel(paramName, leaf.path, index, controls.dataset.gridKind === 'array');
             const startValue = String(leaf.value ?? '');
+            const stepValue = simpleGridRange && leaves.length === 1 ? simpleGridRange.step : '0';
+            const endValue = simpleGridRange && leaves.length === 1 ? simpleGridRange.stop : startValue;
             controls.insertAdjacentHTML('beforeend', `
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-2" data-grid-row="1" data-path="${escapeHtml(JSON.stringify(leaf.path))}" data-param-name="${escapeHtml(paramName)}" data-template-type="${typeof leaf.value}">
                     <div class="text-xs text-slate-600 dark:text-slate-300 md:pt-2" data-param-leaf-label="1">${escapeHtml(label)}</div>
@@ -612,11 +657,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     </label>
                     <label class="flex flex-col gap-1">
                         <span class="text-xs text-slate-600 dark:text-slate-300">Step</span>
-                        <input type="text" data-grid-role="step" class="${baseClass}" value="0" />
+                        <input type="text" data-grid-role="step" class="${baseClass}" value="${escapeHtml(stepValue)}" />
                     </label>
                     <label class="flex flex-col gap-1">
                         <span class="text-xs text-slate-600 dark:text-slate-300">End</span>
-                        <input type="text" data-grid-role="end" class="${baseClass}" value="${escapeHtml(startValue)}" />
+                        <input type="text" data-grid-role="end" class="${baseClass}" value="${escapeHtml(endValue)}" />
                     </label>
                 </div>
             `);
@@ -849,7 +894,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const inputs = section.querySelectorAll('.param-input');
         inputs.forEach(input => {
             const paramName = input.dataset.param;
-            const preset = ncpiPresets[paramName];
+            const preset = restoredValueOrPreset(paramName, ncpiPresets[paramName]);
             if (!input.name) {
                 input.name = paramName;
             }
@@ -863,6 +908,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (!input.dataset.originalType) {
                     input.dataset.originalType = input.type || 'text';
                 }
+                ensureInputCanCarryValue(input, preset);
                 input.value = preset;
             }
 
@@ -877,7 +923,44 @@ document.addEventListener('DOMContentLoaded', function() {
         return section;
     }
 
+    function restoreSimulationFormControls() {
+        const restoredMode = hasRestoredValue('sim_run_mode') ? String(restoreForm.sim_run_mode || '') : '';
+        if (restoredMode) {
+            const modeInput = Array.from(elements.runModeInputs).find(input => input.value === restoredMode);
+            if (modeInput) {
+                modeInput.checked = true;
+            }
+        }
+        if (elements.repetitionsInput && hasRestoredValue('sim_repetitions')) {
+            elements.repetitionsInput.value = String(restoreForm.sim_repetitions ?? '');
+        }
+        if (elements.useNumpySeedInput && Object.keys(restoreForm).length > 0) {
+            elements.useNumpySeedInput.checked = hasRestoredValue('sim_use_numpy_seed');
+        }
+        if (elements.numpySeedInput && hasRestoredValue('sim_numpy_seed')) {
+            elements.numpySeedInput.value = String(restoreForm.sim_numpy_seed ?? '');
+        }
+        if (elements.jointGroupsContainer && hasRestoredValue('sim_joint_groups')) {
+            let groups = [];
+            try {
+                const rawGroups = restoreForm.sim_joint_groups;
+                groups = Array.isArray(rawGroups) ? rawGroups : JSON.parse(String(rawGroups || '[]'));
+            } catch (_err) {
+                groups = [];
+            }
+            if (Array.isArray(groups)) {
+                elements.jointGroupsContainer.replaceChildren();
+                groups.forEach(group => {
+                    if (Array.isArray(group) && group.length > 0) {
+                        addJointGroupCard(group.map(value => String(value)));
+                    }
+                });
+            }
+        }
+    }
+
     createParameterSection();
+    restoreSimulationFormControls();
     refreshLeafLabels();
     refreshJointGroupsUi();
 

--- a/webui/static/js/simulation_four_area.js
+++ b/webui/static/js/simulation_four_area.js
@@ -68,6 +68,47 @@ document.addEventListener('DOMContentLoaded', function() {
         areaEditorStatus: document.getElementById('four-area-editor-status'),
         interAreaModeStatus: document.getElementById('inter-area-mode-status'),
     };
+    const restoreForm = readSimulationRestoreForm();
+
+    function readSimulationRestoreForm() {
+        const node = document.getElementById('simulation-restore-form');
+        if (!node) {
+            return {};
+        }
+        try {
+            const parsed = JSON.parse(node.textContent || '{}');
+            return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+        } catch (_err) {
+            return {};
+        }
+    }
+
+    function hasRestoredValue(name) {
+        return Object.prototype.hasOwnProperty.call(restoreForm, name);
+    }
+
+    function restoredValueOrPreset(name, preset) {
+        return hasRestoredValue(name) ? restoreForm[name] : preset;
+    }
+
+    function parseSimpleGridRangeSpec(value) {
+        const text = String(value ?? '').trim();
+        if (!text.toLowerCase().startsWith('grid=')) {
+            return null;
+        }
+        const spec = text.slice(5).trim();
+        if (!spec || /[\[\]{}(),]/.test(spec)) {
+            return null;
+        }
+        const parts = spec.split(':').map(part => part.trim());
+        if (parts.length !== 3) {
+            return null;
+        }
+        if (!parts.every(part => Number.isFinite(Number(part)))) {
+            return null;
+        }
+        return { start: parts[0], stop: parts[1], step: parts[2] };
+    }
     let areaLocalState = [];
     let activeAreaIndex = 0;
 
@@ -81,7 +122,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const originalType = input.dataset.originalType;
         const textValue = String(value ?? '');
         const wantsGridSpec = textValue.toLowerCase().startsWith('grid=');
-        if (wantsGridSpec && originalType === 'number') {
+        const wantsInvalidNumericText = originalType === 'number' && textValue !== '' && !Number.isFinite(Number(textValue));
+        if ((wantsGridSpec || wantsInvalidNumericText) && originalType === 'number') {
             input.type = 'text';
             input.inputMode = 'decimal';
             return;
@@ -342,6 +384,54 @@ document.addEventListener('DOMContentLoaded', function() {
         });
         areaLocalState = Array.from({ length: totalAreas }, () => cloneLocalAreaState(baseSnapshot));
         activeAreaIndex = 0;
+    }
+
+    function localStateFromRawParamValue(paramName, rawValue) {
+        const state = cloneLocalAreaState(localParamState(paramName) || {});
+        state.inputValue = String(rawValue ?? '');
+
+        const parsed = parseStructured(rawValue);
+        if (Array.isArray(parsed)) {
+            state.singleRows = collectLeaves(parsed).map(leaf => String(leaf.value ?? ''));
+        }
+
+        const simpleGridRange = parseSimpleGridRangeSpec(rawValue);
+        if (simpleGridRange && Array.isArray(state.gridRows) && state.gridRows.length > 0) {
+            state.gridRows = state.gridRows.map((row, index) => {
+                if (index !== 0) {
+                    return row;
+                }
+                return {
+                    start: simpleGridRange.start,
+                    step: simpleGridRange.step,
+                    end: simpleGridRange.stop,
+                };
+            });
+        }
+
+        return state;
+    }
+
+    function restoreAreaLocalStateFromForm() {
+        if (!Array.isArray(areaLocalState) || areaLocalState.length === 0) {
+            return;
+        }
+        let restoredAny = false;
+        for (let areaIndex = 0; areaIndex < areaLocalState.length; areaIndex += 1) {
+            const snapshot = cloneLocalAreaState(areaLocalState[areaIndex] || {});
+            areaSpecificLocalParams.forEach(paramName => {
+                const formKey = `area_${areaIndex}.${paramName}`;
+                if (!hasRestoredValue(formKey)) {
+                    return;
+                }
+                snapshot[paramName] = localStateFromRawParamValue(paramName, restoreForm[formKey]);
+                restoredAny = true;
+            });
+            areaLocalState[areaIndex] = snapshot;
+        }
+        if (restoredAny) {
+            applyAreaLocalState(activeAreaIndex);
+        }
     }
 
     function indexedName(names, index, fallbackPrefix) {
@@ -1034,7 +1124,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function addGridControls(input, preset) {
         const initial = (preset !== undefined && preset !== null) ? preset : (input.value || '');
-        const parsed = parseStructured(initial);
+        const simpleGridRange = parseSimpleGridRangeSpec(initial);
+        const parsed = simpleGridRange ? Number(simpleGridRange.start) : parseStructured(initial);
         const controls = document.createElement('div');
         controls.className = 'grid-parameter-controls hidden mt-2 flex flex-col gap-2';
         const paramName = input.dataset.param || input.name || '';
@@ -1051,6 +1142,8 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             const label = describeLeafLabel(paramName, leaf.path, index, controls.dataset.gridKind === 'array');
             const startValue = String(leaf.value ?? '');
+            const stepValue = simpleGridRange && leaves.length === 1 ? simpleGridRange.step : '0';
+            const endValue = simpleGridRange && leaves.length === 1 ? simpleGridRange.stop : startValue;
             controls.insertAdjacentHTML('beforeend', `
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-2" data-grid-row="1" data-path="${escapeHtml(JSON.stringify(leaf.path))}" data-param-name="${escapeHtml(paramName)}" data-template-type="${typeof leaf.value}">
                     <div class="text-xs text-slate-600 dark:text-slate-300 md:pt-2" data-param-leaf-label="1">${escapeHtml(label)}</div>
@@ -1060,11 +1153,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     </label>
                     <label class="flex flex-col gap-1">
                         <span class="text-xs text-slate-600 dark:text-slate-300">Step</span>
-                        <input type="text" data-grid-role="step" class="${baseClass}" value="0" />
+                        <input type="text" data-grid-role="step" class="${baseClass}" value="${escapeHtml(stepValue)}" />
                     </label>
                     <label class="flex flex-col gap-1">
                         <span class="text-xs text-slate-600 dark:text-slate-300">End</span>
-                        <input type="text" data-grid-role="end" class="${baseClass}" value="${escapeHtml(startValue)}" />
+                        <input type="text" data-grid-role="end" class="${baseClass}" value="${escapeHtml(endValue)}" />
                     </label>
                 </div>
             `);
@@ -1470,7 +1563,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const inputs = section.querySelectorAll('.param-input');
         inputs.forEach(input => {
             const paramName = input.dataset.param;
-            const preset = ncpiPresets[paramName];
+            const preset = restoredValueOrPreset(paramName, ncpiPresets[paramName]);
             if (!input.name) {
                 input.name = paramName;
             }
@@ -1484,6 +1577,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (!input.dataset.originalType) {
                     input.dataset.originalType = input.type || 'text';
                 }
+                ensureInputCanCarryValue(input, preset);
                 input.value = preset;
             }
 
@@ -1500,11 +1594,49 @@ document.addEventListener('DOMContentLoaded', function() {
         return section;
     }
 
+    function restoreSimulationFormControls() {
+        const restoredMode = hasRestoredValue('sim_run_mode') ? String(restoreForm.sim_run_mode || '') : '';
+        if (restoredMode) {
+            const modeInput = Array.from(elements.runModeInputs).find(input => input.value === restoredMode);
+            if (modeInput) {
+                modeInput.checked = true;
+            }
+        }
+        if (elements.repetitionsInput && hasRestoredValue('sim_repetitions')) {
+            elements.repetitionsInput.value = String(restoreForm.sim_repetitions ?? '');
+        }
+        if (elements.useNumpySeedInput && Object.keys(restoreForm).length > 0) {
+            elements.useNumpySeedInput.checked = hasRestoredValue('sim_use_numpy_seed');
+        }
+        if (elements.numpySeedInput && hasRestoredValue('sim_numpy_seed')) {
+            elements.numpySeedInput.value = String(restoreForm.sim_numpy_seed ?? '');
+        }
+        if (elements.jointGroupsContainer && hasRestoredValue('sim_joint_groups')) {
+            let groups = [];
+            try {
+                const rawGroups = restoreForm.sim_joint_groups;
+                groups = Array.isArray(rawGroups) ? rawGroups : JSON.parse(String(rawGroups || '[]'));
+            } catch (_err) {
+                groups = [];
+            }
+            if (Array.isArray(groups)) {
+                elements.jointGroupsContainer.replaceChildren();
+                groups.forEach(group => {
+                    if (Array.isArray(group) && group.length > 0) {
+                        addJointGroupCard(group.map(value => String(value)));
+                    }
+                });
+            }
+        }
+    }
+
     // Initialize UI
     createParameterSection();
+    restoreSimulationFormControls();
     setupInterAreaMatrixUi();
     refreshLeafLabels();
     initializeAreaLocalState();
+    restoreAreaLocalStateFromForm();
     refreshAreaSelectorOptions();
     refreshJointGroupsUi();
 

--- a/webui/templates/1.2.2.new_sim_hagen.html
+++ b/webui/templates/1.2.2.new_sim_hagen.html
@@ -187,6 +187,7 @@
 
 
 <form id="run-simulation-form" method="POST" action="{{ url_for('run_trial_simulation', model_type='hagen') }}">
+    <script id="simulation-restore-form" type="application/json">{{ simulation_restore_form | default({}) | tojson }}</script>
     <section class="flex flex-col gap-4 px-4 pb-2">
         <h2 class="text-slate-900 dark:text-white text-xl font-bold leading-tight tracking-[-0.015em]">Simulation mode</h2>
         <div class="flex flex-col md:flex-row gap-4">

--- a/webui/templates/1.2.3.new_sim_four_area.html
+++ b/webui/templates/1.2.3.new_sim_four_area.html
@@ -230,6 +230,7 @@
 
 
 <form id="run-simulation-form" method="POST" action="{{ url_for('run_trial_simulation', model_type='four_area') }}">
+    <script id="simulation-restore-form" type="application/json">{{ simulation_restore_form | default({}) | tojson }}</script>
     <section class="flex flex-col gap-3 px-4 pb-2">
         <h2 class="text-slate-900 dark:text-white text-xl font-bold leading-tight tracking-[-0.015em]">Local area editor</h2>
         <div class="grid grid-cols-1 md:grid-cols-[minmax(14rem,20rem)_1fr] gap-3 items-end">

--- a/webui/templates/1.2.4.new_sim_cavallari.html
+++ b/webui/templates/1.2.4.new_sim_cavallari.html
@@ -239,6 +239,7 @@
 </template>
 
 <form id="run-simulation-form" method="POST" action="{{ url_for('run_trial_simulation', model_type='cavallari') }}">
+    <script id="simulation-restore-form" type="application/json">{{ simulation_restore_form | default({}) | tojson }}</script>
     <section class="flex flex-col gap-4 px-4 pb-2">
         <h2 class="text-slate-900 dark:text-white text-xl font-bold leading-tight tracking-[-0.015em]">Simulation mode</h2>
         <div class="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-left dark:border-amber-500/30 dark:bg-amber-500/10">


### PR DESCRIPTION
This PR improves the WebUI Simulation configuration flow for predefined simulations (Hagen, Cavallari, Four-area).

It adds form restoration after server-side configuration errors, so users no longer lose their current setup when they need to fix a single invalid field. It also adds backend validation for common simulation configuration constraints and improves error messages so they refer to user-facing field labels instead of internal Python paths.

## Changes

- Preserve submitted Simulation configuration after pre-job validation errors.
  - Stores the submitted form temporarily in the Flask session.
  - Restores it only on the matching simulation page.
  - Applies to Hagen, Cavallari, and Four-area predefined simulations.

- Restore UI state after returning to configuration.
  - Parameter values now prefer restored form values over JS presets.
  - Restores run mode, repetitions, NumPy seed settings, and joint sweep groups.
  - Four-area also restores area-local fields like `area_0.*`.

- Add server-side validation for Simulation configuration.
  - Time values must be `> 0`.
  - Population sizes must be `>= 0`.
  - Grid ranges must follow step direction:
    - positive step: end must be greater than start;
    - negative step: end must be less than start.
  - Connection probabilities must be `>= 0`.

- Improve validation messages.
  - Errors now use UI-facing field labels instead of internal indexed names.
  - Example: `Population sizes Nₓ must be >= 0` instead of `'N_X[0]' must be >= 0`.