### PR TITLE
webui: add unified local and remote launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,30 +99,155 @@ pip install "ncpi[hctsa]"           # hctsa backend support
 
 ## 5) WebUI: installation and usage
 
-The WebUI is available from the repository source (`webui/app.py`).
+The WebUI is run from a source checkout of this repository. Clone the repository before using the launcher:
+
+```bash
+git clone https://github.com/necolab-ugr/ncpi.git
+cd ncpi
+```
+
+If the repository is already cloned, update it before continuing:
+
+```bash
+git pull --ff-only
+```
 
 ### Install WebUI dependencies
-After activating your Conda environment:
+
+Activate the Conda environment on the machine that will run Flask, then install the WebUI dependencies:
 
 ```bash
-pip install "ncpi[webui]"
+conda activate ncpi-env
+pip install -e ".[webui]"
 ```
 
-### Start WebUI
-From the repository root:
+The editable installation uses the code in the current, updated repository checkout.
+
+For local execution, this is your local machine. For remote execution, these dependencies must be installed in the
+Conda environment on the server.
+
+### Run locally
+
+From the repository root, with the Conda environment activated:
 
 ```bash
-python webui/app.py
+python webui/launcher.py local
 ```
 
-Then open:
+The launcher starts Flask and opens the default browser at:
 
 ```text
 http://127.0.0.1:5000
 ```
 
-For best results, we recommend running the WebUI in Chrome, as our tests are most stable there and we have observed a
-couple of issues in other browsers.
+The following compatibility command also starts the local WebUI:
+
+```bash
+python webui/app.py
+```
+
+For best results, we recommend Chrome. Our browser tests are most stable there, and some issues have been observed in
+other browsers.
+
+### Run on a remote server over SSH
+
+A process running on an SSH server cannot directly open a browser on the client machine. The launcher therefore runs
+on your **local machine**, creates an SSH tunnel, starts Flask on the server, waits for it to become available, and
+then opens the local browser.
+
+#### Remote prerequisites
+
+1. The NCPI repository must be cloned on both the local machine and the server.
+2. Both checkouts must contain the current launcher implementation. Update both repositories before starting, ideally
+   to the same Git commit:
+
+   An older server checkout that does not contain the current `webui/launcher.py` and the corresponding
+   `webui/app.py` changes is not compatible with this remote workflow.
+
+```bash
+# Run in the NCPI checkout on the local machine and again on the server
+git pull --ff-only
+git rev-parse HEAD
+```
+
+3. The server must have a Python installation with the WebUI dependencies. Conda is recommended, but a virtual
+   environment or system Python can also be used:
+
+```bash
+# Run on the server
+conda activate ncpi-env
+cd /absolute/path/to/ncpi
+pip install -e ".[webui]"
+which python
+```
+
+Use the path printed by `which python` as the value of `--python`. For a system installation, use an executable such as
+`python3` or `/usr/bin/python3`. An explicit path is recommended because non-interactive SSH sessions may not activate
+Conda or virtual environments and may use a different `PATH`.
+
+#### Remote command
+
+Run the following command from the NCPI repository on your **local machine**:
+
+```bash
+python webui/launcher.py remote user@server \
+  --ssh-port 22 \
+  --local-port 5001 \
+  --remote-port 5001 \
+  --remote-dir /absolute/path/to/ncpi \
+  --python /absolute/path/to/conda/env/bin/python
+```
+
+For example:
+
+```bash
+python webui/launcher.py remote username@example.org \
+  --ssh-port 22 \
+  --local-port 5001 \
+  --remote-port 5001 \
+  --remote-dir /home/username/ncpi \
+  --python /home/username/miniconda3/envs/ncpi-env/bin/python
+```
+
+The browser opens `http://127.0.0.1:<local-port>`. Keep the launcher terminal open while using the WebUI. Press
+`Ctrl+C` to close the SSH tunnel and stop the remote Flask process.
+
+#### Remote arguments
+
+| Argument                 |     Required     | Description |
+| :----------------------- | :--------------: | :---------- |
+| `destination`            |       Yes        | SSH destination, such as `user@server`. |
+| `--remote-dir`           |       Yes        | Updated NCPI repository path on the server. |
+| `--python`               |   Recommended    | Server Python executable: Conda, `venv`, or system Python. |
+| `--ssh-port`             |        No        | SSH port. Default: `22`. |
+| `--local-port`           |        No        | Local browser port. Default: `5000`. |
+| `--remote-port`          |        No        | Remote Flask port. Default: `5000`. |
+| `--remote-app`           |        No        | App path under `--remote-dir`. Default: `webui/app.py`. |
+| `--ssh-executable`       |        No        | Local SSH executable. Default: `ssh`. |
+| `--startup-timeout`      |        No        | Startup timeout in seconds. Default: `60`. |
+| `--no-browser`           |        No        | Start without opening the local browser. |
+
+If required fields are missing or a connection fails, the launcher prints the fields to review and an example command.
+
+#### Manual SSH alternative
+
+The launcher is recommended, but the equivalent workflow can be performed manually:
+
+```bash
+ssh -L 5001:127.0.0.1:5001 -p 22 user@server
+```
+
+Then, inside the SSH session:
+
+```bash
+cd /absolute/path/to/ncpi
+/absolute/path/to/conda/env/bin/python webui/app.py \
+  --host 127.0.0.1 \
+  --port 5001 \
+  --no-browser
+```
+
+Finally, open `http://127.0.0.1:5001` on the local machine.
 
 ### Windows note
 You can run the same command from Anaconda Prompt or PowerShell.

--- a/tests/Features/test_specparam.py
+++ b/tests/Features/test_specparam.py
@@ -6,7 +6,11 @@ import scipy.signal as scipy_signal
 specparam = pytest.importorskip("specparam")
 from specparam import SpectralModel
 from specparam.sim import sim_power_spectrum
-from specparam.sim.utils import set_random_seed
+
+try:
+    from specparam.utils.random import set_random_seed
+except:
+    from specparam.sim.utils import set_random_seed
 
 from ncpi.Features import Features
 

--- a/tests/Features/test_specparam.py
+++ b/tests/Features/test_specparam.py
@@ -227,7 +227,6 @@ def test_freq_range_sanity(feat_default):
 
 def test_select_peak_invalid_raises():
     from specparam.sim import sim_power_spectrum
-    from specparam.sim.utils import set_random_seed
 
     set_random_seed(21)
 

--- a/tests/test_webui_launcher.py
+++ b/tests/test_webui_launcher.py
@@ -1,0 +1,211 @@
+from argparse import Namespace
+
+import pytest
+
+from webui import launcher
+
+
+def test_browser_only_opens_for_local_non_ssh_session():
+    assert launcher.should_open_browser("127.0.0.1", environ={})
+    assert not launcher.should_open_browser(
+        "127.0.0.1",
+        environ={"SSH_CONNECTION": "client 123 server 22"},
+    )
+    assert not launcher.should_open_browser("0.0.0.0", environ={})
+    assert not launcher.should_open_browser(
+        "127.0.0.1",
+        no_browser=True,
+        environ={},
+    )
+
+
+def test_ssh_session_disables_flask_reloader(monkeypatch):
+    class FakeApp:
+        run_arguments = None
+
+        def run(self, **kwargs):
+            self.run_arguments = kwargs
+
+    app = FakeApp()
+    monkeypatch.setenv("SSH_CONNECTION", "client 123 server 22")
+
+    launcher.run_webui(app, ["--no-browser"])
+
+    assert app.run_arguments["debug"] is True
+    assert app.run_arguments["use_reloader"] is False
+
+
+def test_local_session_keeps_flask_reloader(monkeypatch):
+    class FakeApp:
+        run_arguments = None
+
+        def run(self, **kwargs):
+            self.run_arguments = kwargs
+
+    app = FakeApp()
+    for name in launcher.SSH_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(name, raising=False)
+
+    launcher.run_webui(app, ["--no-browser"])
+
+    assert app.run_arguments["use_reloader"] is True
+
+def test_browser_url_uses_loopback_for_wildcard_bind_address():
+    assert launcher.browser_url("0.0.0.0", 5000) == "http://127.0.0.1:5000"
+
+
+def test_build_ssh_command_for_remote_webui():
+    args = Namespace(
+        destination="alice@example.org",
+        remote_dir="/srv/ncpi project",
+        ssh_port=2222,
+        local_port=5050,
+        remote_port=5000,
+        python="/opt/ncpi env/bin/python",
+        remote_app="webui/app.py",
+        ssh_executable="ssh",
+    )
+
+    assert launcher.build_ssh_command(args) == [
+        "ssh",
+        "-tt",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-L",
+        "127.0.0.1:5050:127.0.0.1:5000",
+        "-p",
+        "2222",
+        "alice@example.org",
+        "cd -- '/srv/ncpi project' && "
+        "trap 'kill \"$ncpi_pid\" 2>/dev/null; wait \"$ncpi_pid\" 2>/dev/null' "
+        "HUP INT TERM EXIT; '/opt/ncpi env/bin/python' webui/app.py "
+        "--host 127.0.0.1 --port 5000 --no-browser & ncpi_pid=$!; "
+        "wait \"$ncpi_pid\"",
+    ]
+
+
+def test_local_port_check_enables_address_reuse(monkeypatch):
+    calls = []
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def setsockopt(self, level, option, value):
+            calls.append(("setsockopt", level, option, value))
+
+        def bind(self, address):
+            calls.append(("bind", address))
+
+    monkeypatch.setattr(launcher.socket, "socket", lambda *args: FakeSocket())
+
+    launcher.ensure_local_port_available(5001)
+
+    assert calls == [
+        (
+            "setsockopt",
+            launcher.socket.SOL_SOCKET,
+            launcher.socket.SO_REUSEADDR,
+            1,
+        ),
+        ("bind", ("127.0.0.1", 5001)),
+    ]
+
+
+def test_wait_for_webui_fails_when_ssh_exits():
+    class ExitedProcess:
+        @staticmethod
+        def poll():
+            return 255
+
+    with pytest.raises(RuntimeError, match="SSH exited with status 255"):
+        launcher.wait_for_webui(ExitedProcess(), 5000, timeout=1)
+
+
+def test_main_dispatches_local_mode(monkeypatch):
+    calls = []
+    fake_app = object()
+
+    monkeypatch.setattr(launcher, "_load_webui_app", lambda: fake_app)
+    monkeypatch.setattr(
+        launcher,
+        "_run_webui_with_args",
+        lambda app, args: calls.append((app, args.port)),
+    )
+
+    assert launcher.main(["local", "--port", "5050", "--no-browser"]) == 0
+    assert calls == [(fake_app, 5050)]
+
+def test_main_requires_explicit_mode():
+    with pytest.raises(SystemExit) as exc_info:
+        launcher.main([])
+
+    assert exc_info.value.code == 2
+
+
+def test_main_dispatches_remote_mode(monkeypatch):
+    monkeypatch.setattr(launcher, "run_remote", lambda argv: ("remote", argv))
+
+    assert launcher.main(["remote", "user@server"]) == (
+        "remote",
+        ["user@server"],
+    )
+
+
+def test_missing_mode_prints_local_and_remote_commands(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        launcher.main([])
+
+    error = capsys.readouterr().err
+    assert exc_info.value.code == 2
+    assert "You must specify how to run the application" in error
+    assert launcher.LOCAL_COMMAND in error
+    assert launcher.REMOTE_COMMAND in error
+
+
+def test_remote_missing_fields_prints_required_configuration(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        launcher.run_remote([])
+
+    error = capsys.readouterr().err
+    assert exc_info.value.code == 2
+    assert "The following required fields are missing" in error
+    assert "<user@server>" in error
+    assert "--remote-dir" in error
+    assert launcher.REMOTE_COMMAND in error
+
+
+def test_relative_remote_dir_prints_field_to_correct():
+    with pytest.raises(SystemExit) as exc_info:
+        launcher.run_remote(["user@server", "--remote-dir", "ncpi"])
+
+    message = str(exc_info.value)
+    assert "--remote-dir must be an absolute path" in message
+    assert "--remote-dir: ncpi" in message
+    assert launcher.REMOTE_COMMAND in message
+
+
+def test_remote_runtime_guidance_targets_ssh_and_python_fields():
+    args = Namespace(
+        destination="user@server",
+        remote_dir="/srv/ncpi",
+        ssh_port=22,
+        local_port=5001,
+        remote_port=5001,
+        python="/env/bin/python",
+    )
+
+    ssh_guidance = launcher._remote_runtime_guidance(
+        RuntimeError("SSH exited with status 255"), args
+    )
+    python_guidance = launcher._remote_runtime_guidance(
+        RuntimeError("SSH exited with status 127"), args
+    )
+
+    assert "destination: user@server" in ssh_guidance
+    assert "--ssh-port: 22" in ssh_guidance
+    assert "--remote-dir: /srv/ncpi" in python_guidance
+    assert "--python: /env/bin/python" in python_guidance

--- a/webui/app.py
+++ b/webui/app.py
@@ -18408,10 +18408,6 @@ def download_results(job_id):
     )
 
 if __name__ == '__main__':
-    import threading
-    import webbrowser
-    host = '127.0.0.1'
-    port = 5000
-    if host in ('127.0.0.1', 'localhost'):
-        threading.Timer(1.0, lambda: webbrowser.open(f'http://{host}:{port}')).start()
-    app.run(debug=True, host=host, port=port)
+    from launcher import run_webui
+
+    run_webui(app)

--- a/webui/launcher.py
+++ b/webui/launcher.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Start the NCPI WebUI locally or remotely over SSH."""
+
+import argparse
+import http.client
+import os
+import shlex
+import socket
+import subprocess
+import sys
+import threading
+import time
+import webbrowser
+from pathlib import PurePosixPath
+
+LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+SSH_ENVIRONMENT_VARIABLES = ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")
+
+
+LOCAL_COMMAND = "python webui/launcher.py local"
+REMOTE_COMMAND = (
+    "python webui/launcher.py remote <user@server> "
+    "--remote-dir <absolute_ncpi_path> "
+    "--python <conda_python_path>"
+)
+
+
+class GuidedArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *args, guidance=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.guidance = guidance
+
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        details = f"Error: {message}\n"
+        if self.guidance:
+            details += f"\n{self.guidance(message)}\n"
+        self.exit(2, details)
+
+
+def _mode_guidance(_message):
+    return (
+        "You must specify how to run the application:\n"
+        f"  Local:  {LOCAL_COMMAND}\n"
+        f"  Remote: {REMOTE_COMMAND}"
+    )
+
+
+def _remote_guidance(message):
+    missing = []
+    if "destination" in message:
+        missing.append("  <user@server>  SSH destination, for example user@example.org")
+    if "--remote-dir" in message:
+        missing.append("  --remote-dir   Absolute path to the NCPI repository on the server")
+
+    lines = ["Remote configuration:"]
+    if missing:
+        lines.append("The following required fields are missing:")
+        lines.extend(missing)
+    elif "invalid int value" in message:
+        lines.append("The specified port must be an integer.")
+    else:
+        lines.append("Check the field identified in the error.")
+    lines.extend(("", "Template:", f"  {REMOTE_COMMAND}"))
+    return "\n".join(lines)
+
+
+
+def _remote_runtime_guidance(error, args):
+    message = str(error)
+    if "status 255" in message:
+        fields = (
+            f"  destination: {args.destination}\n"
+            f"  --ssh-port: {args.ssh_port}\n"
+            "Check that these match the values used by your SSH command."
+        )
+    elif "status 127" in message:
+        fields = (
+            f"  --remote-dir: {args.remote_dir}\n"
+            f"  --python: {args.python}\n"
+            "Check that both paths exist on the server."
+        )
+    else:
+        fields = (
+            f"  --local-port: {args.local_port}\n"
+            f"  --remote-port: {args.remote_port}\n"
+            f"  --python: {args.python}\n"
+            "Check that Flask can start with these values."
+        )
+    return f"Fields to check:\n{fields}\n\nTemplate:\n  {REMOTE_COMMAND}"
+
+def is_ssh_session(environ=None):
+    environ = os.environ if environ is None else environ
+    return any(environ.get(name) for name in SSH_ENVIRONMENT_VARIABLES)
+
+
+def browser_url(host, port):
+    browser_host = "127.0.0.1" if host in {"0.0.0.0", "::"} else host
+    return f"http://{browser_host}:{port}"
+
+
+def should_open_browser(host, no_browser=False, environ=None):
+    return not no_browser and host in LOOPBACK_HOSTS and not is_ssh_session(environ)
+
+
+def _schedule_browser_open(url, debug, environ=None):
+    environ = os.environ if environ is None else environ
+    if debug and environ.get("WERKZEUG_RUN_MAIN") != "true":
+        return
+    threading.Timer(1.0, lambda: webbrowser.open(url)).start()
+
+
+def _build_local_parser():
+    parser = argparse.ArgumentParser(description="Run the NCPI WebUI.")
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("NCPI_WEBUI_HOST", "127.0.0.1"),
+        help="Flask bind address (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("NCPI_WEBUI_PORT", "5000")),
+        help="Flask port (default: 5000).",
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open a browser when running locally.",
+    )
+    return parser
+
+
+def run_webui(app, argv=None):
+    _run_webui_with_args(app, _build_local_parser().parse_args(argv))
+
+
+def _run_webui_with_args(app, args):
+    url = browser_url(args.host, args.port)
+    debug = True
+    use_reloader = not is_ssh_session()
+
+    if should_open_browser(args.host, args.no_browser):
+        _schedule_browser_open(url, debug)
+    elif (
+        is_ssh_session()
+        and os.environ.get("WERKZEUG_RUN_MAIN") != "true"
+    ):
+        print(
+            "\nSSH session detected. The remote process cannot open a browser "
+            "on the SSH client.\n"
+            f"Open {url} on your local machine through an SSH tunnel, or use "
+            "webui/launcher.py remote from the local checkout.\n",
+            flush=True,
+        )
+
+    app.run(debug=debug, host=args.host, port=args.port, use_reloader=use_reloader)
+
+
+def build_remote_command(remote_dir, python_executable, remote_app, remote_port):
+    app_command = (
+        f"{shlex.quote(python_executable)} {shlex.quote(remote_app)} "
+        f"--host 127.0.0.1 --port {remote_port} --no-browser"
+    )
+    return (
+        f"cd -- {shlex.quote(remote_dir)} && "
+        "trap 'kill \"$ncpi_pid\" 2>/dev/null; wait \"$ncpi_pid\" 2>/dev/null' "
+        "HUP INT TERM EXIT; "
+        f"{app_command} & ncpi_pid=$!; wait \"$ncpi_pid\""
+    )
+
+
+def build_ssh_command(args):
+    forwarding = f"127.0.0.1:{args.local_port}:127.0.0.1:{args.remote_port}"
+    remote_command = build_remote_command(
+        args.remote_dir,
+        args.python,
+        args.remote_app,
+        args.remote_port,
+    )
+    return [
+        args.ssh_executable,
+        "-tt",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-L",
+        forwarding,
+        "-p",
+        str(args.ssh_port),
+        args.destination,
+        remote_command,
+    ]
+
+
+def ensure_local_port_available(port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        probe.bind(("127.0.0.1", port))
+
+
+def wait_for_webui(process, port, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        return_code = process.poll()
+        if return_code is not None:
+            raise RuntimeError(
+                f"SSH exited with status {return_code} before the WebUI started."
+            )
+        connection = http.client.HTTPConnection("127.0.0.1", port, timeout=0.5)
+        try:
+            connection.request("GET", "/")
+            response = connection.getresponse()
+            response.read(1)
+            return
+        except (OSError, http.client.HTTPException):
+            time.sleep(0.2)
+        finally:
+            connection.close()
+    raise TimeoutError(
+        f"The WebUI did not become available on local port {port} "
+        f"within {timeout:g} seconds."
+    )
+
+
+def _build_remote_parser():
+    parser = GuidedArgumentParser(
+        guidance=_remote_guidance,
+        description=(
+            "Start NCPI on a remote machine through an SSH tunnel and open "
+            "the WebUI in this machine's browser."
+        )
+    )
+    parser.add_argument("destination", help="SSH destination, for example user@server.")
+    parser.add_argument(
+        "--remote-dir",
+        required=True,
+        help="Absolute path to the NCPI repository on the remote machine.",
+    )
+    parser.add_argument("--ssh-port", type=int, default=22, help="SSH port (default: 22).")
+    parser.add_argument(
+        "--local-port",
+        type=int,
+        default=5000,
+        help="Local browser port (default: 5000).",
+    )
+    parser.add_argument(
+        "--remote-port",
+        type=int,
+        default=5000,
+        help="Remote Flask port (default: 5000).",
+    )
+    parser.add_argument(
+        "--python",
+        default="python",
+        help="Python executable on the remote machine (default: python).",
+    )
+    parser.add_argument(
+        "--remote-app",
+        default="webui/app.py",
+        help="App path relative to --remote-dir (default: webui/app.py).",
+    )
+    parser.add_argument(
+        "--ssh-executable",
+        default="ssh",
+        help="Local SSH executable (default: ssh).",
+    )
+    parser.add_argument(
+        "--startup-timeout",
+        type=float,
+        default=60.0,
+        help="Seconds to wait for the WebUI (default: 60).",
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Create the tunnel without opening the local browser.",
+    )
+    return parser
+
+
+def run_remote(argv=None):
+    args = _build_remote_parser().parse_args(argv)
+    if not PurePosixPath(args.remote_dir).is_absolute():
+        raise SystemExit(
+            "Error: --remote-dir must be an absolute path on the server.\n\n"
+            "Field to correct:\n"
+            f"  --remote-dir: {args.remote_dir}\n\n"
+            f"Template:\n  {REMOTE_COMMAND}"
+        )
+
+    try:
+        ensure_local_port_available(args.local_port)
+    except OSError as exc:
+        raise SystemExit(
+            f"Error: local port {args.local_port} is not available: {exc}\n\n"
+            "Field to correct:\n"
+            f"  --local-port: {args.local_port}\n"
+            "Try another local port, for example --local-port 5002.\n\n"
+            f"Template:\n  {REMOTE_COMMAND}"
+        ) from exc
+
+    command = build_ssh_command(args)
+    url = f"http://127.0.0.1:{args.local_port}"
+    print(f"Starting remote NCPI WebUI at {url}", flush=True)
+    try:
+        process = subprocess.Popen(command)
+    except OSError as exc:
+        raise SystemExit(
+            f"Error: SSH could not be executed: {exc}\n\n"
+            "Field to check:\n"
+            f"  --ssh-executable: {args.ssh_executable}\n\n"
+            f"Template:\n  {REMOTE_COMMAND}"
+        ) from exc
+
+    try:
+        wait_for_webui(process, args.local_port, args.startup_timeout)
+        if not args.no_browser and not webbrowser.open(url):
+            print(f"Could not open a browser automatically. Open {url}", flush=True)
+        return process.wait()
+    except KeyboardInterrupt:
+        return 130
+    except (RuntimeError, TimeoutError) as exc:
+        print(f"Error: {exc}", file=sys.stderr, flush=True)
+        print(_remote_runtime_guidance(exc, args), file=sys.stderr, flush=True)
+        return 1
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+
+
+def _build_mode_parser():
+    parser = GuidedArgumentParser(
+        guidance=_mode_guidance,
+        description="Start the NCPI WebUI locally or remotely over SSH."
+    )
+    parser.add_argument("mode", choices=("local", "remote"))
+    return parser
+
+
+def _load_webui_app():
+    try:
+        from .app import app
+    except ImportError:
+        from app import app
+    return app
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv or argv[0] in {"-h", "--help"}:
+        _build_mode_parser().parse_args(argv)
+
+    mode = argv.pop(0)
+    if mode == "local":
+        args = _build_local_parser().parse_args(argv)
+        _run_webui_with_args(_load_webui_app(), args)
+        return 0
+    if mode == "remote":
+        return run_remote(argv)
+    _build_mode_parser().error(f"invalid mode: {mode}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary

  - Add a unified WebUI launcher for local and remote execution.
  - Automatically open the local browser when the WebUI is ready.
  - Support remote execution through an SSH tunnel.
  - Improve process cleanup when stopping with Ctrl+C.
  - Add guided error messages for missing or invalid arguments.
  - Document local, Conda, virtual environment, system Python, and SSH workflows.

  ## Usage

  ### Local

  python webui/launcher.py local

  ### Remote

  python webui/launcher.py remote user@server \
    --ssh-port 22 \
    --local-port 5001 \
    --remote-port 5001 \
    --remote-dir /absolute/path/to/ncpi \
    --python /absolute/path/to/python

  ## Changes

  - Add webui/launcher.py with local and remote modes.
  - Make webui/app.py delegate startup configuration to the launcher.
  - Detect SSH sessions and disable the Flask reloader remotely.
  - Create and monitor SSH port forwarding.
  - Open the browser only on the local machine.
  - Clean up SSH and remote Flask processes on shutdown.
  - Allow immediate local-port reuse.
  - Support Conda, venv, and system Python installations.
  - Add actionable English error messages.
  - Expand the README with prerequisites, arguments, examples, and manual SSH instructions.
  - Add launcher unit tests.

  ## Testing

  pytest -q tests/test_webui_launcher.py