### PR TITLE
auto-open browser on local server startup

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -18399,4 +18399,10 @@ def download_results(job_id):
     )
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import threading
+    import webbrowser
+    host = '127.0.0.1'
+    port = 5000
+    if host in ('127.0.0.1', 'localhost'):
+        threading.Timer(1.0, lambda: webbrowser.open(f'http://{host}:{port}')).start()
+    app.run(debug=True, host=host, port=port)


### PR DESCRIPTION
## Auto-open browser on local WebUI startup

  Adds automatic browser launch when starting the WebUI server locally with `python webui/app.py`. The browser opens at
  `http://127.0.0.1:5000` one second after the server starts, so the user no longer has to copy-paste the URL manually.

  ### Why it only works locally

  The browser is opened using Python's `webbrowser` module, which calls the browser **installed on the same machine where 
  the Python process is running**. When the server runs on a remote machine, `webbrowser.open()` would attempt to launch a
   browser there — which typically has no graphical interface — so it would silently fail or error.

  There is no way for a Flask server to trigger a browser on the client side at startup, because at that point no client
  has connected yet. The HTTP protocol is request-driven: the server can only respond to requests, never push an action to
   a browser that hasn't visited the URL first.

  ### Solution

  The auto-open behavior is guarded by checking whether the server is binding to `127.0.0.1` or `localhost`. If the host
  is anything else (e.g. `0.0.0.0` for a remote or LAN deployment), the browser is not opened and the server starts
  normally, printing the address to the terminal as usual.