### PR TITLE
Fix CDM/LFP input validation in FieldPotentials

### DIFF
--- a/tests/webui/FieldPotential/test_webui_constraints.py
+++ b/tests/webui/FieldPotential/test_webui_constraints.py
@@ -64,6 +64,92 @@ def test_analysis_plot_warns_when_reducing_vector_signals_to_vector_magnitude(
     assert "Warning: this plot computes vector magnitude (module)" in html
 
 
+def _kernel_post_flash_messages(app_module, data):
+    with app_module.app.test_client() as client:
+        response = client.post(
+            "/start_computation_redirect/field_potential_kernel",
+            data=data,
+            headers={"Referer": "/field_potential/kernel?tab=cdm_computation"},
+        )
+        assert response.status_code in {302, 303}
+        with client.session_transaction() as session:
+            return [message for _category, message in session.get("_flashes", [])]
+
+
+def test_kernel_start_redirect_requires_output_or_manual_cdm_inputs(
+    field_potential_webui_app_module,
+    field_potential_example_paths,
+):
+    paths = field_potential_example_paths["hagen"]
+    messages = _kernel_post_flash_messages(
+        field_potential_webui_app_module,
+        {
+            "mc_folder": paths["mc_folder"],
+            "kernel_params_module_source_mode": "server-path",
+            "kernel_params_module": paths["kernel_params_module"],
+        },
+    )
+
+    assert any("Multicompartment network simulation outputs" in message for message in messages)
+    assert any("Mean firing rates (mean_nu_X)" in message for message in messages)
+    assert any("Resting membrane potential (Vrest)" in message for message in messages)
+
+
+def test_kernel_start_redirect_requires_missing_manual_counterpart(
+    field_potential_webui_app_module,
+    field_potential_example_paths,
+):
+    paths = field_potential_example_paths["hagen"]
+    messages = _kernel_post_flash_messages(
+        field_potential_webui_app_module,
+        {
+            "mc_folder": paths["mc_folder"],
+            "kernel_params_module_source_mode": "server-path",
+            "kernel_params_module": paths["kernel_params_module"],
+            "mean_nu_x": "1.0",
+        },
+    )
+
+    assert any("Resting membrane potential (Vrest)" in message for message in messages)
+
+
+def test_kernel_start_redirect_rejects_partial_manual_values_with_outputs(
+    field_potential_webui_app_module,
+    field_potential_example_paths,
+):
+    paths = field_potential_example_paths["hagen"]
+    messages = _kernel_post_flash_messages(
+        field_potential_webui_app_module,
+        {
+            "mc_folder": paths["mc_folder"],
+            "output_sim_path": "/tmp/simulation-output",
+            "mean_nu_x": "1.0",
+            "kernel_params_module_source_mode": "server-path",
+            "kernel_params_module": paths["kernel_params_module"],
+        },
+    )
+
+    assert any("both Mean firing rates" in message for message in messages)
+    assert any("Resting membrane potential (Vrest)" in message for message in messages)
+
+
+def test_kernel_start_redirect_requires_mc_folder(
+    field_potential_webui_app_module,
+    field_potential_example_paths,
+):
+    paths = field_potential_example_paths["hagen"]
+    messages = _kernel_post_flash_messages(
+        field_potential_webui_app_module,
+        {
+            "output_sim_path": "/tmp/simulation-output",
+            "kernel_params_module_source_mode": "server-path",
+            "kernel_params_module": paths["kernel_params_module"],
+        },
+    )
+
+    assert any("Multicompartment neuron model folder" in message for message in messages)
+
+
 def test_kernel_probe_selection_rejects_simultaneous_cdm_probe_choices(
     hagen_simulation_output,
     compute_utils_module,

--- a/webui/app.py
+++ b/webui/app.py
@@ -17953,6 +17953,46 @@ def start_computation_redirect(computation_type):
                 shutil.copy2(source_path, copied_path)
                 file_paths[file_key] = copied_path
         if computation_type == "field_potential_kernel":
+            kernel_missing = []
+            if not (request.form.get("mc_folder") or "").strip():
+                kernel_missing.append("Multicompartment neuron model folder")
+
+            output_sim_path_value = (request.form.get("output_sim_path") or "").strip()
+            mean_nu_value = (request.form.get("mean_nu_x") or "").strip()
+            vrest_value = (request.form.get("vrest_value") or "").strip()
+            if not output_sim_path_value:
+                if not mean_nu_value and not vrest_value:
+                    kernel_missing.append(
+                        "Multicompartment network simulation outputs, or both Mean firing rates "
+                        "(mean_nu_X) and Resting membrane potential (Vrest)"
+                    )
+                elif not mean_nu_value:
+                    kernel_missing.append("Mean firing rates (mean_nu_X), or Multicompartment network simulation outputs")
+                elif not vrest_value:
+                    kernel_missing.append("Resting membrane potential (Vrest), or Multicompartment network simulation outputs")
+            elif bool(mean_nu_value) != bool(vrest_value):
+                kernel_missing.append(
+                    "both Mean firing rates (mean_nu_X) and Resting membrane potential (Vrest), "
+                    "or neither manual value when using simulation outputs"
+                )
+
+            kernel_params_source_mode_for_required = (
+                request.form.get("kernel_params_module_source_mode") or "server-path"
+            ).strip().lower()
+            has_kernel_params_upload = bool(file_paths.get("kernel_params_file"))
+            has_kernel_params_server = bool((request.form.get("kernel_params_module") or "").strip())
+            has_kernel_params = (
+                has_kernel_params_upload
+                if kernel_params_source_mode_for_required == "upload"
+                else has_kernel_params_server
+            )
+            if not has_kernel_params:
+                kernel_missing.append("Kernel parameters module")
+
+            if kernel_missing:
+                flash(f"Required before compute: {'; '.join(kernel_missing)}.", "error")
+                return redirect(request.referrer or url_for("field_potential_kernel"))
+
             kernel_params_source_mode = (request.form.get("kernel_params_module_source_mode") or "server-path").strip().lower()
             if kernel_params_source_mode not in {"upload", "server-path"}:
                 kernel_params_source_mode = "server-path"

--- a/webui/static/js/field_potential_proxy.js
+++ b/webui/static/js/field_potential_proxy.js
@@ -496,7 +496,7 @@ function setupUploadZones() {
             if (!uploadedBox || !uploadedName) return;
             if (defaultName && !isDefaultIgnored()) {
                 uploadedName.textContent = defaultName;
-                if (uploadedLabel) uploadedLabel.textContent = 'Loaded';
+                if (uploadedLabel) uploadedLabel.textContent = 'Pipeline detection';
                 uploadedBox.classList.remove('hidden');
                 if (clearSelectionBtn) clearSelectionBtn.classList.remove('hidden');
             } else {
@@ -537,12 +537,11 @@ function setupUploadZones() {
         let autoBtn = null;
         let localBtn = null;
         let serverBtn = null;
-        let hasDetectedDefault = false;
+        const hasDetectedDefault = Boolean(defaultName);
 
         if (!customBrowseBtn) {
             const controls = document.createElement('div');
             controls.className = 'w-full flex flex-wrap items-center justify-center gap-2 mb-1';
-            hasDetectedDefault = Boolean(defaultName);
             controls.innerHTML = `
                 <button type="button" data-upload-action="true" class="proxy-upload-auto px-2.5 py-1 text-[10px] rounded border" ${hasDetectedDefault ? '' : 'disabled aria-disabled="true"'}>Pipeline detection</button>
                 <button type="button" data-upload-action="true" class="proxy-upload-local px-2.5 py-1 text-[10px] rounded border">Local upload</button>
@@ -557,7 +556,24 @@ function setupUploadZones() {
                 serverBtn.classList.add('hidden');
             }
         } else {
-            if (sourceModeInput) sourceModeInput.value = 'server-path';
+            customBrowseBtn.setAttribute('data-upload-action', 'true');
+            const pipelineBtn = document.createElement('button');
+            pipelineBtn.type = 'button';
+            pipelineBtn.setAttribute('data-upload-action', 'true');
+            pipelineBtn.className = 'proxy-upload-auto px-2.5 py-1 text-[10px] rounded border';
+            pipelineBtn.textContent = 'Pipeline detection';
+            if (!hasDetectedDefault) {
+                pipelineBtn.disabled = true;
+                pipelineBtn.setAttribute('aria-disabled', 'true');
+            }
+            const controls = customBrowseBtn.parentElement || zone;
+            controls.insertBefore(pipelineBtn, customBrowseBtn);
+            autoBtn = pipelineBtn;
+            if (window.isLocalRuntime) {
+                localBtn = customBrowseBtn;
+            } else {
+                serverBtn = customBrowseBtn;
+            }
         }
 
         const applyModeVisuals = (mode) => {
@@ -587,7 +603,9 @@ function setupUploadZones() {
         const syncServerSelectionUi = () => {
             const selected = String(serverPathInput.value || '').trim();
             if (filename) {
-                filename.textContent = selected ? basenameFromPath(selected) : 'Server file not selected';
+                filename.textContent = selected
+                    ? basenameFromPath(selected)
+                    : (defaultName && !isDefaultIgnored() ? defaultName : 'Server file not selected');
             }
             if (uploadedBox && uploadedName) {
                 if (selected) {
@@ -595,6 +613,11 @@ function setupUploadZones() {
                     setDefaultIgnored(true);
                     uploadedName.textContent = basenameFromPath(selected);
                     if (uploadedLabel) uploadedLabel.textContent = 'Selected server file';
+                    uploadedBox.classList.remove('hidden');
+                    if (clearSelectionBtn) clearSelectionBtn.classList.remove('hidden');
+                } else if (defaultName && !isDefaultIgnored()) {
+                    uploadedName.textContent = defaultName;
+                    if (uploadedLabel) uploadedLabel.textContent = 'Pipeline detection';
                     uploadedBox.classList.remove('hidden');
                     if (clearSelectionBtn) clearSelectionBtn.classList.remove('hidden');
                 } else {
@@ -610,7 +633,7 @@ function setupUploadZones() {
             if (uploadedBox && uploadedName) {
                 if (hasDetectedDefault && !isDefaultIgnored()) {
                     uploadedName.textContent = defaultName;
-                    if (uploadedLabel) uploadedLabel.textContent = 'Loaded';
+                    if (uploadedLabel) uploadedLabel.textContent = 'Pipeline detection';
                     uploadedBox.classList.remove('hidden');
                     if (clearSelectionBtn) clearSelectionBtn.classList.remove('hidden');
                 } else {
@@ -683,6 +706,9 @@ function setupUploadZones() {
             localBtn.addEventListener('click', (event) => {
                 event.stopPropagation();
                 setMode('upload');
+                if (customBrowseBtn && localBtn === customBrowseBtn) {
+                    input.click();
+                }
                 notifyNuExtTrialDetection();
             });
         }
@@ -699,6 +725,9 @@ function setupUploadZones() {
                 event.stopPropagation();
                 if (!allowServerSource) return;
                 setMode('server-path');
+                if (customBrowseBtn && serverBtn === customBrowseBtn) {
+                    openServerPicker();
+                }
                 notifyNuExtTrialDetection();
             });
         }
@@ -720,11 +749,6 @@ function setupUploadZones() {
         }
 
         zone.addEventListener('click', (event) => {
-            if (customBrowseBtn) {
-                if (event.target && event.target.closest('[data-upload-action]')) return;
-                openServerPicker();
-                return;
-            }
             if (event.target && event.target.closest('[data-upload-action]')) {
                 return;
             }
@@ -739,43 +763,32 @@ function setupUploadZones() {
             input.click();
         });
 
-        // Drag & drop disabled when custom button exists
-        if (!customBrowseBtn) {
-            zone.addEventListener('dragover', (event) => {
-                event.preventDefault();
-                if (isServerPathMode() || isAutoDetectedMode()) return;
-                zone.classList.add('border-primary', 'bg-primary/5');
-            });
-            zone.addEventListener('dragleave', () => {
-                zone.classList.remove('border-primary', 'bg-primary/5');
-            });
-            zone.addEventListener('drop', (event) => {
-                event.preventDefault();
-                if (isServerPathMode() || isAutoDetectedMode()) return;
-                zone.classList.remove('border-primary', 'bg-primary/5');
-                if (event.dataTransfer.files && event.dataTransfer.files[0]) {
-                    input.files = event.dataTransfer.files;
-                    serverPathInput.value = '';
-                    syncLocalSelectionUi();
-                    notifyNuExtTrialDetection();
-                }
-            });
-        }
+        zone.addEventListener('dragover', (event) => {
+            event.preventDefault();
+            if (isServerPathMode() || isAutoDetectedMode()) return;
+            zone.classList.add('border-primary', 'bg-primary/5');
+        });
+        zone.addEventListener('dragleave', () => {
+            zone.classList.remove('border-primary', 'bg-primary/5');
+        });
+        zone.addEventListener('drop', (event) => {
+            event.preventDefault();
+            if (isServerPathMode() || isAutoDetectedMode()) return;
+            zone.classList.remove('border-primary', 'bg-primary/5');
+            if (event.dataTransfer.files && event.dataTransfer.files[0]) {
+                input.files = event.dataTransfer.files;
+                serverPathInput.value = '';
+                syncLocalSelectionUi();
+                notifyNuExtTrialDetection();
+            }
+        });
 
         input.addEventListener('change', () => {
-            if (customBrowseBtn) return;
             if (isServerPathMode()) return;
             serverPathInput.value = '';
             syncLocalSelectionUi();
             notifyNuExtTrialDetection();
         });
-
-        if (customBrowseBtn) {
-            customBrowseBtn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                openServerPicker();
-            });
-        }
 
         zoneCandidateGetters.push(() => {
             const selectedFile = input.files && input.files[0] ? input.files[0] : null;
@@ -787,28 +800,25 @@ function setupUploadZones() {
                 return { fileKey, kind: 'server', path: selectedServerPath };
             }
             const mode = String(sourceModeInput.value || '').trim().toLowerCase();
-            if ((mode === 'auto-detected' || mode === 'upload') && defaultName && !isDefaultIgnored()) {
+            if (defaultName && !isDefaultIgnored() && (mode === 'auto-detected' || mode === 'upload' || !selectedServerPath)) {
                 return { fileKey, kind: 'default', useDefault: true };
             }
             return null;
         });
 
-        if (customBrowseBtn) {
-            // Always server-path, no visual buttons to update
-            sourceModeInput.value = 'server-path';
-            syncServerSelectionUi();
+        const initialMode = String(sourceModeInput.value || '').trim().toLowerCase();
+        const initialServerPath = String(serverPathInput.value || '').trim();
+        if (!allowServerSource) {
+            serverPathInput.value = '';
+            setMode('upload');
+        } else if (initialMode === 'auto-detected' || (hasDetectedDefault && !isDefaultIgnored() && !initialServerPath)) {
+            setMode('auto-detected');
+        } else if (customBrowseBtn && window.isLocalRuntime && initialMode === 'server-path' && !initialServerPath) {
+            setMode('upload');
+        } else if (initialMode === 'server-path') {
+            setMode('server-path');
         } else {
-            const initialMode = String(sourceModeInput.value || '').trim().toLowerCase();
-            if (!allowServerSource) {
-                serverPathInput.value = '';
-                setMode('upload');
-            } else if (initialMode === 'server-path') {
-                setMode('server-path');
-            } else if (initialMode === 'auto-detected' || (hasDetectedDefault && !isDefaultIgnored())) {
-                setMode('auto-detected');
-            } else {
-                setMode(defaultMode);
-            }
+            setMode(defaultMode);
         }
     });
 

--- a/webui/templates/2.2.0.field_potential_kernel.html
+++ b/webui/templates/2.2.0.field_potential_kernel.html
@@ -667,11 +667,14 @@
             </button>
         </template>
         <template x-if="activeTab === 'cdm_computation'">
-            <button type="submit" form="kernel-compute-form"
-                class="flex items-center justify-center gap-2 py-2.5 px-5 w-full sm:w-auto bg-primary text-white font-bold text-base rounded-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50 dark:focus:ring-offset-background-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
-                Compute CDM/LFP
-                <span class="material-symbols-outlined">arrow_forward</span>
-            </button>
+            <div class="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:items-start">
+                <button type="submit" form="kernel-compute-form"
+                    class="flex items-center justify-center gap-2 py-2.5 px-5 w-full sm:w-auto bg-primary text-white font-bold text-base rounded-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50 dark:focus:ring-offset-background-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                    Compute CDM/LFP
+                    <span class="material-symbols-outlined">arrow_forward</span>
+                </button>
+                <p id="kernel-compute-validation-error" class="hidden max-w-xl text-xs font-semibold text-red-600 dark:text-red-400"></p>
+            </div>
         </template>
     </div>
 
@@ -795,6 +798,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const meegComputeForm = document.getElementById('meeg-compute-form');
     const kernelDtInput = document.querySelector('input[name="dt"]');
     const signalScaleInput = document.getElementById('signal-scale');
+    const kernelMeanNuInput = kernelComputeForm ? kernelComputeForm.querySelector('input[name="mean_nu_x"]') : null;
+    const kernelVrestInput = kernelComputeForm ? kernelComputeForm.querySelector('input[name="vrest_value"]') : null;
     let kernelScaleAutoMode = true;
     const biophysItemsContainer = document.getElementById('biophysItems');
     const biophysAddBtn = document.getElementById('biophysAddBtn');
@@ -891,11 +896,30 @@ document.addEventListener('DOMContentLoaded', () => {
     if (biophysAddBtn) {
         biophysAddBtn.addEventListener('click', () => createBiophysRow(''));
     }
+    const kernelComputeRequirementMessage = (missing) => {
+        if (!missing.length) return '';
+        return `Required before compute: ${missing.join('; ')}.`;
+    };
     const kernelMissingMandatorySelections = () => {
         const missing = [];
         const mcFolderPath = String(document.getElementById('mcFolderHiddenInput')?.value || '').trim();
         if (!mcFolderPath) {
             missing.push('Multicompartment neuron model folder');
+        }
+
+        const outputSimPath = String(document.getElementById('outputSimHiddenInput')?.value || '').trim();
+        const meanNuValue = String(kernelMeanNuInput?.value || '').trim();
+        const vrestValue = String(kernelVrestInput?.value || '').trim();
+        if (!outputSimPath) {
+            if (!meanNuValue && !vrestValue) {
+                missing.push('Multicompartment network simulation outputs, or both Mean firing rates (mean_nu_X) and Resting membrane potential (Vrest)');
+            } else if (!meanNuValue) {
+                missing.push('Mean firing rates (mean_nu_X), or Multicompartment network simulation outputs');
+            } else if (!vrestValue) {
+                missing.push('Resting membrane potential (Vrest), or Multicompartment network simulation outputs');
+            }
+        } else if ((meanNuValue && !vrestValue) || (!meanNuValue && vrestValue)) {
+            missing.push('both Mean firing rates (mean_nu_X) and Resting membrane potential (Vrest), or neither manual value when using simulation outputs');
         }
 
         const paramsMode = String(document.getElementById('kernelParamsModuleSourceMode')?.value || 'upload')
@@ -912,19 +936,26 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     const updateKernelSubmitAvailability = () => {
         const kernelSubmitBtn = document.querySelector('button[type="submit"][form="kernel-compute-form"]');
+        const validationError = document.getElementById('kernel-compute-validation-error');
         if (!kernelSubmitBtn) return;
         const missing = kernelMissingMandatorySelections();
         const blocked = missing.length > 0;
+        const message = kernelComputeRequirementMessage(missing);
         kernelSubmitBtn.disabled = blocked;
         kernelSubmitBtn.setAttribute('aria-disabled', blocked ? 'true' : 'false');
-        kernelSubmitBtn.title = blocked ? `Required before compute: ${missing.join(', ')}.` : '';
+        kernelSubmitBtn.title = message;
+        if (validationError) {
+            if (validationError.textContent !== message) {
+                validationError.textContent = message;
+            }
+            validationError.classList.toggle('hidden', !blocked);
+        }
     };
     if (kernelComputeForm) {
         kernelComputeForm.addEventListener('submit', (event) => {
             const missing = kernelMissingMandatorySelections();
             if (missing.length > 0) {
                 event.preventDefault();
-                alert(`Cannot compute CDM/LFP yet. Missing required inputs: ${missing.join(', ')}.`);
                 updateKernelSubmitAvailability();
                 return;
             }
@@ -963,6 +994,11 @@ document.addEventListener('DOMContentLoaded', () => {
         kernelDtInput.addEventListener('input', () => syncKernelScaleFromDt());
         kernelDtInput.addEventListener('change', () => syncKernelScaleFromDt());
     }
+    [kernelMeanNuInput, kernelVrestInput].forEach((input) => {
+        if (!input) return;
+        input.addEventListener('input', () => updateKernelSubmitAvailability());
+        input.addEventListener('change', () => updateKernelSubmitAvailability());
+    });
     updateKernelSubmitAvailability();
     const kernelSubmitButtonObserver = new MutationObserver(() => updateKernelSubmitAvailability());
     kernelSubmitButtonObserver.observe(document.body, { childList: true, subtree: true });

--- a/webui/templates/2.2.0.field_potential_kernel.html
+++ b/webui/templates/2.2.0.field_potential_kernel.html
@@ -345,7 +345,7 @@
                                 {% endif %}
                                 <div class="mt-2 hidden w-full rounded-md border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/30 px-3 py-2 text-xs text-green-700 dark:text-green-300"
                                     data-role="auto-summary">
-                                    <span class="font-semibold text-green-800 dark:text-green-200">Detected from pipeline:</span>
+                                    <span class="font-semibold text-green-800 dark:text-green-200">Pipeline detection:</span>
                                     <div class="mt-1">
                                         <span class="block flex-1 font-mono break-all" data-role="auto-name"></span>
                                     </div>
@@ -444,7 +444,7 @@
                                 <div class="mt-2 hidden w-full rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-300 text-[10px] font-semibold px-2 py-1"
                                     data-uploaded data-default-name="{{ 'simulation.pkl → times' if default_sim.times else '' }}">
                                     <div class="flex items-start justify-between gap-2">
-                                        <span><span data-uploaded-label>{% if default_sim.times %}Loaded{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.times %}simulation.pkl → times{% endif %}</span></span>
+                                        <span><span data-uploaded-label>{% if default_sim.times %}Pipeline detection{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.times %}simulation.pkl → times{% endif %}</span></span>
                                         <button type="button" data-upload-action="true" data-clear-upload class="hidden inline-flex items-center justify-center rounded-md p-1 text-green-700 hover:text-red-600 dark:text-green-300 dark:hover:text-red-400" title="Remove selected file" aria-label="Remove selected file">
                                             <span class="material-symbols-outlined text-sm leading-none">close</span>
                                         </button>
@@ -591,7 +591,7 @@
                             <div class="mt-2 hidden w-full rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-300 text-[10px] font-semibold px-2 py-1"
                                 data-uploaded data-default-name="{{ default_meeg.cdm_name }}">
                                 <div class="flex items-start justify-between gap-2">
-                                    <span><span data-uploaded-label>{% if default_meeg.cdm_exists %}Loaded{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_meeg.cdm_exists %}{{ default_meeg.cdm_name }}{% endif %}</span></span>
+                                    <span><span data-uploaded-label>{% if default_meeg.cdm_exists %}Pipeline detection{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_meeg.cdm_exists %}{{ default_meeg.cdm_name }}{% endif %}</span></span>
                                     <button type="button" data-upload-action="true" data-clear-upload class="hidden inline-flex items-center justify-center rounded-md p-1 text-green-700 hover:text-red-600 dark:text-green-300 dark:hover:text-red-400" title="Remove selected file" aria-label="Remove selected file">
                                         <span class="material-symbols-outlined text-sm leading-none">close</span>
                                     </button>
@@ -2543,7 +2543,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const autoSummary = document.createElement('div');
         autoSummary.className = 'mt-2 hidden w-full rounded-md border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/30 px-3 py-2 text-xs text-green-700 dark:text-green-300';
         autoSummary.innerHTML = `
-            <span class="font-semibold text-green-800 dark:text-green-200">Detected from pipeline:</span>
+            <span class="font-semibold text-green-800 dark:text-green-200">Pipeline detection:</span>
             <div class="mt-1 flex items-start justify-between gap-2">
                 <span class="block flex-1 font-mono break-all" data-role="auto-name"></span>
             </div>

--- a/webui/templates/2.3.0.field_potential_proxy.html
+++ b/webui/templates/2.3.0.field_potential_proxy.html
@@ -108,7 +108,7 @@
                         <div class="mt-2 w-full rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-300 text-[10px] font-semibold px-2 py-1 {% if not default_sim.times %}hidden{% endif %}"
                             data-uploaded data-default-name="{{ 'times.pkl' if default_sim.times else '' }}">
                             <div class="flex items-start justify-between gap-2">
-                                <span><span data-uploaded-label>{% if default_sim.times %}Loaded{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.times %}times.pkl{% endif %}</span></span>
+                                <span><span data-uploaded-label>{% if default_sim.times %}Pipeline detection{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.times %}times.pkl{% endif %}</span></span>
                                 <button type="button" data-upload-action="true" data-clear-upload class="hidden inline-flex items-center justify-center rounded-md p-1 text-green-700 hover:text-red-600 dark:text-green-300 dark:hover:text-red-400" title="Remove selected file" aria-label="Remove selected file">
                                     <span class="material-symbols-outlined text-sm leading-none">close</span>
                                 </button>
@@ -137,7 +137,7 @@
                         <div class="mt-2 w-full rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-300 text-[10px] font-semibold px-2 py-1 {% if not default_sim.gids %}hidden{% endif %}"
                             data-uploaded data-default-name="{{ 'gids.pkl' if default_sim.gids else '' }}">
                             <div class="flex items-start justify-between gap-2">
-                                <span><span data-uploaded-label>{% if default_sim.gids %}Loaded{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.gids %}gids.pkl{% endif %}</span></span>
+                                <span><span data-uploaded-label>{% if default_sim.gids %}Pipeline detection{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.gids %}gids.pkl{% endif %}</span></span>
                                 <button type="button" data-upload-action="true" data-clear-upload class="hidden inline-flex items-center justify-center rounded-md p-1 text-green-700 hover:text-red-600 dark:text-green-300 dark:hover:text-red-400" title="Remove selected file" aria-label="Remove selected file">
                                     <span class="material-symbols-outlined text-sm leading-none">close</span>
                                 </button>
@@ -166,7 +166,7 @@
                         <div class="mt-2 w-full rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-300 text-[10px] font-semibold px-2 py-1 {% if not default_sim.vm %}hidden{% endif %}"
                             data-uploaded data-default-name="{{ default_sim_names.vm if default_sim.vm else '' }}">
                             <div class="flex items-start justify-between gap-2">
-                                <span><span data-uploaded-label>{% if default_sim.vm %}Loaded{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.vm %}{{ default_sim_names.vm }}{% endif %}</span></span>
+                                <span><span data-uploaded-label>{% if default_sim.vm %}Pipeline detection{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.vm %}{{ default_sim_names.vm }}{% endif %}</span></span>
                                 <button type="button" data-upload-action="true" data-clear-upload class="hidden inline-flex items-center justify-center rounded-md p-1 text-green-700 hover:text-red-600 dark:text-green-300 dark:hover:text-red-400" title="Remove selected file" aria-label="Remove selected file">
                                     <span class="material-symbols-outlined text-sm leading-none">close</span>
                                 </button>
@@ -195,7 +195,7 @@
                         <div class="mt-2 w-full rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-300 text-[10px] font-semibold px-2 py-1 {% if not default_sim.ampa %}hidden{% endif %}"
                             data-uploaded data-default-name="{{ default_sim_names.ampa if default_sim.ampa else '' }}">
                             <div class="flex items-start justify-between gap-2">
-                                <span><span data-uploaded-label>{% if default_sim.ampa %}Loaded{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.ampa %}{{ default_sim_names.ampa }}{% endif %}</span></span>
+                                <span><span data-uploaded-label>{% if default_sim.ampa %}Pipeline detection{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.ampa %}{{ default_sim_names.ampa }}{% endif %}</span></span>
                                 <button type="button" data-upload-action="true" data-clear-upload class="hidden inline-flex items-center justify-center rounded-md p-1 text-green-700 hover:text-red-600 dark:text-green-300 dark:hover:text-red-400" title="Remove selected file" aria-label="Remove selected file">
                                     <span class="material-symbols-outlined text-sm leading-none">close</span>
                                 </button>
@@ -224,7 +224,7 @@
                         <div class="mt-2 w-full rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-300 text-[10px] font-semibold px-2 py-1 {% if not default_sim.gaba %}hidden{% endif %}"
                             data-uploaded data-default-name="{{ default_sim_names.gaba if default_sim.gaba else '' }}">
                             <div class="flex items-start justify-between gap-2">
-                                <span><span data-uploaded-label>{% if default_sim.gaba %}Loaded{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.gaba %}{{ default_sim_names.gaba }}{% endif %}</span></span>
+                                <span><span data-uploaded-label>{% if default_sim.gaba %}Pipeline detection{% else %}Uploaded{% endif %}</span>: <span data-uploaded-name>{% if default_sim.gaba %}{{ default_sim_names.gaba }}{% endif %}</span></span>
                                 <button type="button" data-upload-action="true" data-clear-upload class="hidden inline-flex items-center justify-center rounded-md p-1 text-green-700 hover:text-red-600 dark:text-green-300 dark:hover:text-red-400" title="Remove selected file" aria-label="Remove selected file">
                                     <span class="material-symbols-outlined text-sm leading-none">close</span>
                                 </button>


### PR DESCRIPTION
 ## Summary

  This PR updates the FieldPotentials CDM/LFP computation flow to validate the required
  inputs before allowing the computation to start.

  ## Changes

  - Added frontend validation for the Current Dipole Moment/LFP compute button.
  - The compute button is disabled when required inputs are missing.
  - Added a red validation message below the button explaining what still needs to be
  provided.
  - Supported both valid input combinations:
    - Multicompartment neuron model folder + simulation outputs
    - Multicompartment neuron model folder + mean firing rates + resting membrane
    potential
  - Added backend validation to prevent invalid CDM/LFP computation requests from being
  submitted directly.