### PR TITLE
Move Features and Analysis validation messages below action buttons

### DIFF
--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -2140,6 +2140,12 @@ def custom_feature(sample, params):
                 const firstKey = Object.keys(errors).find((key) => errors[key]);
                 return firstKey ? errors[firstKey] : '';
             },
+            computeSubmitValidationMessages() {
+                const messages = Object.values(this.featureMethodValidationErrors()).filter(Boolean);
+                const blockReason = this.computeSubmitBlockReason();
+                if (blockReason && !messages.includes(blockReason)) messages.push(blockReason);
+                return [...new Set(messages)];
+            },
             clearFeatureMethodValidationMessages() {
                 const form = this.featureMethodConfigForm();
                 if (!form) return;
@@ -2161,12 +2167,6 @@ def custom_feature(sample, params):
                     field.setAttribute('data-feature-param-invalid', '1');
                     field.setAttribute('aria-invalid', 'true');
                     field.classList.add('border-red-500', 'dark:border-red-400', 'focus:border-red-500', 'focus:ring-red-500');
-                    const messageNode = document.createElement('p');
-                    messageNode.setAttribute('data-feature-param-error', name);
-                    messageNode.className = 'mt-1 text-xs font-medium text-red-600 dark:text-red-400';
-                    messageNode.textContent = message;
-                    const container = field.closest('label') || field.parentElement;
-                    if (container) container.appendChild(messageNode);
                 });
             },
             refreshFeatureMethodValidation() {
@@ -3500,7 +3500,7 @@ def custom_feature(sample, params):
             },
             submitComputeFeatures(event) {
                 const form = event.target;
-                if (this.submitInProgress) return;
+                if (this.submitInProgress || this.computeSubmitBlockReason()) return;
 
                 this.stopUploadWaitPulse();
                 this.submitError = '';
@@ -6473,15 +6473,6 @@ def custom_feature(sample, params):
                 <p x-show="submitError" class="text-xs text-red-600 dark:text-red-400" x-text="submitError"></p>
             </div>
 
-            <template x-if="activeTab === 'configure-method' && !submitInProgress && computeSubmitBlockReason()">
-                <div class="flex mt-6 w-full p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700/40 rounded-xl">
-                    <span class="text-blue-600 dark:text-blue-400 text-base leading-5">⏳</span>
-                    <p class="text-sm text-amber-800 dark:text-amber-200">
-                        Configuration issue: <span class="font-semibold" x-text="computeSubmitBlockReason()"></span>
-                    </p>
-                </div>
-            </template>
-
             <div class="mt-10 flex flex-col sm:flex-row justify-between items-center gap-4">
                 <template x-if="activeTab === 'load-data'">
                     <a href="{{ url_for('dashboard') }}"
@@ -6500,14 +6491,21 @@ def custom_feature(sample, params):
                     </button>
                 </template>
 
-                <template x-if="activeTab === 'configure-method' && canSubmitFeatures()">
-                    <button type="submit"
-                        :disabled="submitInProgress"
-                        :class="submitInProgress ? 'opacity-70 cursor-not-allowed' : ''"
-                        class="flex items-center justify-center gap-2 h-12 px-6 w-full sm:w-auto bg-primary text-white font-bold text-base rounded-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50 dark:focus:ring-offset-background-dark transition-colors">
-                        <span x-text="submitInProgress ? (hasUploadPayload() ? 'Uploading files...' : 'Processing...') : 'Compute features'"></span>
-                        <span class="material-symbols-outlined">arrow_forward</span>
-                    </button>
+                <template x-if="activeTab === 'configure-method'">
+                    <div class="w-full sm:w-auto">
+                        <button type="submit"
+                            :disabled="submitInProgress || Boolean(computeSubmitBlockReason())"
+                            :class="(submitInProgress || computeSubmitBlockReason()) ? 'opacity-70 cursor-not-allowed' : ''"
+                            class="flex items-center justify-center gap-2 h-12 px-6 w-full sm:w-auto bg-primary text-white font-bold text-base rounded-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50 dark:focus:ring-offset-background-dark transition-colors">
+                            <span x-text="submitInProgress ? (hasUploadPayload() ? 'Uploading files...' : 'Processing...') : 'Compute features'"></span>
+                            <span class="material-symbols-outlined">arrow_forward</span>
+                        </button>
+                        <div x-show="!submitInProgress && computeSubmitValidationMessages().length" class="mt-2 space-y-1 text-xs font-medium text-red-600 dark:text-red-400">
+                            <template x-for="message in computeSubmitValidationMessages()" :key="message">
+                                <p x-text="message"></p>
+                            </template>
+                        </div>
+                    </div>
                 </template>
 
                 <template x-if="activeTab === 'select-method' && hasAnyData()">

--- a/webui/templates/5.1.0.analysis.html
+++ b/webui/templates/5.1.0.analysis.html
@@ -806,6 +806,12 @@
                 const fields = ['group_by', 'control_group', 'value_col', 'cohend_abs_threshold'];
                 return fields.map((field) => this.topomapValidationIssue(field)).filter(Boolean);
             },
+            topomapPlotValidationMessages() {
+                const messages = this.topomapComparisonValidationMessages();
+                const blockReason = this.topomapComparisonBlockReason();
+                if (blockReason && !messages.includes(blockReason)) messages.push(blockReason);
+                return [...new Set(messages)];
+            },
             topomapComparisonBlockReason() {
                 if (!this.dfColumns.length) {
                     return 'Upload a dataframe to enable column selection.';
@@ -2194,7 +2200,6 @@
                                             type="number" min="0" step="any" placeholder="No filter"
                                             x-model="topomapCohendAbsThreshold" />
                                     </div>
-                                    <p x-show="topomapValidationIssue('cohend_abs_threshold')" class="mt-1 text-xs text-red-600 dark:text-red-400" x-text="topomapValidationIssue('cohend_abs_threshold')"></p>
                                 </div>
                                 <div class="sm:col-span-3">
                                     <label class="block text-sm font-medium leading-6 text-slate-900 dark:text-slate-300"
@@ -2213,7 +2218,6 @@
                                     </div>
                                     <p x-show="columnsLoading" class="mt-2 text-xs text-slate-500 dark:text-slate-400">Loading columns...</p>
                                     <p x-show="!columnsLoading && !dfColumns.length" class="mt-2 text-xs text-slate-500 dark:text-slate-400">Upload a dataframe to enable column selection.</p>
-                                    <p x-show="topomapValidationIssue('group_by')" class="mt-2 text-xs text-red-600 dark:text-red-400" x-text="topomapValidationIssue('group_by')"></p>
                                 </div>
                                 <div class="sm:col-span-3" x-show="topomapMode === 'compare_categories'" x-cloak>
                                     <label class="block text-sm font-medium leading-6 text-slate-900 dark:text-slate-300"
@@ -2231,7 +2235,6 @@
                                     </div>
                                     <p x-show="topomapGroupValuesLoading" class="mt-1 text-xs text-slate-500 dark:text-slate-400">Loading group values...</p>
                                     <p x-show="topomapGroupValuesError" class="mt-1 text-xs text-red-600 dark:text-red-400" x-text="topomapGroupValuesError"></p>
-                                    <p x-show="topomapValidationIssue('control_group')" class="mt-1 text-xs text-red-600 dark:text-red-400" x-text="topomapValidationIssue('control_group')"></p>
                                 </div>
                                 <div class="sm:col-span-3">
                                     <label class="block text-sm font-medium leading-6 text-slate-900 dark:text-slate-300"
@@ -2249,7 +2252,6 @@
                                     </div>
                                     <p x-show="columnsLoading" class="mt-2 text-xs text-slate-500 dark:text-slate-400">Loading columns...</p>
                                     <p x-show="!columnsLoading && !dfColumns.length" class="mt-2 text-xs text-slate-500 dark:text-slate-400">Upload a dataframe to enable column selection.</p>
-                                    <p x-show="topomapValidationIssue('value_col')" class="mt-2 text-xs text-red-600 dark:text-red-400" x-text="topomapValidationIssue('value_col')"></p>
                                 </div>
 
                                 <div class="sm:col-span-3">
@@ -2627,13 +2629,20 @@
                 </template>
 
                 <template x-if="activeTab === 'topomap' && isDataframeSelected() && !isSimulationSelectionActive()">
-                    <button type="submit"
-                        formaction="{{ url_for('analysis_plot_topomap') }}"
-                        data-plot-action="topomap"
-                        class="flex items-center justify-center gap-2 h-12 px-6 w-full sm:w-auto bg-primary text-white font-bold text-base rounded-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50 dark:focus:ring-offset-background-dark transition-colors"
-                        :disabled="isTopomapPlotDisabled()">
-                        Plot topomap
-                    </button>
+                    <div class="w-full sm:w-auto">
+                        <button type="submit"
+                            formaction="{{ url_for('analysis_plot_topomap') }}"
+                            data-plot-action="topomap"
+                            class="flex items-center justify-center gap-2 h-12 px-6 w-full sm:w-auto bg-primary text-white font-bold text-base rounded-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50 dark:focus:ring-offset-background-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            :disabled="isTopomapPlotDisabled()">
+                            Plot topomap
+                        </button>
+                        <div x-show="topomapPlotValidationMessages().length" class="mt-2 space-y-1 text-xs font-medium text-red-600 dark:text-red-400">
+                            <template x-for="message in topomapPlotValidationMessages()" :key="message">
+                                <p x-text="message"></p>
+                            </template>
+                        </div>
+                    </div>
                 </template>
 
                 <template x-if="activeTab === 'simulation-outputs' && isSimulationSelectionActive() && !isDataframeSelected()">


### PR DESCRIPTION
  Move validation messages in Features and Analysis to appear below their respective action
  buttons.

  ## Changes

  ### Features

  - Keep the Compute features button visible when validation errors exist.
  - Disable the button until all requirements are met.
  - Show validation messages below the button.
  - Keep invalid configuration fields highlighted in red.

  ### Analysis

  - Move topomap group-comparison validation messages below the Plot topomap button.
  - Keep the button disabled until all required fields are valid.
  - Add disabled styling to the button