### PR TITLE
Rename and restyle buttons

### DIFF
--- a/tests/webui/Features/test_subsample_webui_Krukow_Eyes_close.py
+++ b/tests/webui/Features/test_subsample_webui_Krukow_Eyes_close.py
@@ -21,7 +21,7 @@ def run(playwright: Playwright) -> None:
     page.get_by_label("Samples axis Dim 0 Dim 1 Dim").first.select_option("1")
     page.get_by_label("IDs axis None Dim 0 Dim 1 Dim").first.select_option("-1")
     page.get_by_label("Trials/Epochs axis None Dim 0").first.select_option("0")
-    page.get_by_label("Recording type source * Value").first.select_option("__value__")
+    page.get_by_label("Recording type source * Custom (Select Recording type value)").first.select_option("__value__")
     page.get_by_label("Recording type value LFP CDM").first.select_option("EEG")
     page.get_by_label("Subject ID source None Custom").select_option("__file_extracted_sep__underscore__2")
     page.get_by_label("Group source None Custom").select_option("__file_extracted_sep__underscore__0")

--- a/tests/webui/Features/test_subsample_webui_Krukow_ShortBlock.py
+++ b/tests/webui/Features/test_subsample_webui_Krukow_ShortBlock.py
@@ -22,7 +22,7 @@ def run(playwright: Playwright) -> None:
     page.get_by_label("Samples axis Dim 0 Dim 1 Dim").first.select_option("1")
     page.get_by_label("IDs axis None Dim 0 Dim 1 Dim").first.select_option("-1")
     page.get_by_label("Trials/Epochs axis None Dim 0").first.select_option("0")
-    page.get_by_label("Recording type source * Value").first.select_option("__value__")
+    page.get_by_label("Recording type source * Custom (Select Recording type value)").first.select_option("__value__")
     page.get_by_label("Recording type value LFP CDM").first.select_option("EEG")
     page.get_by_label("Subject ID source None Custom").select_option("__file_id__")
     page.get_by_label("Group source None Custom").select_option("__file_extracted_sep__underscore__0")
@@ -58,4 +58,3 @@ def run(playwright: Playwright) -> None:
 def test_features_subsample_Krukow_ShortBlock():
     with sync_playwright() as playwright:
         run(playwright)
-

--- a/tests/webui/Features/test_subsample_webui_POCTEP_RAW.py
+++ b/tests/webui/Features/test_subsample_webui_POCTEP_RAW.py
@@ -22,7 +22,7 @@ def run(playwright: Playwright) -> None:
     page.get_by_label("Samples axis Dim 0 Dim 1 Dim").first.select_option("0")
     page.get_by_label("IDs axis None Dim 0 Dim 1 Dim").first.select_option("-1")
     page.get_by_label("Trials/Epochs axis None Dim 0").first.select_option("-1")
-    page.get_by_label("Recording type source * Value").first.select_option("__value__")
+    page.get_by_label("Recording type source * Custom (Select Recording type value)").first.select_option("__value__")
     page.get_by_label("Recording type value LFP CDM").first.select_option("EEG")
     page.get_by_label("Subject ID source None Custom").select_option("__file_extracted_sep__underscore__1")
     page.get_by_label("Group source None Custom").select_option("__file_extracted_sep__underscore__0")
@@ -63,4 +63,3 @@ def run(playwright: Playwright) -> None:
 def test_features_subsample_POCTEP_RAW():
     with sync_playwright() as playwright:
         run(playwright)
-

--- a/tests/webui/Features/test_subsample_webui_POCTEP_SENSORS.py
+++ b/tests/webui/Features/test_subsample_webui_POCTEP_SENSORS.py
@@ -30,7 +30,7 @@ def run(playwright: Playwright) -> None:
     page.get_by_label("Condition source None Custom").select_option("__value__")
     page.get_by_role("textbox", name="Condition value").click()
     page.get_by_role("textbox", name="Condition value").fill("resting-state")
-    page.get_by_label("Recording type source * Value").first.select_option("__value__")
+    page.get_by_label("Recording type source * Custom (Select Recording type value)").first.select_option("__value__")
     page.get_by_label("Recording type value LFP CDM").first.select_option("EEG")
     page.get_by_role("checkbox", name="Enable epoching").check()
     page.get_by_role("checkbox", name="Apply z-score before epoching").check()
@@ -63,4 +63,3 @@ def run(playwright: Playwright) -> None:
 def test_features_subsample_POCTEP_SENSORS():
     with sync_playwright() as playwright:
         run(playwright)
-

--- a/tests/webui/Features/test_subsample_webui_POCTEP_SOURCES.py
+++ b/tests/webui/Features/test_subsample_webui_POCTEP_SOURCES.py
@@ -22,7 +22,7 @@ def run(playwright: Playwright) -> None:
     page.get_by_label("Samples axis Dim 0 Dim 1 Dim").first.select_option("0")
     page.get_by_label("IDs axis None Dim 0 Dim 1 Dim").first.select_option("-1")
     page.get_by_label("Trials/Epochs axis None Dim 0").first.select_option("-1")
-    page.get_by_label("Recording type source * Value").first.select_option("__value__")
+    page.get_by_label("Recording type source * Custom (Select Recording type value)").first.select_option("__value__")
     page.get_by_label("Recording type value LFP CDM").first.select_option("EEG")
     page.get_by_label("Subject ID source None Custom").select_option("__file_extracted_sep__underscore__1")
     page.get_by_label("Group source None Custom").select_option("__file_extracted_sep__underscore__0")
@@ -63,4 +63,3 @@ def run(playwright: Playwright) -> None:
 def test_features_subsample_POCTEP_SOURCES():
     with sync_playwright() as playwright:
         run(playwright)
-

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -4055,17 +4055,17 @@ def custom_feature(sample, params):
                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm"
                             >
                         </label>
-                        <div class="flex flex-wrap gap-2">
+                        <div class="flex flex-wrap gap-2 pt-1">
                             <button
                                 type="button"
                                 @click="applyFilenameFormatAndReinspect()"
-                                class="px-2 py-1 rounded border border-primary/40 bg-white dark:bg-[#191e33] text-primary text-[11px] font-semibold hover:bg-primary/10">
+                                class="w-[8.0rem] px-2 py-0.1 rounded-lg border border-green-700 bg-green-600 text-white text-sm font-semibold shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-[#111422]">
                                 Inspect
                             </button>
                             <button
                                 type="button"
                                 @click="clearFilenameFormatAndReinspect()"
-                                class="px-2 py-1 rounded border border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-gray-700 dark:text-gray-300 text-[11px] font-semibold hover:bg-gray-50 dark:hover:bg-[#222a45]">
+                                class="w-[8.0rem] px-2 py-0.1 rounded-lg border border-gray-900 bg-white dark:bg-[#191e33] text-gray-900 dark:text-gray-100 text-sm font-semibold shadow-sm hover:bg-gray-50 dark:hover:bg-[#222a45] focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-[#111422]">
                                 Use automatic detection
                             </button>
                         </div>
@@ -4115,16 +4115,18 @@ def custom_feature(sample, params):
                                         x-text="token">
                                     </button>
                                 </template>
+                            </div>
+                            <div class="flex flex-wrap gap-2 pt-1">
                                 <button
                                     type="button"
                                     @click="applyFilenameFormatAndReinspect()"
-                                    class="px-2 py-1 rounded border border-primary/40 bg-white dark:bg-[#191e33] text-primary text-[11px] font-semibold hover:bg-primary/10">
+                                    class="w-[8.0rem] px-2 py-0.1 rounded-lg border border-green-700 bg-green-600 text-white text-sm font-semibold shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-[#191e33]">
                                     Inspect
                                 </button>
                                 <button
                                     type="button"
                                     @click="clearFilenameFormatAndReinspect()"
-                                    class="px-2 py-1 rounded border border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-gray-700 dark:text-gray-300 text-[11px] font-semibold hover:bg-gray-50 dark:hover:bg-[#222a45]">
+                                    class="w-[8.0rem] px-2 py-0.1 rounded-lg border border-gray-900 bg-white dark:bg-[#191e33] text-gray-900 dark:text-gray-100 text-sm font-semibold shadow-sm hover:bg-gray-50 dark:hover:bg-[#222a45] focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-[#191e33]">
                                     Use automatic detection
                                 </button>
                             </div>
@@ -4629,7 +4631,7 @@ def custom_feature(sample, params):
                                             <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Recording type source *</span>
                                             <select name="parser_recording_type_source" x-model="parserRecordingTypeSource" @change="onPipelineRecordingTypeSourceChange()"
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                                <option value="__value__" :style="parserManualOptionStyle()">Value</option>
+                                                <option value="__value__" :style="parserManualOptionStyle()">Custom (Select Recording type value)</option>
                                                 <template x-for="field in parserInfo.candidate_fields || []" :key="'pipeline-rec-type-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>
@@ -4955,7 +4957,7 @@ def custom_feature(sample, params):
                                             <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Recording type source *</span>
                                             <select name="parser_recording_type_source" x-model="parserRecordingTypeSource" @change="onPipelineRecordingTypeSourceChange()"
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
-                                                <option value="__value__" :style="parserManualOptionStyle()">Value</option>
+                                                <option value="__value__" :style="parserManualOptionStyle()">Custom (Select Recording type value)</option>
                                                 <template x-for="field in parserInfo.candidate_fields || []" :key="'rec-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>


### PR DESCRIPTION
- Restyled the filename format action buttons to make `Inspect` more visible.
- Moved the action buttons below the filename format tokens.
- Updated `Inspect` with a green highlighted style.
- Updated `Use automatic detection` to match the same button size with the dark/neutral styling.
- Renamed the recording type manual option label to `Custom (Select Recording type value)`.
- Updated affected WebUI tests to use the new recording type option label.