### PR TITLE
Ncpi cancel button

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -8015,6 +8015,45 @@ def _simulation_restore_endpoint_for_model(model_type):
     }.get(str(model_type or "").strip().lower())
 
 
+_RESTORABLE_COMPUTATION_TARGETS = {
+    "field_potential_proxy": ("field_potential_proxy", {}),
+    "field_potential_kernel": ("field_potential_kernel", {}),
+    "field_potential_meeg": ("field_potential_kernel", {"tab": "meeg"}),
+    "features": ("features_methods", {"entry": "compute"}),
+    "inference_training": ("new_training", {}),
+    "inference": ("compute_predictions", {}),
+    "analysis": ("analysis", {}),
+}
+
+
+def _restore_target_for_computation_type(computation_type, form=None):
+    key = str(computation_type or "").strip().lower()
+    if key == "field_potential_kernel" and isinstance(form, dict):
+        active_tab = str(form.get("restore_active_tab") or "").strip()
+        if active_tab in {"create_kernel", "cdm_computation"}:
+            return "field_potential_kernel", {"tab": active_tab}
+    return _RESTORABLE_COMPUTATION_TARGETS.get(key)
+
+
+def _remember_module_restore_form(computation_type, form):
+    session["module_restore_form"] = {
+        "computation_type": str(computation_type or "").strip().lower(),
+        "form": dict(form or {}),
+    }
+
+
+def _pop_module_restore_form(computation_type):
+    payload = session.pop("module_restore_form", None)
+    if not isinstance(payload, dict):
+        return {}
+    expected_type = str(computation_type or "").strip().lower()
+    payload_type = str(payload.get("computation_type") or "").strip().lower()
+    if payload_type != expected_type:
+        return {}
+    form = payload.get("form")
+    return form if isinstance(form, dict) else {}
+
+
 @app.route("/simulation/new_sim/hagen")
 def new_sim_hagen():
     restore_form = _pop_simulation_restore_form("hagen")
@@ -8048,26 +8087,42 @@ def new_sim_custom():
     return render_template("1.2.1.new_sim_custom.html")
 
 
-@app.route("/simulation/restore_config/<job_id>", methods=["POST"])
-def restore_simulation_config(job_id):
+@app.route("/restore_config/<job_id>", methods=["POST"])
+def restore_job_config(job_id):
     status = job_status.get(job_id)
     if not isinstance(status, dict):
-        flash("Simulation job not found.", "error")
-        return redirect(url_for("simulation"))
+        flash("Job not found.", "error")
+        return redirect(url_for("dashboard"))
 
+    computation_type = str(status.get("computation_type") or "").strip().lower()
     if status.get("status") not in {"failed", "cancelled"}:
-        flash("Configuration can only be restored after a failed or cancelled simulation.", "error")
-        return redirect(url_for("job_status_page", job_id=job_id, computation_type="simulation"))
+        flash("Configuration can only be restored after a failed or cancelled job.", "error")
+        return redirect(url_for("job_status_page", job_id=job_id, computation_type=computation_type))
 
-    model_type = status.get("simulation_restore_model_type")
-    restore_form = status.get("simulation_restore_form")
-    endpoint = _simulation_restore_endpoint_for_model(model_type)
-    if not endpoint or not isinstance(restore_form, dict):
-        flash("No restorable simulation configuration is available for this job.", "error")
-        return redirect(url_for("simulation"))
+    if computation_type == "simulation":
+        model_type = status.get("simulation_restore_model_type")
+        restore_form = status.get("simulation_restore_form")
+        endpoint = _simulation_restore_endpoint_for_model(model_type)
+        if not endpoint or not isinstance(restore_form, dict):
+            flash("No restorable simulation configuration is available for this job.", "error")
+            return redirect(url_for("simulation"))
+        _remember_simulation_restore_form(model_type, restore_form)
+        return redirect(url_for(endpoint))
 
-    _remember_simulation_restore_form(model_type, restore_form)
-    return redirect(url_for(endpoint))
+    restore_form = status.get("restore_form")
+    target = _restore_target_for_computation_type(computation_type, restore_form)
+    if not target or not isinstance(restore_form, dict):
+        flash("No restorable configuration is available for this job.", "error")
+        return redirect(url_for("dashboard"))
+
+    endpoint, values = target
+    _remember_module_restore_form(computation_type, restore_form)
+    return redirect(url_for(endpoint, **values))
+
+
+@app.route("/simulation/restore_config/<job_id>", methods=["POST"])
+def restore_simulation_config(job_id):
+    return restore_job_config(job_id)
 
 
 def _simulation_computation(job_id, job_status, params):
@@ -8925,6 +8980,9 @@ def field_potential_kernel():
         detected_simulation_model=detected_simulation_model,
         detected_simulation_origin=detected_simulation_origin,
         initial_tab=initial_tab,
+        module_restore_form=_pop_module_restore_form(
+            "field_potential_meeg" if initial_tab == "meeg" else "field_potential_kernel"
+        ),
         biophys_options=biophys_options,
         mc_models_local_staged_default=remembered_mc_folder_local,
         mc_outputs_local_staged_default=remembered_output_sim_local,
@@ -8984,6 +9042,7 @@ def field_potential_proxy():
         default_sim_names=default_sim_names,
         default_sim_paths=default_paths,
         webui_runtime=webui_runtime,
+        module_restore_form=_pop_module_restore_form("field_potential_proxy"),
     )
 
 
@@ -9343,6 +9402,7 @@ def features_methods():
         features_data_files=features_data_files,
         has_features_data=bool(features_data_files),
         features_runtime=runtime_context,
+        module_restore_form=_pop_module_restore_form("features"),
     )
 
 
@@ -10752,7 +10812,10 @@ def remove_inference_file():
 # New training for inference configuration page
 @app.route("/inference/new_training")
 def new_training():
-    return render_template("4.2.0.new_training.html")
+    return render_template(
+        "4.2.0.new_training.html",
+        module_restore_form=_pop_module_restore_form("inference_training"),
+    )
 
 
 @app.route("/inference/training/compare_inputs", methods=["POST"])
@@ -10860,6 +10923,7 @@ def compute_predictions():
         feature_data_files=feature_data_files,
         has_feature_data=bool(feature_data_files),
         default_feature_file=default_feature_file,
+        module_restore_form=_pop_module_restore_form("inference"),
     )
 
 
@@ -11197,6 +11261,7 @@ def analysis():
         topomap_image_interp_options=TOPO_MAP_IMAGE_INTERP_OPTIONS,
         boxplot_colormap_options=_boxplot_colormap_options(),
         analysis_plot_config=_load_analysis_plot_config(),
+        module_restore_form=_pop_module_restore_form("analysis"),
     )
 
 
@@ -18078,6 +18143,7 @@ def start_computation_redirect(computation_type):
             "field_potential_kernel",
             "field_potential_meeg",
         } else "time",
+        "restore_form": dict(request.form),
     }
 
     # Submit the long-running task according to the computation type.
@@ -18198,8 +18264,20 @@ def get_status(job_id):
         "simulation_mode": status.get("simulation_mode"),
         "can_restore_config": bool(
             status.get("status") in {"failed", "cancelled"}
-            and _simulation_restore_endpoint_for_model(status.get("simulation_restore_model_type"))
-            and isinstance(status.get("simulation_restore_form"), dict)
+            and (
+                (
+                    status.get("computation_type") == "simulation"
+                    and _simulation_restore_endpoint_for_model(status.get("simulation_restore_model_type"))
+                    and isinstance(status.get("simulation_restore_form"), dict)
+                )
+                or (
+                    _restore_target_for_computation_type(
+                        status.get("computation_type"),
+                        status.get("restore_form"),
+                    )
+                    and isinstance(status.get("restore_form"), dict)
+                )
+            )
         ),
         "meeg_trial_total": status.get("meeg_trial_total"),
         "meeg_trial_index": status.get("meeg_trial_index"),

--- a/webui/app.py
+++ b/webui/app.py
@@ -8007,6 +8007,14 @@ def _pop_simulation_restore_form(model_type):
     return form if isinstance(form, dict) else {}
 
 
+def _simulation_restore_endpoint_for_model(model_type):
+    return {
+        "hagen": "new_sim_hagen",
+        "cavallari": "new_sim_cavallari",
+        "four_area": "new_sim_four_area",
+    }.get(str(model_type or "").strip().lower())
+
+
 @app.route("/simulation/new_sim/hagen")
 def new_sim_hagen():
     restore_form = _pop_simulation_restore_form("hagen")
@@ -8038,6 +8046,28 @@ def new_sim_four_area():
 @app.route("/simulation/new_sim/custom")
 def new_sim_custom():
     return render_template("1.2.1.new_sim_custom.html")
+
+
+@app.route("/simulation/restore_config/<job_id>", methods=["POST"])
+def restore_simulation_config(job_id):
+    status = job_status.get(job_id)
+    if not isinstance(status, dict):
+        flash("Simulation job not found.", "error")
+        return redirect(url_for("simulation"))
+
+    if status.get("status") not in {"failed", "cancelled"}:
+        flash("Configuration can only be restored after a failed or cancelled simulation.", "error")
+        return redirect(url_for("job_status_page", job_id=job_id, computation_type="simulation"))
+
+    model_type = status.get("simulation_restore_model_type")
+    restore_form = status.get("simulation_restore_form")
+    endpoint = _simulation_restore_endpoint_for_model(model_type)
+    if not endpoint or not isinstance(restore_form, dict):
+        flash("No restorable simulation configuration is available for this job.", "error")
+        return redirect(url_for("simulation"))
+
+    _remember_simulation_restore_form(model_type, restore_form)
+    return redirect(url_for(endpoint))
 
 
 def _simulation_computation(job_id, job_status, params):
@@ -8465,6 +8495,8 @@ def run_trial_simulation(model_type):
         "simulation_total": len(run_forms),
         "simulation_completed": 0,
         "simulation_mode": run_mode,
+        "simulation_restore_model_type": model_type,
+        "simulation_restore_form": dict(form),
     }
 
     future = executor.submit(
@@ -18164,6 +18196,11 @@ def get_status(job_id):
         "simulation_total": status.get("simulation_total"),
         "simulation_completed": status.get("simulation_completed"),
         "simulation_mode": status.get("simulation_mode"),
+        "can_restore_config": bool(
+            status.get("status") in {"failed", "cancelled"}
+            and _simulation_restore_endpoint_for_model(status.get("simulation_restore_model_type"))
+            and isinstance(status.get("simulation_restore_form"), dict)
+        ),
         "meeg_trial_total": status.get("meeg_trial_total"),
         "meeg_trial_index": status.get("meeg_trial_index"),
         "meeg_sensors_total": status.get("meeg_sensors_total"),

--- a/webui/templates/2.2.0.field_potential_kernel.html
+++ b/webui/templates/2.2.0.field_potential_kernel.html
@@ -6,6 +6,7 @@
 <script>
     window.__webuiRuntime = {{ webui_runtime | tojson }};
     window.isLocalRuntime = !(window.__webuiRuntime?.is_server_runtime);
+    window.__fieldPotentialKernelRestoreForm = {{ module_restore_form | default({}) | tojson }};
 </script>
 <script id="tailwind-config">
     tailwind.config = {
@@ -85,6 +86,7 @@
     <!-- Tab contents -->
     <form id="kernel-compute-form" method="POST" enctype="multipart/form-data"
         action="{{ url_for('start_computation_redirect', computation_type='field_potential_kernel') }}">
+    <input type="hidden" name="restore_active_tab" :value="activeTab" />
     <div class="space-y-8 pt-6">
         <!-- Create Kernel Tab -->
         <div x-show="activeTab === 'create_kernel'">
@@ -772,6 +774,15 @@
 <script defer="" src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+    const kernelRestoreForm = (
+        window.__fieldPotentialKernelRestoreForm
+        && typeof window.__fieldPotentialKernelRestoreForm === 'object'
+        && !Array.isArray(window.__fieldPotentialKernelRestoreForm)
+    ) ? window.__fieldPotentialKernelRestoreForm : {};
+    const hasKernelRestoreField = (name) => Object.prototype.hasOwnProperty.call(kernelRestoreForm, name);
+    const kernelRestoreValue = (name, fallback = '') => (
+        hasKernelRestoreField(name) ? String(kernelRestoreForm[name] ?? '') : fallback
+    );
     const kernelComputeForm = document.getElementById('kernel-compute-form');
     const meegComputeForm = document.getElementById('meeg-compute-form');
     const kernelDtInput = document.querySelector('input[name="dt"]');
@@ -782,7 +793,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const biophysHidden = document.getElementById('biophysHidden');
     const availableBiophysOptions = {{ biophys_options | tojson }};
     const preferredBiophysDefaults = ['set_Ih_linearized_hay2011', 'make_cell_uniform'];
-    const defaultBiophysItems = preferredBiophysDefaults.filter((name) => availableBiophysOptions.includes(name));
+    const restoredBiophysItems = (() => {
+        if (!hasKernelRestoreField('biophys')) {
+            return [];
+        }
+        try {
+            const parsed = JSON.parse(kernelRestoreValue('biophys', '[]'));
+            return Array.isArray(parsed)
+                ? parsed.map((item) => String(item || '').trim()).filter(Boolean)
+                : [];
+        } catch (_err) {
+            return [];
+        }
+    })();
+    const defaultBiophysItems = restoredBiophysItems.length
+        ? restoredBiophysItems
+        : preferredBiophysDefaults.filter((name) => availableBiophysOptions.includes(name));
     if (defaultBiophysItems.length === 0 && availableBiophysOptions.length > 0) {
         defaultBiophysItems.push(availableBiophysOptions[0]);
     }
@@ -1095,18 +1121,49 @@ document.addEventListener('DOMContentLoaded', () => {
         return normalizeKernelBrowseSourceMode(sourceInput?.value || runtimeDefaultPathMode);
     };
 
+    const restoredMcFolderMode = normalizeKernelBrowseSourceMode(
+        kernelRestoreValue('mc_folder_source_mode', kernelMcFolderSourceInput?.value || ''),
+    );
+    const restoredOutputSimMode = normalizeKernelBrowseSourceMode(
+        kernelRestoreValue('output_sim_path_source_mode', kernelOutputSimSourceInput?.value || ''),
+    );
+    const restoredMcFolderPath = kernelRestoreValue(
+        'mc_folder',
+        String(kernelMcFolderInput?.value || '').trim(),
+    ).trim();
+    const restoredOutputSimPath = kernelRestoreValue(
+        'output_sim_path',
+        String(kernelOutputSimPathInput?.value || '').trim(),
+    ).trim();
+
     const folderSelectionStateByName = {
         mc_folder: {
-            mode: resolveInitialFolderMode('mc_folder', kernelMcFolderSourceInput),
-            serverPath: String(kernelMcFolderInput?.value || '').trim(),
-            localStagedPath: rememberedLocalStagedByField.mc_folder || '',
-            localLabel: basenameFromFolderPath(rememberedLocalStagedByField.mc_folder || ''),
+            mode: resolveInitialFolderMode('mc_folder', { value: restoredMcFolderMode }),
+            serverPath: restoredMcFolderMode === 'local-upload'
+                ? String(kernelMcFolderInput?.value || '').trim()
+                : restoredMcFolderPath,
+            localStagedPath: restoredMcFolderMode === 'local-upload'
+                ? restoredMcFolderPath
+                : (rememberedLocalStagedByField.mc_folder || ''),
+            localLabel: basenameFromFolderPath(
+                restoredMcFolderMode === 'local-upload'
+                    ? restoredMcFolderPath
+                    : (rememberedLocalStagedByField.mc_folder || ''),
+            ),
         },
         output_sim_path: {
-            mode: resolveInitialFolderMode('output_sim_path', kernelOutputSimSourceInput),
-            serverPath: String(kernelOutputSimPathInput?.value || '').trim(),
-            localStagedPath: rememberedLocalStagedByField.output_sim_path || '',
-            localLabel: basenameFromFolderPath(rememberedLocalStagedByField.output_sim_path || ''),
+            mode: resolveInitialFolderMode('output_sim_path', { value: restoredOutputSimMode }),
+            serverPath: restoredOutputSimMode === 'local-upload'
+                ? String(kernelOutputSimPathInput?.value || '').trim()
+                : restoredOutputSimPath,
+            localStagedPath: restoredOutputSimMode === 'local-upload'
+                ? restoredOutputSimPath
+                : (rememberedLocalStagedByField.output_sim_path || ''),
+            localLabel: basenameFromFolderPath(
+                restoredOutputSimMode === 'local-upload'
+                    ? restoredOutputSimPath
+                    : (rememberedLocalStagedByField.output_sim_path || ''),
+            ),
         },
     };
     const kernelPathPreviewStateByField = {
@@ -2088,6 +2145,29 @@ document.addEventListener('DOMContentLoaded', () => {
     const kernelPredefinedParamsByModel = {{ kernel_predefined_params_by_model | tojson }};
     const detectedKernelSimulationModel = String({{ detected_simulation_model | tojson }} || '').trim().toLowerCase();
     const detectedKernelSimulationOrigin = String({{ detected_simulation_origin | tojson }} || '').trim().toLowerCase();
+    const hasKernelParamsRestore = hasKernelRestoreField('kernel_params_module')
+        || hasKernelRestoreField('kernel_params_module_source_mode')
+        || hasKernelRestoreField('kernel_params_predefined_model');
+    if (hasKernelParamsRestore) {
+        if (kernelParamsSourceModeInput) {
+            kernelParamsSourceModeInput.value = kernelRestoreValue(
+                'kernel_params_module_source_mode',
+                kernelParamsSourceModeInput.value || '',
+            );
+        }
+        if (kernelParamsServerPathInput) {
+            kernelParamsServerPathInput.value = kernelRestoreValue(
+                'kernel_params_module',
+                kernelParamsServerPathInput.value || '',
+            );
+        }
+        if (kernelParamsPredefinedModelInput) {
+            kernelParamsPredefinedModelInput.value = kernelRestoreValue(
+                'kernel_params_predefined_model',
+                kernelParamsPredefinedModelInput.value || '',
+            );
+        }
+    }
     const kernelHasDetectedPredefinedModel = ['hagen', 'cavallari', 'four_area'].includes(detectedKernelSimulationModel)
         && detectedKernelSimulationOrigin !== 'custom';
 
@@ -2218,12 +2298,19 @@ document.addEventListener('DOMContentLoaded', () => {
         kernelParamsAutoButtons.forEach((btn) => setKernelParamButtonState(btn, false));
         const initialRawMode = String(kernelParamsSourceModeInput.value || '').trim().toLowerCase();
         const initialMode = initialRawMode === 'server-path' ? 'server-path' : 'upload';
+        const initialPredefinedModel = String(kernelParamsPredefinedModelInput.value || '').trim().toLowerCase();
         setKernelParamsMode(initialMode, { clearAuto: false });
         const initialServerPath = String(kernelParamsServerPathInput.value || '').trim();
         if (initialServerPath) {
-            setKernelParamsServerSelection(initialServerPath);
+            setKernelParamsServerSelection(initialServerPath, { preserveAuto: Boolean(initialPredefinedModel) });
         }
-        if (kernelHasDetectedPredefinedModel && !kernelParamsAutoDisabled) {
+        if (initialPredefinedModel && !kernelParamsAutoDisabled) {
+            const initialModelCfg = kernelPredefinedParamsByModel[initialPredefinedModel] || {};
+            setKernelParamsAutoSelection(
+                initialPredefinedModel,
+                initialModelCfg.label || initialPredefinedModel,
+            );
+        } else if (kernelHasDetectedPredefinedModel && !kernelParamsAutoDisabled && !hasKernelParamsRestore) {
             const detectedAutoBtn = kernelParamsAutoButtons.find(
                 (btn) => String(btn.dataset.kernelParamsAutoModel || '').trim().toLowerCase() === detectedKernelSimulationModel,
             );

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -5,6 +5,7 @@
 <script>
     window.__featuresPipelineFiles = {{ pipeline_files | tojson }};
     window.__featuresRuntime = {{ (features_runtime if features_runtime is defined else webui_runtime) | tojson }};
+    window.__featuresRestoreForm = {{ module_restore_form | default({}) | tojson }};
     window.__featuresInitialEntry = {{ request.args.get('entry', '') | tojson }};
     window.__featuresInitialTab = {{ request.args.get('tab', '') | tojson }};
 
@@ -17,10 +18,15 @@
             ? 'server-path'
             : 'upload';
         const defaultSimulationSourceMode = 'server-path';
+        const restoreForm = (() => {
+            const value = window.__featuresRestoreForm || {};
+            return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+        })();
+        const hasRestoreForm = Object.keys(restoreForm).length > 0;
         const initialEntry = String(window.__featuresInitialEntry || '').trim().toLowerCase();
         const initialTab = String(window.__featuresInitialTab || '').trim().toLowerCase();
         const startOnLoadPrecomputed = initialEntry === 'load' || initialTab === 'load-precomputed';
-        const startOnCompute = initialEntry === 'compute' || ['load-data', 'select-method', 'configure-method'].includes(initialTab);
+        const startOnCompute = hasRestoreForm || initialEntry === 'compute' || ['load-data', 'select-method', 'configure-method'].includes(initialTab);
         let initialActiveTab = 'entry';
         let initialEntryChoice = '';
         if (startOnLoadPrecomputed){
@@ -227,7 +233,9 @@ def custom_feature(sample, params):
                 }
             ],
             init() {
-                if (this.entryChoice === 'compute' && this.activeTab === 'load-data') {
+                if (hasRestoreForm) {
+                    this.restoreFeaturesConfiguration(restoreForm);
+                } else if (this.entryChoice === 'compute' && this.activeTab === 'load-data') {
                     this.computeFlowSelectorOpen = true;
                     this.computeFlowConfigOpen = false;
                 }
@@ -245,6 +253,126 @@ def custom_feature(sample, params):
                         });
                     });
                 });
+            },
+            restoreValue(form, name, fallback = '') {
+                if (!form || !Object.prototype.hasOwnProperty.call(form, name)) return fallback;
+                return form[name] ?? fallback;
+            },
+            restoreBool(form, name) {
+                return ['1', 'true', 'on', 'yes'].includes(String(this.restoreValue(form, name, '')).trim().toLowerCase());
+            },
+            restoreJson(form, name, fallback) {
+                const raw = this.restoreValue(form, name, '');
+                if (raw === '') return fallback;
+                try {
+                    const parsed = JSON.parse(String(raw));
+                    return parsed ?? fallback;
+                } catch (_err) {
+                    return fallback;
+                }
+            },
+            restoreParserControls(form) {
+                const textFields = {
+                    parser_data_locator: 'parserDataLocator',
+                    parser_fs_manual: 'parserFsManual',
+                    parser_fs_source: 'parserFsSource',
+                    parser_sensor_names: 'parserSensorNames',
+                    parser_ch_names_source: 'parserChNamesSource',
+                    parser_ch_names_autocomplete_axis: 'parserChNamesAutocompleteAxis',
+                    parser_recording_type: 'parserRecordingType',
+                    parser_recording_type_locator: 'parserRecordingTypeLocator',
+                    parser_recording_type_source: 'parserRecordingTypeSource',
+                    parser_metadata_mode: 'parserMetadataMode',
+                    parser_metadata_subject_id_source: 'parserMetadataSubjectIdSource',
+                    parser_metadata_subject_id: 'parserMetadataSubjectId',
+                    parser_metadata_group_source: 'parserMetadataGroupSource',
+                    parser_metadata_group: 'parserMetadataGroup',
+                    parser_metadata_species_source: 'parserMetadataSpeciesSource',
+                    parser_metadata_species: 'parserMetadataSpecies',
+                    parser_metadata_condition_source: 'parserMetadataConditionSource',
+                    parser_metadata_condition: 'parserMetadataCondition',
+                    parser_subject_id_locator: 'parserSubjectIdLocator',
+                    parser_group_locator: 'parserGroupLocator',
+                    parser_species_locator: 'parserSpeciesLocator',
+                    parser_condition_locator: 'parserConditionLocator',
+                    parser_fs_locator: 'parserFsLocator',
+                    parser_ch_names_locator: 'parserChNamesLocator',
+                    parser_table_layout: 'parserTableLayout',
+                    parser_long_time_col: 'parserLongTimeCol',
+                    parser_long_channel_col: 'parserLongChannelCol',
+                    parser_long_value_col: 'parserLongValueCol',
+                    parser_axis_channels: 'parserAxisChannels',
+                    parser_axis_samples: 'parserAxisSamples',
+                    parser_axis_epochs: 'parserAxisEpochs',
+                    parser_axis_ids: 'parserAxisIds',
+                    parser_epoch_length_s: 'parserEpochLengthS',
+                    parser_epoch_step_s: 'parserEpochStepS',
+                    parser_segment_t0_s: 'parserSegmentT0S',
+                    parser_segment_t1_s: 'parserSegmentT1S',
+                    parser_aggregate_method: 'parserAggregateMethod',
+                    parser_aggregate_labels: 'parserAggregateLabels',
+                    parser_aggregate_label_value: 'parserAggregateLabelValue',
+                    parser_filename_format: 'parserFilenameFormat',
+                    additional_file_link_field: 'additionalFileLinkField',
+                };
+                Object.entries(textFields).forEach(([fieldName, propName]) => {
+                    if (Object.prototype.hasOwnProperty.call(form, fieldName)) {
+                        this[propName] = String(form[fieldName] ?? '');
+                    }
+                });
+                this.parserArrayAxesEnabled = this.restoreBool(form, 'parser_array_axes_enabled');
+                this.parserEnableEpoching = this.restoreBool(form, 'parser_enable_epoching');
+                this.parserZscore = this.restoreBool(form, 'parser_zscore');
+                this.parserZscoreAfterEpoch = this.restoreBool(form, 'parser_zscore_after_epoch');
+                this.parserEnableAggregate = this.restoreBool(form, 'parser_enable_aggregate');
+                if (Object.prototype.hasOwnProperty.call(form, 'parser_aggregate_over')) {
+                    this.parserAggregateOverSelected = String(form.parser_aggregate_over || '')
+                        .split(',')
+                        .map((item) => item.trim())
+                        .filter((item) => item.length > 0);
+                }
+                if (Object.prototype.hasOwnProperty.call(form, 'select-method')) {
+                    this.selectedMethod = String(form['select-method'] || '');
+                }
+                this.normalizeParserRecordingTypeSource();
+                this.syncParserSelectDom();
+            },
+            async restoreFeaturesConfiguration(form) {
+                this.entryChoice = 'compute';
+                this.activeTab = 'load-data';
+                this.computeFlowSelectorOpen = false;
+                this.computeFlowConfigOpen = true;
+                const sourceKind = String(this.restoreValue(form, 'data_source_kind', 'new-simulation')).trim() || 'new-simulation';
+                try {
+                    if (sourceKind === 'pipeline') {
+                        const existingPath = String(this.restoreValue(form, 'existing_data_path', '')).trim();
+                        this.computeFlowChoice = 'pipeline';
+                        this.dataSourceKind = 'pipeline';
+                        this.selectedPipelinePath = existingPath;
+                        if (existingPath) await this.inspectParserSource(existingPath, null);
+                    } else if (sourceKind === 'new-empirical') {
+                        this.computeFlowChoice = 'new-data';
+                        this.dataSourceKind = 'new-empirical';
+                        this.empiricalSourceMode = String(this.restoreValue(form, 'empirical_source_mode', this.defaultEmpiricalSourceMode)).trim() || this.defaultEmpiricalSourceMode;
+                        this.empiricalFolderPath = String(this.restoreValue(form, 'empirical_folder_path', '')).trim();
+                        this.empiricalDataFileSelections = this.restoreJson(form, 'empirical_data_file_selections', {});
+                        this.empiricalSubfolderSelections = this.restoreJson(form, 'empirical_subfolder_selections', {});
+                        if (this.empiricalSourceMode === 'server-path' && this.empiricalFolderPath) await this.inspectEmpiricalFolderPath();
+                    } else {
+                        this.computeFlowChoice = 'new-data';
+                        this.dataSourceKind = 'new-simulation';
+                        this.simulationSourceMode = 'server-path';
+                        this.simulationFolderPath = String(this.restoreValue(form, 'simulation_folder_path', '')).trim();
+                        this.simulationFolderPaths = this.restoreJson(form, 'simulation_folder_paths', this.simulationFolderPath ? [this.simulationFolderPath] : []);
+                        this.simulationDataFileSelections = this.restoreJson(form, 'simulation_data_file_selections', {});
+                        if ((this.simulationFolderPaths || []).length > 0 || this.simulationFolderPath) await this.inspectSimulationFolderPath();
+                    }
+                } finally {
+                    this.restoreParserControls(form);
+                    this.computeFlowSelectorOpen = false;
+                    this.computeFlowConfigOpen = true;
+                    this.activeTab = 'load-data';
+                }
             },
             isUploaded(id) {
                 return this.uploads[id] !== undefined;

--- a/webui/templates/base.html
+++ b/webui/templates/base.html
@@ -160,6 +160,52 @@
 						<script src="{{ url_for('static', filename='js/alertMessages.js') }}"></script>
 					<!-- Block for page-specific JavaScript -->
 					{% block scripts %}{% endblock %}
+					{% set module_restore_form_data = module_restore_form | default({}) %}
+					{% if module_restore_form_data %}
+					<script id="module-restore-form" type="application/json">{{ module_restore_form_data | tojson }}</script>
+					<script>
+					(function () {
+						function readRestoreForm() {
+							const node = document.getElementById('module-restore-form');
+							if (!node) return {};
+							try {
+								const parsed = JSON.parse(node.textContent || '{}');
+								return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+							} catch (_err) {
+								return {};
+							}
+						}
+
+						function restoreField(field, rawValue) {
+							if (!field || field.type === 'file') return;
+							const value = String(rawValue ?? '');
+							if (field.type === 'radio') {
+								field.checked = field.value === value;
+							} else if (field.type === 'checkbox') {
+								field.checked = value === 'on' || value === 'true' || value === '1' || field.value === value;
+							} else {
+								field.value = value;
+							}
+							field.dispatchEvent(new Event('input', { bubbles: true }));
+							field.dispatchEvent(new Event('change', { bubbles: true }));
+						}
+
+						function restoreFormValues() {
+							const restoreForm = readRestoreForm();
+							Object.entries(restoreForm).forEach(([name, value]) => {
+								if (!name) return;
+								document.querySelectorAll(`[name="${CSS.escape(name)}"]`).forEach((field) => {
+									restoreField(field, value);
+								});
+							});
+						}
+
+						document.addEventListener('DOMContentLoaded', function () {
+							window.setTimeout(restoreFormValues, 0);
+						});
+					})();
+					</script>
+					{% endif %}
 				</div>
 			</div>
 		</div>

--- a/webui/templates/loading_page.html
+++ b/webui/templates/loading_page.html
@@ -248,19 +248,20 @@
             Save results
         </button>
 
-        {% if computation_type == 'simulation' %}
-        <a x-show="!pending && status === 'finished'" href="{{url_for('field_potential')}}"
-            class="bg-primary text-white px-10 py-3 rounded-lg font-bold text-lg hover:brightness-105 transition-all shadow-md">
-            Continue to Field Potential
-        </a>
         <form x-show="!pending && (status === 'failed' || status === 'cancelled') && canRestoreConfig"
             method="POST"
-            action="{{ url_for('restore_simulation_config', job_id=job_id) }}">
+            action="{{ url_for('restore_job_config', job_id=job_id) }}">
             <button type="submit"
                 class="bg-white text-primary border border-primary px-10 py-3 rounded-lg font-bold text-lg hover:bg-primary/5 transition-all shadow-md">
                 Back to configuration
             </button>
         </form>
+
+        {% if computation_type == 'simulation' %}
+        <a x-show="!pending && status === 'finished'" href="{{url_for('field_potential')}}"
+            class="bg-primary text-white px-10 py-3 rounded-lg font-bold text-lg hover:brightness-105 transition-all shadow-md">
+            Continue to Field Potential
+        </a>
         <a x-show="!pending && status === 'failed'" href="{{url_for('simulation')}}"
             class="bg-white text-primary border border-primary px-10 py-3 rounded-lg font-bold text-lg hover:bg-primary/5 transition-all shadow-md">
             Return to Simulation

--- a/webui/templates/loading_page.html
+++ b/webui/templates/loading_page.html
@@ -253,6 +253,14 @@
             class="bg-primary text-white px-10 py-3 rounded-lg font-bold text-lg hover:brightness-105 transition-all shadow-md">
             Continue to Field Potential
         </a>
+        <form x-show="!pending && (status === 'failed' || status === 'cancelled') && canRestoreConfig"
+            method="POST"
+            action="{{ url_for('restore_simulation_config', job_id=job_id) }}">
+            <button type="submit"
+                class="bg-white text-primary border border-primary px-10 py-3 rounded-lg font-bold text-lg hover:bg-primary/5 transition-all shadow-md">
+                Back to configuration
+            </button>
+        </form>
         <a x-show="!pending && status === 'failed'" href="{{url_for('simulation')}}"
             class="bg-white text-primary border border-primary px-10 py-3 rounded-lg font-bold text-lg hover:bg-primary/5 transition-all shadow-md">
             Return to Simulation
@@ -316,6 +324,7 @@ document.addEventListener('alpine:init', () => {
         output: "",
         cancelRequested: false,
         cancelling: false,
+        canRestoreConfig: false,
         uploadProgress: 0,
         uploadMessage: "",
         simulationTotal: 0,
@@ -391,6 +400,7 @@ document.addEventListener('alpine:init', () => {
                     this.progress = Number(data.progress || 0);
                     this.output = data.output || "";
                     this.cancelRequested = !!data.cancel_requested || this.status === 'cancelled';
+                    this.canRestoreConfig = !!data.can_restore_config;
                     this.simulationTotal = Number(data.simulation_total || 0);
                     this.simulationCompleted = Number(data.simulation_completed || 0);
                     this.meegTrialTotal = Number(data.meeg_trial_total || 0);


### PR DESCRIPTION
## Summary

  Adds a `Back to configuration` button for failed or cancelled jobs so users can return to the module configuration page with
  the previous form values restored.

  ## Changes

  - `webui/app.py`
    - Stores the submitted form data for restorable jobs.
    - Adds restore handling for Simulation, Field Potential, Features, Inference, Training, and Analysis modules.
    - Redirects restored jobs back to the correct configuration page.

  - `webui/templates/loading_page.html`
    - Adds the `Back to configuration` button when a job fails or is cancelled.

  - `webui/templates/base.html`
    - Adds generic form-value restoration for module configuration pages.

  - `webui/templates/2.2.0.field_potential_kernel.html`
    - Restores Field Potential Kernel tab state and Kernel-specific configuration fields.

  - `webui/templates/3.1.features_methods.html`
    - Restores the Features configuration directly into the parser/configuration view instead of returning to the data-source
    selector.