### PR TITLE
distinguish pipeline and uploaded features in inference

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -1879,6 +1879,14 @@ def _list_features_data_files():
     return sorted(files)
 
 
+def _is_pipeline_features_file(relative_path):
+    """Return whether a features file was computed by the Features pipeline."""
+    try:
+        return Path(str(relative_path)).parts[:1] == ("pipeline",)
+    except (TypeError, ValueError):
+        return False
+
+
 def _bootstrap_features_data_from_previous_steps():
     """
     Ensure inference can auto-detect features from earlier steps.
@@ -1912,7 +1920,9 @@ def _bootstrap_features_data_from_previous_steps():
     _, src_path = max(candidates, key=lambda item: item[0])
     features_dir = _features_data_dir(create=True)
     dst_name = os.path.basename(src_path)
-    dst_path = os.path.join(features_dir, dst_name)
+    pipeline_dir = os.path.join(features_dir, "pipeline")
+    os.makedirs(pipeline_dir, exist_ok=True)
+    dst_path = os.path.join(pipeline_dir, dst_name)
 
     # Avoid noisy copy errors if source and destination are already the same.
     if os.path.realpath(src_path) != os.path.realpath(dst_path):
@@ -10961,21 +10971,54 @@ def compute_predictions():
         flush=True,
     )
     default_feature_file = ""
+    default_features_server_file_path = ""
+    default_features_source_mode = ""
     if feature_data_files:
         features_root = _features_data_dir(create=False)
-        try:
-            default_feature_file = max(
-                feature_data_files,
-                key=lambda name: os.path.getmtime(os.path.join(features_root, name))
-            )
-        except Exception:
-            default_feature_file = feature_data_files[-1]
+        pipeline_feature_files = {
+            name for name in feature_data_files if _is_pipeline_features_file(name)
+        }
+        # Backward compatibility for feature outputs written before pipeline
+        # outputs had their own folder.  A completed Features job still
+        # identifies those in-memory outputs as pipeline data.
+        for status in job_status.values():
+            candidate = status.get("dashboard_features_path") if isinstance(status, dict) else None
+            if not candidate or not _is_path_within_root(candidate, features_root):
+                continue
+            relative_candidate = os.path.relpath(candidate, features_root)
+            if relative_candidate in feature_data_files:
+                pipeline_feature_files.add(relative_candidate)
+        def _newest_feature_file(candidates):
+            if not candidates:
+                return ""
+            try:
+                return max(
+                    candidates,
+                    key=lambda name: os.path.getmtime(os.path.join(features_root, name)),
+                )
+            except Exception:
+                return candidates[-1]
+
+        # Keep the two sources independent.  A previously loaded dataframe
+        # must not suppress pipeline detection when a computed output exists.
+        default_feature_file = _newest_feature_file(
+            [name for name in feature_data_files if name in pipeline_feature_files]
+        )
+        manually_loaded_feature_file = _newest_feature_file(
+            [name for name in feature_data_files if name not in pipeline_feature_files]
+        )
+        if default_feature_file:
+            default_features_source_mode = "auto-detected"
+        if manually_loaded_feature_file:
+            default_features_server_file_path = os.path.join(features_root, manually_loaded_feature_file)
     trained_assets = _trained_inference_assets(request.args.get("training_job_id"))
     return render_template(
         "4.3.0.compute_predictions.html",
         feature_data_files=feature_data_files,
         has_feature_data=bool(feature_data_files),
         default_feature_file=default_feature_file,
+        default_features_server_file_path=default_features_server_file_path,
+        default_features_source_mode=default_features_source_mode,
         default_trained_model_file=trained_assets.get("model_file", ""),
         default_trained_scaler_file=trained_assets.get("scaler_file", ""),
         default_trained_assets_folder=trained_assets.get("folder_path", ""),

--- a/webui/compute_utils.py
+++ b/webui/compute_utils.py
@@ -204,6 +204,8 @@ def _features_data_dir():
 
 def _persist_features_dataframe(output_df, method):
     features_dir = _features_data_dir()
+    pipeline_dir = os.path.join(features_dir, "pipeline")
+    os.makedirs(pipeline_dir, exist_ok=True)
     safe_method = "".join(ch if ch.isalnum() or ch in {"_", "-"} else "_" for ch in str(method or "features"))
     # Cleanup legacy per-job files for this method so only one canonical file remains.
     legacy_pattern = os.path.join(features_dir, f"features_computed_{safe_method}_*.pkl")
@@ -214,7 +216,10 @@ def _persist_features_dataframe(output_df, method):
         except OSError:
             pass
 
-    output_path = os.path.join(features_dir, f"{safe_method}_features.pkl")
+    # Keep computed outputs separate from files loaded through the Features
+    # module.  Inference uses this location to distinguish pipeline detection
+    # from an explicitly loaded features dataframe.
+    output_path = os.path.join(pipeline_dir, f"{safe_method}_features.pkl")
     output_df.to_pickle(output_path)
     return output_path
 

--- a/webui/templates/4.3.0.compute_predictions.html
+++ b/webui/templates/4.3.0.compute_predictions.html
@@ -105,21 +105,12 @@
             <div class="grid grid-cols-1 gap-6">
                 <div>
                     <input id="existing-features-file" type="hidden" name="existing_features_file" value="{{ default_feature_file | default('') }}">
-                    <input id="features-source-mode" type="hidden" name="features_source_mode" value="{{ 'auto-detected' if default_feature_file else 'server-path' }}">
-                    <input id="features-server-file-path" type="hidden" name="features_server_file_path" value="">
+                    <input id="features-source-mode" type="hidden" name="features_source_mode" value="{{ default_features_source_mode or 'server-path' }}">
+                    <input id="features-server-file-path" type="hidden" name="features_server_file_path" value="{{ default_features_server_file_path | default('') }}">
                     <input id="file-upload-features" class="hidden" name="features_predict_file" type="file" />
                     <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1" data-field-help-static="1" data-help="Select the feature dataframe used as prediction input. It must contain a Features column whose rows are numeric feature vectors compatible with the selected trained model: feature count, order, preprocessing, and units must match the data used during training. The resulting Predictions column is attached to the selected or subsampled rows.">
                         Features Data <span class="text-red-500">*</span>
                     </label>
-                    <div
-                        id="features-loaded-status"
-                        class="mb-3 w-full rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-300 text-sm font-semibold px-3 py-2"
-                        {% if not default_feature_file %}style="display:none;"{% endif %}
-                    >
-                        Loaded:
-                        <span id="features-loaded-name">{{ default_feature_file | default('') }}</span>
-                        (detected from previous steps)
-                    </div>
                     <div
                         id="features-drop-zone"
                         class="custom-file-card drop-zone rounded-xl border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 transition-all cursor-pointer">
@@ -150,7 +141,7 @@
                             </div>
                         </div>
                         <div id="features-selected-server" class="mt-3 hidden rounded-md border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/30 px-3 py-2 text-xs text-green-700 dark:text-green-300">
-                            <span class="font-semibold text-green-800 dark:text-green-200" x-text="isLocalRuntime ? 'Selected local file:' : 'Selected server file:'"></span>
+                            <span class="font-semibold text-green-800 dark:text-green-200" x-text="featuresSourceMode === 'auto-detected' ? 'Pipeline detection:' : (isLocalRuntime ? 'Selected local file:' : 'Selected server file:')"></span>
                             <div class="mt-1 flex items-start justify-between gap-2">
                                 <span id="features-selected-server-path" class="block flex-1 font-mono break-all"></span>
                                 <button id="features-server-clear" type="button" class="inline-flex items-center justify-center rounded-md p-1 text-green-700 hover:text-red-600 dark:text-green-300 dark:hover:text-red-400" title="Remove selected server file" aria-label="Remove selected server file">
@@ -162,7 +153,7 @@
                     <div
                         id="features-not-loaded-status"
                         class="mt-2 w-full rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 text-amber-700 dark:text-amber-300 text-[10px] font-semibold px-2 py-1"
-                        {% if default_feature_file %}style="display:none;"{% endif %}
+                        {% if default_feature_file or default_features_server_file_path %}style="display:none;"{% endif %}
                     >
                         Not loaded: no features dataframe detected from previous steps.
                     </div>
@@ -638,11 +629,12 @@
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 <script>
 window.__inferenceInitialData = {
-    featuresSourceMode: {{ ('auto-detected' if default_feature_file else inference_default_source_mode) | tojson }},
+    featuresSourceMode: {{ (default_features_source_mode or inference_default_source_mode) | tojson }},
     assetsSourceMode: {{ inference_default_source_mode | tojson }},
     isLocalRuntime: !(window.__webuiRuntime || {}).is_server_runtime,
     hasDefaultFeature: {{ 'true' if default_feature_file else 'false' }},
     defaultFeatureFile: {{ (default_feature_file | default('')) | tojson }},
+    defaultFeaturesServerFilePath: {{ (default_features_server_file_path | default('')) | tojson }},
     defaultTrainedAssetsFolder: {{ (default_trained_assets_folder | default('')) | tojson }},
     defaultTrainedModelFile: {{ (default_trained_model_file | default('')) | tojson }},
     defaultTrainedScalerFile: {{ (default_trained_scaler_file | default('')) | tojson }}
@@ -654,7 +646,7 @@ function inferencePredictionsData() {
         allowServerSource: true,
         isLocalRuntime: window.__inferenceInitialData.isLocalRuntime,
         featuresSourceMode: window.__inferenceInitialData.featuresSourceMode,
-        featuresServerFilePath: '',
+        featuresServerFilePath: window.__inferenceInitialData.defaultFeaturesServerFilePath,
         assetsSourceMode: window.__inferenceInitialData.assetsSourceMode,
         assetsSelectionSourceMode: window.__inferenceInitialData.defaultTrainedModelFile ? 'auto-detected' : 'server-path',
         assetsServerFolderPath: window.__inferenceInitialData.defaultTrainedAssetsFolder,
@@ -805,7 +797,6 @@ function inferencePredictionsData() {
         const existingInput = byId("existing-features-file");
         const featuresSourceModeInput = byId("features-source-mode");
         const featuresServerFilePathInput = byId("features-server-file-path");
-        const loadedStatus = byId("features-loaded-status");
         const notLoadedStatus = byId("features-not-loaded-status");
         const localSummary = byId("features-selected-local");
         const localName = byId("features-selected-local-name");
@@ -819,7 +810,7 @@ function inferencePredictionsData() {
 
         if (
             !input || !existingInput || !featuresSourceModeInput || !featuresServerFilePathInput
-            || !loadedStatus || !notLoadedStatus || !localSummary || !localName
+            || !notLoadedStatus || !localSummary || !localName
             || !serverSummary || !serverPathEl || !uploadBtn || !serverBtn
         ) {
             return;
@@ -847,9 +838,8 @@ function inferencePredictionsData() {
             }
             if (hintEl) hintEl.textContent = "Using detected features dataframe from previous steps";
             localSummary.classList.add("hidden");
-            serverSummary.classList.add("hidden");
-            serverPathEl.textContent = "";
-            loadedStatus.style.display = existingName ? "" : "none";
+            serverPathEl.textContent = existingName;
+            serverSummary.classList.toggle("hidden", !existingName);
             notLoadedStatus.style.display = existingName ? "none" : "";
             if (state) {
                 state.featuresSourceMode = "auto-detected";
@@ -862,7 +852,6 @@ function inferencePredictionsData() {
             serverBtn.classList.remove(...inactiveClasses);
             if (hintEl) hintEl.textContent = "Drag and drop files or click to browse";
             localSummary.classList.add("hidden");
-            loadedStatus.style.display = "none";
             serverPathEl.textContent = serverPath;
             if (serverPath) {
                 serverSummary.classList.remove("hidden");
@@ -890,14 +879,12 @@ function inferencePredictionsData() {
         if (file) {
             localName.textContent = file.name;
             localSummary.classList.remove("hidden");
-            loadedStatus.style.display = "none";
             notLoadedStatus.style.display = "none";
             return;
         }
 
         localName.textContent = "";
         localSummary.classList.add("hidden");
-        loadedStatus.style.display = "none";
         notLoadedStatus.style.display = "";
     }
 


### PR DESCRIPTION
 ## Summary

  Fixes feature-source handling between the Features and Inference WebUI modules.

  Inference previously treated every dataframe stored in the Features data directory as a
  pipeline result. Therefore, files loaded through Features > Load data were incorrectly shown
  as Pipeline detection, instead of as a manually selected local/server file.

  ## Changes

  ### webui/compute_utils.py

  - Stores newly computed Features outputs in features/data/pipeline/.
  - Keeps calculated pipeline outputs separate from externally loaded feature files.

  ### webui/app.py

  - Detects pipeline files by their pipeline/ location.
  - Keeps pipeline and manually loaded feature candidates independent.
  - Inference now exposes:
      - The latest computed Features result through Pipeline detection.
      - The latest file loaded through Features > Load data through Local upload / Server file.

  - Preserves compatibility with completed Features jobs created before the new pipeline/
    folder layout.

  ### webui/templates/4.3.0.compute_predictions.html

  - Preloads the manually loaded Features file as a local/server selection instead of pipeline
    data.

  - Keeps the computed Features file available through Pipeline detection.
  - Allows switching between both sources.
  - Displays the pipeline-selected file using the same green selection card style as local/
    server uploads.