### PR TITLE
Correct subfolder filter and remove folder selector in Features module

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -2790,55 +2790,6 @@ def _numeric_wildcard_stem(stem):
     return wildcard, re.compile(regex_src)
 
 
-def _extract_analysis_folder_name_tokens_from_form(form, key="parser_analysis_folder_names"):
-    tokens = []
-    for raw in _extract_text_list_from_form(form, key):
-        safe = secure_filename(str(raw or "")).strip("_")
-        token = safe or "selected_folder"
-        if token and token not in tokens:
-            tokens.append(token)
-    return tokens
-
-
-def _resolve_selected_analysis_folder_paths(form, folder_summaries):
-    available_paths = []
-    seen = set()
-    for item in folder_summaries or []:
-        path = str(item.get("folder_path") or "").strip()
-        if not path or path in seen:
-            continue
-        seen.add(path)
-        available_paths.append(path)
-
-    if not available_paths:
-        return []
-
-    selected_paths = _extract_folder_paths_from_form(
-        form,
-        singular_key=None,
-        plural_key="parser_analysis_folder_paths",
-    )
-    if len(selected_paths) > 1:
-        raise ValueError("Select only one folder for feature extraction.")
-
-    selected_path = selected_paths[0] if selected_paths else ""
-    available_set = set(available_paths)
-    unknown = [selected_path] if selected_path and selected_path not in available_set else []
-    if unknown:
-        raise ValueError(
-            "Unknown folders selected for feature extraction: "
-            + ", ".join(unknown[:4])
-            + (", ..." if len(unknown) > 4 else "")
-        )
-
-    if "parser_analysis_folder_paths" in form and len(available_paths) > 1 and not selected_path:
-        raise ValueError("Select one folder for feature extraction.")
-
-    if not selected_path:
-        return [available_paths[0]]
-    return [selected_path]
-
-
 # def _validate_uniform_supported_extension_per_folder(entries, label):
 #     ext_by_folder = defaultdict(set)
 #     folder_labels = {}
@@ -16671,14 +16622,20 @@ def start_computation_redirect(computation_type):
                     simulation_subfolder_filter_map = _extract_subfolder_filter_map_from_form(
                         request.form,
                         "simulation_subfolder_selections",
+                    ) or _extract_subfolder_filter_map_from_form(
+                        request.form,
+                        "empirical_subfolder_selections",
                     )
                     simulation_entries, folder_summaries, _, folder_contexts = _collect_supported_folder_file_entries(
                         simulation_folder_paths,
                         "Simulation outputs",
                         data_file_selection_map=simulation_data_file_selections,
                     )
-                    selected_analysis_paths = _resolve_selected_analysis_folder_paths(request.form, folder_summaries)
-                    selected_set = set(selected_analysis_paths)
+                    selected_set = {
+                        str(item.get("folder_path") or "").strip()
+                        for item in (folder_summaries or [])
+                        if str(item.get("folder_path") or "").strip()
+                    }
                     selected_entries = [
                         entry for entry in simulation_entries
                         if str(entry.get("folder_path") or "") in selected_set
@@ -16709,7 +16666,7 @@ def start_computation_redirect(computation_type):
                         "[compute %s] simulation folder mode folders=%d selected_folders=%d files=%d selected_files=%d",
                         job_id,
                         len(folder_summaries),
-                        len(selected_analysis_paths),
+                        len(selected_set),
                         len(simulation_entries),
                         len(selected_entries),
                     )
@@ -16766,8 +16723,11 @@ def start_computation_redirect(computation_type):
                         "Empirical",
                         data_file_selection_map=empirical_data_file_selections,
                     )
-                    selected_analysis_paths = _resolve_selected_analysis_folder_paths(request.form, folder_summaries)
-                    selected_set = set(selected_analysis_paths)
+                    selected_set = {
+                        str(item.get("folder_path") or "").strip()
+                        for item in (folder_summaries or [])
+                        if str(item.get("folder_path") or "").strip()
+                    }
                     selected_entries = [
                         entry for entry in empirical_entries
                         if str(entry.get("folder_path") or "") in selected_set
@@ -16798,7 +16758,7 @@ def start_computation_redirect(computation_type):
                         "[compute %s] empirical folder mode folders=%d selected_folders=%d files=%d selected_files=%d",
                         job_id,
                         len(folder_summaries),
-                        len(selected_analysis_paths),
+                        len(selected_set),
                         len(empirical_entries),
                         len(selected_entries),
                     )
@@ -17095,8 +17055,11 @@ def start_computation_redirect(computation_type):
                         "Simulation outputs",
                         data_file_selection_map=simulation_data_file_selections,
                     )
-                    selected_analysis_paths = _resolve_selected_analysis_folder_paths(request.form, folder_summaries)
-                    selected_path_set = set(selected_analysis_paths)
+                    selected_path_set = {
+                        str(item.get("folder_path") or "").strip()
+                        for item in (folder_summaries or [])
+                        if str(item.get("folder_path") or "").strip()
+                    }
                     selected_entries = [
                         entry for entry in source_entries
                         if str(entry.get("folder_path") or "") in selected_path_set
@@ -17107,6 +17070,18 @@ def start_computation_redirect(computation_type):
                         if folder_path not in selected_path_set:
                             continue
                         selected_data_entries.extend(list(context.get("selected_entries") or []))
+                    if simulation_subfolder_filter_map and selected_data_entries:
+                        _filtered = []
+                        for _entry in selected_data_entries:
+                            _fp = str(_entry.get("folder_path") or "").strip()
+                            _included = simulation_subfolder_filter_map.get(_fp, [])
+                            if not _included:
+                                _filtered.append(_entry)
+                                continue
+                            _sub = str(_entry.get("level1_subfolder") or "").strip()
+                            if not _sub or _sub in _included:
+                                _filtered.append(_entry)
+                        selected_data_entries = _filtered
                     if selected_data_entries:
                         selected_entries = selected_data_entries
                     if not filename_format_spec:
@@ -17122,6 +17097,7 @@ def start_computation_redirect(computation_type):
                                 source_entries,
                                 selected_path_set,
                                 nested_selected_exts,
+                                simulation_subfolder_filter_map,
                             )
                             if expanded_auto_entries:
                                 selected_entries = expanded_auto_entries
@@ -17136,6 +17112,7 @@ def start_computation_redirect(computation_type):
                             source_entries,
                             selected_path_set,
                             folder_contexts,
+                            simulation_subfolder_filter_map,
                         )
                         if expanded_entries:
                             selected_entries = expanded_entries
@@ -17235,20 +17212,6 @@ def start_computation_redirect(computation_type):
                         row for row in upload_items
                         if Path(str(row[1] or "")).suffix.lower() in FEATURES_PARSER_FILE_EXTENSIONS
                     ]
-                    selected_analysis_name_tokens = _extract_analysis_folder_name_tokens_from_form(request.form)
-                    if len(selected_analysis_name_tokens) > 1:
-                        raise ValueError("Select only one folder for feature extraction.")
-                    if "parser_analysis_folder_names" in request.form and len(local_folder_tokens) > 1 and not selected_analysis_name_tokens:
-                        raise ValueError("Select one folder for feature extraction.")
-                    selected_token = selected_analysis_name_tokens[0] if selected_analysis_name_tokens else (
-                        local_folder_tokens[0] if local_folder_tokens else None
-                    )
-                    if selected_token and selected_token not in local_folder_token_set:
-                        raise ValueError(
-                            f"Unknown local folder selected for feature extraction: {selected_token}"
-                        )
-                    if selected_token:
-                        upload_items = [row for row in upload_items if row[3] == selected_token]
                     if filename_format_spec:
                         upload_items, skipped_names = _filter_named_items_by_filename_format(
                             upload_items,
@@ -17387,8 +17350,11 @@ def start_computation_redirect(computation_type):
                         "Empirical",
                         data_file_selection_map=empirical_data_file_selections,
                     )
-                    selected_analysis_paths = _resolve_selected_analysis_folder_paths(request.form, folder_summaries)
-                    selected_path_set = set(selected_analysis_paths)
+                    selected_path_set = {
+                        str(item.get("folder_path") or "").strip()
+                        for item in (folder_summaries or [])
+                        if str(item.get("folder_path") or "").strip()
+                    }
                     selected_entries = [
                         entry for entry in source_entries
                         if str(entry.get("folder_path") or "") in selected_path_set
@@ -17541,19 +17507,6 @@ def start_computation_redirect(computation_type):
                         row for row in upload_items
                         if Path(str(row[1] or "")).suffix.lower() in FEATURES_PARSER_FILE_EXTENSIONS
                     ]
-                    selected_analysis_name_tokens = _extract_analysis_folder_name_tokens_from_form(request.form)
-                    if len(selected_analysis_name_tokens) > 1:
-                        raise ValueError("Select only one folder for feature extraction.")
-                    if "parser_analysis_folder_names" in request.form and len(local_folder_tokens) > 1 and not selected_analysis_name_tokens:
-                        raise ValueError("Select one folder for feature extraction.")
-                    selected_token = selected_analysis_name_tokens[0] if selected_analysis_name_tokens else (
-                        local_folder_tokens[0] if local_folder_tokens else None
-                    )
-                    if selected_token and selected_token not in local_folder_token_set:
-                        raise ValueError(
-                            f"Unknown local folder selected for feature extraction: {selected_token}"
-                        )
-
                     # Before folder filtering, try to resolve companion channel-names file
                     # from any uploaded subfolder (e.g. channels/channels.mat alongside data/).
                     if (

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -67,8 +67,6 @@
             parserDeepScanError: '',
             parserInspectionGeneration: 0,
             parserFilenameFormat: '',
-            parserAnalysisFolderPaths: [],
-            parserAnalysisFolderNames: [],
             empiricalDataFileSelections: {},
             empiricalSubfolderSelections: {},
             empiricalFileCount: 0,
@@ -298,8 +296,6 @@ def custom_feature(sample, params):
                     'parserDeepScanError',
                     'parserInspectionGeneration',
                     'parserFilenameFormat',
-                    'parserAnalysisFolderPaths',
-                    'parserAnalysisFolderNames',
                     'parserDataLocator',
                     'parserFsManual',
                     'parserFsSource',
@@ -911,10 +907,6 @@ def custom_feature(sample, params):
             },
             selectedServerDataFolderPath() {
                 if (!this.isServerDataFolderMode()) return '';
-                const analysisPath = Array.isArray(this.parserAnalysisFolderPaths)
-                    ? String(this.parserAnalysisFolderPaths[0] || '').trim()
-                    : '';
-                if (analysisPath) return analysisPath;
                 const primaryPath = String(this.simulationFolderPath || '').trim();
                 if (primaryPath) return primaryPath;
                 const folderPaths = Array.isArray(this.simulationFolderPaths)
@@ -1390,19 +1382,7 @@ def custom_feature(sample, params):
                 return Array.isArray(this.parserInfo?.folder_summaries) ? this.parserInfo.folder_summaries : [];
             },
             selectedAnalysisFolderSummary() {
-                const folders = this.parserFolderSummaries();
-                if (!folders.length) return null;
-                const selectedPath = Array.isArray(this.parserAnalysisFolderPaths) ? String(this.parserAnalysisFolderPaths[0] || '').trim() : '';
-                if (selectedPath) {
-                    const matchByPath = folders.find((folder) => String(folder?.folder_path || '').trim() === selectedPath);
-                    if (matchByPath) return matchByPath;
-                }
-                const selectedName = Array.isArray(this.parserAnalysisFolderNames) ? String(this.parserAnalysisFolderNames[0] || '').trim() : '';
-                if (selectedName) {
-                    const matchByName = folders.find((folder) => String(folder?.folder_name || '').trim() === selectedName);
-                    if (matchByName) return matchByName;
-                }
-                return folders[0] || null;
+                return (this.parserFolderSummaries() || [])[0] || null;
             },
             selectedAnalysisFolderName() {
                 const folder = this.selectedAnalysisFolderSummary();
@@ -1724,64 +1704,7 @@ def custom_feature(sample, params):
                 const name = String(folder?.folder_name || '').trim();
                 return { type: 'name', value: name || 'selected_folder' };
             },
-            parserIsFolderSelected(folder) {
-                const token = this.parserFolderToken(folder);
-                if (!token.value) return false;
-                if (token.type === 'path') {
-                    return (this.parserAnalysisFolderPaths || []).includes(token.value);
-                }
-                return (this.parserAnalysisFolderNames || []).includes(token.value);
-            },
-            parserToggleFolderSelection(folder) {
-                const token = this.parserFolderToken(folder);
-                if (!token.value) return;
-                if (token.type === 'path') {
-                    this.parserAnalysisFolderPaths = [token.value];
-                    this.parserAnalysisFolderNames = [];
-                    this.ensureDataLocatorMatchesSelectedFolder();
-                    this.syncAdditionalFileSourceModeWithDataSource();
-                    return;
-                }
-                this.parserAnalysisFolderNames = [token.value];
-                this.parserAnalysisFolderPaths = [];
-                this.ensureDataLocatorMatchesSelectedFolder();
-                this.syncAdditionalFileSourceModeWithDataSource();
-            },
-            parserSelectedFolderCount() {
-                let selectedCount = 0;
-                for (const folder of this.parserFolderSummaries()) {
-                    if (this.parserIsFolderSelected(folder)) selectedCount += 1;
-                }
-                return selectedCount;
-            },
             syncAnalysisFolderSelection(payload) {
-                const folders = Array.isArray(payload?.folder_summaries) ? payload.folder_summaries : [];
-                const availablePaths = folders
-                    .map((folder) => String(folder?.folder_path || '').trim())
-                    .filter((value) => value.length > 0);
-                const availableNames = folders
-                    .filter((folder) => String(folder?.folder_path || '').trim().length === 0)
-                    .map((folder) => String(folder?.folder_name || '').trim() || 'selected_folder');
-
-                const currentPaths = Array.isArray(this.parserAnalysisFolderPaths) ? this.parserAnalysisFolderPaths : [];
-                const currentNames = Array.isArray(this.parserAnalysisFolderNames) ? this.parserAnalysisFolderNames : [];
-
-                const currentPath = availablePaths.find((path) => currentPaths.includes(path)) || '';
-                const currentName = availableNames.find((name) => currentNames.includes(name)) || '';
-
-                const selectedToken = currentPath
-                    ? { type: 'path', value: currentPath }
-                    : (currentName
-                        ? { type: 'name', value: currentName }
-                        : (availablePaths.length > 0
-                            ? { type: 'path', value: availablePaths[0] }
-                            : (availableNames.length > 0
-                                ? { type: 'name', value: availableNames[0] }
-                                : null)));
-
-                // Path and name tokens must stay mutually exclusive when data folders are mixed with metadata files.
-                this.parserAnalysisFolderPaths = selectedToken?.type === 'path' ? [selectedToken.value] : [];
-                this.parserAnalysisFolderNames = selectedToken?.type === 'name' ? [selectedToken.value] : [];
                 this.ensureDataLocatorMatchesSelectedFolder();
                 this.syncAdditionalFileSourceModeWithDataSource();
             },
@@ -1940,7 +1863,6 @@ def custom_feature(sample, params):
                 const chSource = String(this.parserChNamesSource || '').trim();
                 if (!chSource) return 'Select a channel names source.';
                 if (chSource === '__manual__' && !String(this.parserSensorNames || '').trim()) return 'Provide manual channel names (comma-separated).';
-                if (this.parserFolderSelectionCount() > 1 && this.parserSelectedFolderCount() !== 1) return 'Select exactly one folder for parser analysis.';
 
                 if (kind === 'pipeline') {
                     if (this.parserEnableEpoching && (!this.parserEpochLengthS || !this.parserEpochStepS)) return 'Epoching is enabled. Set both epoch length and epoch step.';
@@ -2151,8 +2073,6 @@ def custom_feature(sample, params):
                 this.parserAggregateMethod = 'sum';
                 this.parserAggregateLabels = '';
                 this.parserAggregateLabelValue = '';
-                this.parserAnalysisFolderPaths = [];
-                this.parserAnalysisFolderNames = [];
                 this.simulationFolderExtensionError = '';
             },
             selectPipeline(path) {
@@ -3833,8 +3753,6 @@ def custom_feature(sample, params):
                     <input type="hidden" name="simulation_folder_path" :value="simulationFolderPath">
                     <input type="hidden" name="simulation_folder_paths" :value="JSON.stringify(simulationFolderPaths || [])">
                     <input type="hidden" name="simulation_data_file_selections" :value="JSON.stringify(simulationDataFileSelections || {})">
-                    <input type="hidden" name="parser_analysis_folder_paths" :value="JSON.stringify(parserAnalysisFolderPaths || [])">
-                    <input type="hidden" name="parser_analysis_folder_names" :value="JSON.stringify(parserAnalysisFolderNames || [])">
                     <input type="hidden" name="parser_deep_scan_status" :value="parserDeepScanStatus">
                     <input type="hidden" name="parser_array_axes_enabled"
                         :value="(resolvedDataSourceKind() === 'new-simulation' || resolvedDataSourceKind() === 'new-empirical') ? '1' : (parserArrayAxesEnabled ? '1' : '0')">
@@ -4146,36 +4064,7 @@ def custom_feature(sample, params):
                             </div>
                         </div>
 
-                        <div x-show="(parserInfo.folder_summaries || []).length > 1" class="space-y-2">
-                            <h4 class="text-xs font-semibold text-[#34495E] dark:text-white uppercase tracking-wide">Folder used for feature extraction</h4>
-                            <p class="text-[11px] text-gray-500 dark:text-gray-400">
-                                Select exactly one data folder for feature extraction. The other folders are used only to populate parser metadata fields.
-                            </p>
-                            <div class="space-y-2">
-                                <template x-for="folder in parserInfo.folder_summaries || []" :key="'analysis-folder-'+(folder.folder_path || folder.folder_name)">
-                                    <label class="flex items-start gap-2 p-2 rounded-lg border border-gray-200 dark:border-[#323b67] text-xs text-gray-700 dark:text-gray-200 cursor-pointer">
-                                        <input type="radio"
-                                            name="parser-analysis-folder-ui"
-                                            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
-                                            :checked="parserIsFolderSelected(folder)"
-                                            @change="parserToggleFolderSelection(folder)">
-                                        <span class="flex-1">
-                                            <span class="block font-semibold" x-text="folder.folder_name || folder.folder_path"></span>
-                                            <span class="block font-mono break-all opacity-80" x-show="folder.folder_path" x-text="folder.folder_path"></span>
-                                            <span class="block mt-1 opacity-80"><span x-text="folder.file_count || 0"></span> file(s)</span>
-                                        </span>
-                                    </label>
-                                </template>
-                            </div>
-                            <p class="text-xs text-red-600 dark:text-red-400" x-show="parserSelectedFolderCount() !== 1">
-                                Select one folder for feature extraction.
-                            </p>
-                        </div>
-
                         <div x-show="(parserInfo.folder_profiles || []).length > 0" class="space-y-4">
-                            <!-- [DEBUG] -->
-                            <pre class="text-[10px] bg-gray-900 text-green-300 p-2 rounded overflow-x-auto max-h-40"
-                                 x-text="JSON.stringify((parserInfo.folder_profiles||[]).map(p=>({name:p.folder_name,has_nested:p.has_nested_subfolders,all_subfolders:p.all_subfolders})), null, 2)"></pre>
                             <template x-for="folderProfile in parserInfo.folder_profiles || []" :key="'folder-profile-'+(folderProfile.folder_path || folderProfile.folder_name)">
                                 <div class="rounded-lg border border-gray-200 dark:border-[#323b67] p-3 space-y-3">
                                     <div class="flex flex-col gap-1">


### PR DESCRIPTION
### `webui/app.py`
- Read subfolder filter from `empirical_subfolder_selections` as fallback when `simulation_subfolder_selections` is absent.
- Apply `simulation_subfolder_filter_map` directly to `selected_data_entries` before it overwrites `selected_entries`.
- Pass `simulation_subfolder_filter_map` to `_expand_entries_for_selected_extensions_scope` and `_expand_entries_for_filename_format_scope`.
- Replace all calls to `_resolve_selected_analysis_folder_paths` with a set of all available folder paths from `folder_summaries`.
- Remove `_resolve_selected_analysis_folder_paths` and `_extract_analysis_folder_name_tokens_from_form`.
- Remove folder-selection validation from local upload paths.

### `webui/templates/3.1.features_methods.html`
- Remove the "Folder used for feature extraction" radio button section.
- Remove `parserAnalysisFolderPaths` / `parserAnalysisFolderNames` state, persist entries, and associated functions (`parserIsFolderSelected`, `parserToggleFolderSelection`, `parserSelectedFolderCount`).
- Remove hidden inputs `parser_analysis_folder_paths` and `parser_analysis_folder_names`.
- Simplify `selectedAnalysisFolderSummary` to return the first available folder.
- Remove debug `<pre>` block.