### PR TITLE
Fix inference training restore files

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -8056,6 +8056,61 @@ def _remember_module_restore_form(computation_type, form):
     }
 
 
+def _restorable_form_for_computation(
+    computation_type,
+    form,
+    file_paths=None,
+    *,
+    file_display_names=None,
+    job_id=None,
+    restore_dir=None,
+):
+    restore_form = dict(form or {})
+    key = str(computation_type or "").strip().lower()
+    if key != "inference_training":
+        return restore_form
+
+    paths = file_paths if isinstance(file_paths, dict) else {}
+    display_names = file_display_names if isinstance(file_display_names, dict) else {}
+    training_file_fields = {
+        "training_features_file": (
+            "training_features_source_mode",
+            "training_features_server_file_path",
+            "training_features_display_name",
+        ),
+        "training_parameters_file": (
+            "training_parameters_source_mode",
+            "training_parameters_server_file_path",
+            "training_parameters_display_name",
+        ),
+    }
+    for file_key, (mode_key, server_path_key, display_name_key) in training_file_fields.items():
+        staged_path = str(paths.get(file_key) or "").strip()
+        if not staged_path or not os.path.isfile(staged_path):
+            continue
+        display_name = str(display_names.get(file_key) or os.path.basename(staged_path)).strip()
+        restore_path = staged_path
+        if restore_dir:
+            try:
+                os.makedirs(restore_dir, exist_ok=True)
+                safe_name = secure_filename(display_name) or secure_filename(os.path.basename(staged_path)) or f"{file_key}.dat"
+                restore_name = f"inference_training_restore_{file_key}_{job_id or uuid.uuid4().hex}_{safe_name}"
+                restore_path = os.path.join(restore_dir, restore_name)
+                shutil.copy2(staged_path, restore_path)
+            except Exception as exc:
+                app.logger.warning(
+                    "Could not preserve %s for inference-training restore: %s",
+                    file_key,
+                    exc,
+                )
+                restore_path = staged_path
+        restore_form[mode_key] = "server-path"
+        restore_form[server_path_key] = restore_path
+        restore_form[display_name_key] = display_name
+
+    return restore_form
+
+
 def _pop_module_restore_form(computation_type):
     payload = session.pop("module_restore_form", None)
     if not isinstance(payload, dict):
@@ -17315,6 +17370,7 @@ def start_computation_redirect(computation_type):
 
     # If everything is OK, save/prepare the file(s)
     file_paths = {}
+    file_display_names = {}
     kernel_params_module_override = None
     prepared_features_df = None
     empirical_upload_paths = None
@@ -17990,6 +18046,14 @@ def start_computation_redirect(computation_type):
             "features_sim": "features_sim",
             "parameters": "parameters",
         }
+        inference_training_file_key_map = {
+            "training_features_file": "training_features_file",
+            "file-upload-x": "training_features_file",
+            "features_train_file": "training_features_file",
+            "training_parameters_file": "training_parameters_file",
+            "file-upload-y": "training_parameters_file",
+            "parameters_train_file": "training_parameters_file",
+        }
 
         for i, file_key in enumerate(files_obj):
             if computation_type == "inference" and file_key in {
@@ -18011,7 +18075,10 @@ def start_computation_redirect(computation_type):
             normalized_key = file_key
             if computation_type == "inference":
                 normalized_key = inference_file_key_map.get(file_key, file_key)
+            elif computation_type == "inference_training":
+                normalized_key = inference_training_file_key_map.get(file_key, file_key)
             file_paths[normalized_key] = file_path
+            file_display_names[normalized_key] = os.path.basename(str(file.filename).replace("\\", "/")) or os.path.basename(file_path)
         if computation_type in {"field_potential_proxy", "field_potential_kernel", "field_potential_meeg"}:
             server_file_keys = []
             redirect_target = "field_potential_kernel"
@@ -18193,11 +18260,13 @@ def start_computation_redirect(computation_type):
                 copied_path = os.path.join(module_upload_dir, copied_name)
                 shutil.copy2(inference_training_features_server_path, copied_path)
                 file_paths["training_features_file"] = copied_path
+                file_display_names["training_features_file"] = os.path.basename(inference_training_features_server_path)
             if inference_training_parameters_source_mode == "server-path" and inference_training_parameters_server_path:
                 copied_name = f"inference_training_parameters_{job_id}_{os.path.basename(inference_training_parameters_server_path)}"
                 copied_path = os.path.join(module_upload_dir, copied_name)
                 shutil.copy2(inference_training_parameters_server_path, copied_path)
                 file_paths["training_parameters_file"] = copied_path
+                file_display_names["training_parameters_file"] = os.path.basename(inference_training_parameters_server_path)
 
     data = request.form.to_dict() # Get parameters from form POST
     if computation_type == "features" and features_input_subsample_applied:
@@ -18282,7 +18351,14 @@ def start_computation_redirect(computation_type):
             "field_potential_kernel",
             "field_potential_meeg",
         } else "time",
-        "restore_form": dict(request.form),
+        "restore_form": _restorable_form_for_computation(
+            computation_type,
+            request.form,
+            file_paths,
+            file_display_names=file_display_names,
+            job_id=job_id,
+            restore_dir=module_upload_dir,
+        ),
     }
 
     # Submit the long-running task according to the computation type.

--- a/webui/templates/4.2.0.new_training.html
+++ b/webui/templates/4.2.0.new_training.html
@@ -203,6 +203,7 @@
                         <input id="training_features_file_input" name="training_features_file" type="file" class="hidden" />
                         <input id="training_features_file_source_mode" name="training_features_source_mode" type="hidden" value="server-path" />
                         <input id="training_features_file_server_path" name="training_features_server_file_path" type="hidden" value="" />
+                        <input id="training_features_file_display_name" name="training_features_display_name" type="hidden" value="" />
                         <div class="flex flex-wrap justify-center gap-2">
                             <button type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border border-primary bg-primary/10 text-primary font-semibold"
                                 @click.stop>
@@ -245,6 +246,7 @@
                         <input id="training_parameters_file_input" name="training_parameters_file" type="file" class="hidden" />
                         <input id="training_parameters_file_source_mode" name="training_parameters_source_mode" type="hidden" value="server-path" />
                         <input id="training_parameters_file_server_path" name="training_parameters_server_file_path" type="hidden" value="" />
+                        <input id="training_parameters_file_display_name" name="training_parameters_display_name" type="hidden" value="" />
                         <div class="flex flex-wrap justify-center gap-2">
                             <button type="button" class="custom-mode-server-btn px-3 py-1.5 text-xs rounded-lg border border-primary bg-primary/10 text-primary font-semibold"
                                 @click.stop>
@@ -623,6 +625,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const getModeInput = (field) => document.getElementById(`${field}_source_mode`);
     const getServerInput = (field) => document.getElementById(`${field}_server_path`);
     const getFileInput = (field) => document.getElementById(`${field}_input`);
+    const getDisplayInput = (field) => document.getElementById(`${field}_display_name`);
 
     const selectedInput = (field) => {
         const mode = String(getModeInput(field)?.value || "upload").trim().toLowerCase();
@@ -766,8 +769,10 @@ document.addEventListener("DOMContentLoaded", () => {
             const card = getCard(field);
             const serverPath = card ? card.querySelector('[data-role="server-path"]') : null;
             const serverSummary = card ? card.querySelector('[data-role="server-summary"]') : null;
+            const displayInput = getDisplayInput(field);
             if (serverPath) serverPath.textContent = "";
             if (serverSummary) serverSummary.classList.add("hidden");
+            if (displayInput) displayInput.value = "";
         }
         setModeVisuals(field, normalized);
         scheduleInputComparison();
@@ -780,26 +785,31 @@ document.addEventListener("DOMContentLoaded", () => {
         const localSummary = card.querySelector('[data-role="local-summary"]');
         const serverSummary = card.querySelector('[data-role="server-summary"]');
         const serverInput = getServerInput(field);
+        const displayInput = getDisplayInput(field);
         if (localName) localName.textContent = fileName || "";
         if (localSummary) localSummary.classList.toggle("hidden", !fileName);
         if (serverSummary) serverSummary.classList.add("hidden");
         if (serverInput) serverInput.value = "";
+        if (displayInput) displayInput.value = "";
         scheduleInputComparison();
     };
 
-    const setServerSelection = (field, pathValue) => {
+    const setServerSelection = (field, pathValue, displayValue = "") => {
         const card = getCard(field);
         const serverInput = getServerInput(field);
         if (!card || !serverInput) return;
         const cleanPath = String(pathValue || "").trim();
+        const cleanDisplay = String(displayValue || "").trim();
         serverInput.value = cleanPath;
         const serverPath = card.querySelector('[data-role="server-path"]');
         const serverSummary = card.querySelector('[data-role="server-summary"]');
         const localSummary = card.querySelector('[data-role="local-summary"]');
         const localName = card.querySelector('[data-role="local-name"]');
         const fileInput = getFileInput(field);
+        const displayInput = getDisplayInput(field);
 
-        if (serverPath) serverPath.textContent = cleanPath;
+        if (displayInput) displayInput.value = cleanDisplay;
+        if (serverPath) serverPath.textContent = cleanDisplay || cleanPath;
         if (serverSummary) serverSummary.classList.toggle("hidden", !cleanPath);
         if (localSummary) localSummary.classList.add("hidden");
         if (localName) localName.textContent = "";
@@ -912,17 +922,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const fileInput = getFileInput(field);
         const modeInput = getModeInput(field);
+        const serverInput = getServerInput(field);
+        const displayInput = getDisplayInput(field);
         const uploadBtn = card.querySelector(".custom-mode-upload-btn");
         const serverBtn = card.querySelector(".custom-mode-server-btn");
         const localClearBtn = card.querySelector('[data-role="local-clear"]');
         const serverClearBtn = card.querySelector('[data-role="server-clear"]');
-        if (!fileInput || !modeInput || !serverBtn) return;
+        if (!fileInput || !modeInput || !serverInput || !serverBtn) return;
 
         const hasServer = Boolean(String(getServerInput(field)?.value || "").trim());
         const hasLocal = Boolean(fileInput.files && fileInput.files[0]);
         if (hasServer && !hasLocal && allowServerSource) {
             setMode(field, "server-path");
-            setServerSelection(field, getServerInput(field).value);
+            setServerSelection(field, getServerInput(field).value, getDisplayInput(field)?.value || "");
         } else if (hasLocal) {
             setMode(field, "upload");
             setLocalSelection(field, fileInput.files[0].name);
@@ -971,6 +983,25 @@ document.addEventListener("DOMContentLoaded", () => {
             const file = fileInput.files && fileInput.files[0] ? fileInput.files[0] : null;
             setLocalSelection(field, file ? file.name : "");
         });
+
+        modeInput.addEventListener("change", () => {
+            setMode(field, modeInput.value);
+        });
+
+        const syncRestoredServerSelection = () => {
+            const restoredPath = String(serverInput.value || "").trim();
+            const restoredDisplay = String(displayInput?.value || "").trim();
+            if (restoredPath) {
+                setMode(field, "server-path");
+            }
+            setServerSelection(field, restoredPath, restoredDisplay);
+        };
+        serverInput.addEventListener("input", syncRestoredServerSelection);
+        serverInput.addEventListener("change", syncRestoredServerSelection);
+        if (displayInput) {
+            displayInput.addEventListener("input", syncRestoredServerSelection);
+            displayInput.addEventListener("change", syncRestoredServerSelection);
+        }
 
         ["dragenter", "dragover"].forEach((eventName) => {
             card.addEventListener(eventName, (event) => {


### PR DESCRIPTION
## Problem

When cancelling an Inference training job and returning with “Back to configuration”, the selected Features Data and Parameters Data files were not restored. The user had to select them again manually.

## Solution

The training files are now preserved as restorable copies before the job starts, and the restored form uses those internal paths to allow retrying without re-uploading. The UI also shows the original/short file name instead of the full temporary path.

## Changes

### `webui/app.py`

- Added a helper to build the `restore_form` for `inference_training`.
- Preserve restorable copies of Features and Parameters files outside the worker-cleaned file paths.
- Store display names so the UI can show `sim_X`, `sim_theta`, or the original file name.

### `webui/templates/4.2.0.new_training.html`

- Added hidden fields for the visible Features and Parameters file names.
- Updated the file-card JavaScript to restore selected training files.
- Display the short file name while keeping the temporary path as an internal value.