### PR TITLE
Webui load files features

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -4950,6 +4950,17 @@ def _build_folder_inspection_profiles(folder_entries, folder_summaries, filename
                     combined_candidates.append(token)
                 if folder_name not in candidate_field_folders[token]:
                     candidate_field_folders[token].append(folder_name)
+            for detail in ext_description.get("field_details") or []:
+                if not isinstance(detail, dict):
+                    continue
+                token = str(detail.get("field") or "").strip()
+                if not token:
+                    continue
+                if token not in seen_candidates:
+                    seen_candidates.add(token)
+                    combined_candidates.append(token)
+                if folder_name not in candidate_field_folders[token]:
+                    candidate_field_folders[token].append(folder_name)
 
         folder_profiles.append({
             "folder_name": folder_name,
@@ -5062,6 +5073,11 @@ def _aggregate_candidate_metadata_from_file_entries(folder_entries):
             field_name = str(detail.get("field") or "").strip()
             if not field_name:
                 continue
+            if field_name not in seen_candidates:
+                seen_candidates.add(field_name)
+                combined_candidates.append(field_name)
+            if folder_name not in candidate_field_folders[field_name]:
+                candidate_field_folders[field_name].append(folder_name)
             if field_name not in field_detail_map:
                 field_detail_map[field_name] = detail
             origin = str(detail.get("origin") or "").strip().lower()

--- a/webui/app.py
+++ b/webui/app.py
@@ -224,7 +224,7 @@ HAGEN_DEFAULTS = {
 CAVALLARI_DEFAULTS = {
     "tstop": 6000.0,
     "dt": 2 ** -4,
-    "local_num_threads": 1,
+    "local_num_threads": 64,
     "X": ["E", "I"],
     "N_X": [4000, 1000],
     "model": "iaf_bw_2003",

--- a/webui/app.py
+++ b/webui/app.py
@@ -224,7 +224,7 @@ HAGEN_DEFAULTS = {
 CAVALLARI_DEFAULTS = {
     "tstop": 6000.0,
     "dt": 2 ** -4,
-    "local_num_threads": 64,
+    "local_num_threads": 1,
     "X": ["E", "I"],
     "N_X": [4000, 1000],
     "model": "iaf_bw_2003",
@@ -6549,7 +6549,10 @@ def _build_parse_config_from_form(form):
         recording_type_value = recording_type_locator if recording_type_locator else recording_type
 
     # Array axis mapping
-    array_axes_enabled = str(form.get("parser_array_axes_enabled", "")).lower() in {"1", "on", "true", "yes"}
+    array_axes_enabled = (
+        data_source_kind != "pipeline"
+        and str(form.get("parser_array_axes_enabled", "")).lower() in {"1", "on", "true", "yes"}
+    )
     array_axes = None
     if array_axes_enabled:
         try:
@@ -17088,17 +17091,11 @@ def start_computation_redirect(computation_type):
                     return redirect(request.referrer or url_for('features_methods'))
             elif ch_names_source == "__autocomplete__":
                 try:
-                    array_axes_enabled = str(request.form.get("parser_array_axes_enabled", "")).lower() in {"1", "on", "true", "yes"}
-                    if array_axes_enabled:
-                        axis_channels_value = int(request.form.get("parser_axis_channels") or 0)
-                        if axis_channels_value < -1:
-                            raise ValueError("Channels axis must be greater than or equal to -1 (None).")
-                    else:
-                        _parse_nonnegative_int(
-                            request.form.get("parser_ch_names_autocomplete_axis"),
-                            default=0,
-                            field_name="Autocomplete channel axis",
-                        )
+                    _parse_nonnegative_int(
+                        request.form.get("parser_ch_names_autocomplete_axis"),
+                        default=0,
+                        field_name="Autocomplete channel axis",
+                    )
                 except Exception as exc:
                     flash(str(exc), 'error')
                     return redirect(request.referrer or url_for('features_methods'))

--- a/webui/static/js/simulation_cavallari.js
+++ b/webui/static/js/simulation_cavallari.js
@@ -53,7 +53,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const ncpiPresets = {
         tstop: 6000.0,
         dt: 0.0625,
-        local_num_threads: 64,
+        local_num_threads: 1,
         X: "['E', 'I']",
         N_X: "[4000, 1000]",
         model: "iaf_bw_2003",

--- a/webui/static/js/simulation_cavallari.js
+++ b/webui/static/js/simulation_cavallari.js
@@ -53,7 +53,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const ncpiPresets = {
         tstop: 6000.0,
         dt: 0.0625,
-        local_num_threads: 1,
+        local_num_threads: 64,
         X: "['E', 'I']",
         N_X: "[4000, 1000]",
         model: "iaf_bw_2003",

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -3877,6 +3877,7 @@ def custom_feature(sample, params):
                 const epochStep = this.parserEpochStepS || '5.0';
                 const segmentT0 = String(this.parserSegmentT0S || '').trim();
                 const segmentT1 = String(this.parserSegmentT1S || '').trim();
+                const includeArrayAxes = kind !== 'pipeline' && this.parserArrayAxesEnabled;
                 const toPyString = (value) => "'" + String(value || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'";
                 const chSource = String(this.parserChNamesSource || '').trim();
                 let chNamesExpr = 'None';
@@ -3889,11 +3890,11 @@ def custom_feature(sample, params):
                         ? `[${sensors.map((s) => toPyString(s)).join(', ')}]`
                         : '[]';
                 } else if (chSource === '__autocomplete__') {
-                    const axis = this.parserArrayAxesEnabled
+                    const axis = includeArrayAxes
                         ? Number.parseInt(String(this.parserAxisChannels || '0'), 10)
                         : 0;
                     const locatorExpr = dataLocator === '__self__' ? 'data' : `data.${dataLocator}`;
-                    if (this.parserArrayAxesEnabled && Number.isFinite(axis) && axis < 0) {
+                    if (includeArrayAxes && Number.isFinite(axis) && axis < 0) {
                         chNamesExpr = `['ch0']`;
                     } else {
                         const axisValue = Number.isFinite(axis) && axis >= 0 ? axis : 0;
@@ -3928,7 +3929,7 @@ def custom_feature(sample, params):
                         `        fs=${fsValue},`,
                         `        ch_names=${chNamesExpr},`,
                     ];
-                    if (this.parserArrayAxesEnabled) {
+                    if (includeArrayAxes) {
                         const axisItems = [];
                         const channelsAxis = Number.parseInt(String(this.parserAxisChannels || '-1'), 10);
                         if (Number.isFinite(channelsAxis) && channelsAxis >= 0) {
@@ -4065,7 +4066,7 @@ def custom_feature(sample, params):
                     `        fs=${fsValue},`,
                     `        ch_names=${chNamesExpr},`,
                 ];
-                if (this.parserArrayAxesEnabled) {
+                if (includeArrayAxes) {
                     const axisItems = [];
                     const channelsAxis = Number.parseInt(String(this.parserAxisChannels || '-1'), 10);
                     if (Number.isFinite(channelsAxis) && channelsAxis >= 0) {
@@ -4500,7 +4501,7 @@ def custom_feature(sample, params):
                     <input type="hidden" name="simulation_data_file_selections" :value="JSON.stringify(simulationDataFileSelections || {})">
                     <input type="hidden" name="parser_deep_scan_status" :value="parserDeepScanStatus">
                     <input type="hidden" name="parser_array_axes_enabled"
-                        :value="resolvedDataSourceKind() === 'new-empirical' ? '1' : (parserArrayAxesEnabled ? '1' : '0')">
+                        :value="resolvedDataSourceKind() === 'pipeline' ? '0' : (resolvedDataSourceKind() === 'new-empirical' ? '1' : (parserArrayAxesEnabled ? '1' : '0'))">
                     <input type="hidden" name="parser_filename_format" :value="String(parserFilenameFormat || '').trim()">
                 
 
@@ -5122,14 +5123,9 @@ def custom_feature(sample, params):
                                         </label>
                                     </div>
 
-                                    <!-- Array dimension mapping (pipeline/simulation) -->
-                                    <div class="rounded-lg border border-gray-200 dark:border-[#323b67] p-3 space-y-3">
-                                        <label x-show="resolvedDataSourceKind() === 'pipeline'" class="inline-flex items-center gap-2 text-sm text-[#34495E] dark:text-gray-300">
-                                            <input type="checkbox" x-model="parserArrayAxesEnabled" data-param="parser_array_axes_enabled"
-                                                class="rounded border-gray-300 text-primary focus:ring-primary/50">
-                                            Specify array dimension mapping
-                                        </label>
-                                        <div x-show="parserArrayAxesEnabled || resolvedDataSourceKind() === 'new-simulation'" class="space-y-2">
+                                    <!-- Array dimension mapping (external simulation data only) -->
+                                    <div x-show="resolvedDataSourceKind() === 'new-simulation'" class="rounded-lg border border-gray-200 dark:border-[#323b67] p-3 space-y-3">
+                                        <div class="space-y-2">
                                             <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
                                                 <label class="text-sm">
                                                     <span class="block text-xs text-gray-500 dark:text-gray-100 mb-1">Channels axis</span>

--- a/webui/templates/3.1.features_methods.html
+++ b/webui/templates/3.1.features_methods.html
@@ -1328,8 +1328,88 @@ def custom_feature(sample, params):
                     || key.startsWith('__file_token_');
             },
             parserCandidateFieldsWithoutFileExtracted() {
-                const fields = Array.isArray(this.parserInfo?.candidate_fields) ? this.parserInfo.candidate_fields : [];
-                return fields.filter((field) => !this.parserIsFileExtractedField(field));
+                return this.parserAllCandidateFields(this.parserInfo, { includeFileExtracted: false });
+            },
+            uniqueParserFields(items) {
+                const out = [];
+                const seen = new Set();
+                for (const item of Array.isArray(items) ? items : []) {
+                    const field = String(item || '').trim();
+                    if (!field || seen.has(field)) continue;
+                    seen.add(field);
+                    out.push(field);
+                }
+                return out;
+            },
+            parserSourceFieldDetails(sourcePayload = null) {
+                const payload = sourcePayload || this.parserInfo || {};
+                const rows = [];
+                const appendRows = (items) => {
+                    if (!Array.isArray(items)) return;
+                    for (const row of items) {
+                        if (row && typeof row === 'object') rows.push(row);
+                    }
+                };
+                const appendProfile = (profile) => {
+                    if (!profile || typeof profile !== 'object') return;
+                    appendRows(profile.field_details);
+                };
+                appendRows(payload.field_details);
+                appendRows(payload.data_file_field_details);
+                const profiles = Array.isArray(payload.extension_profiles) ? payload.extension_profiles : [];
+                for (const profile of profiles) appendProfile(profile);
+                const folderProfiles = Array.isArray(payload.folder_profiles) ? payload.folder_profiles : [];
+                for (const folderProfile of folderProfiles) {
+                    appendRows(folderProfile?.field_details);
+                    const nestedProfiles = Array.isArray(folderProfile?.extension_profiles) ? folderProfile.extension_profiles : [];
+                    for (const profile of nestedProfiles) appendProfile(profile);
+                }
+                return rows;
+            },
+            parserAllCandidateFields(sourcePayload = null, options = {}) {
+                const payload = sourcePayload || this.parserInfo || {};
+                const includeFileExtracted = options.includeFileExtracted !== false;
+                const out = [];
+                const seen = new Set();
+                const addField = (value) => {
+                    const field = String(value || '').trim();
+                    if (!field || seen.has(field)) return;
+                    if (!includeFileExtracted && this.parserIsFileExtractedField(field)) return;
+                    seen.add(field);
+                    out.push(field);
+                };
+                const addFields = (items) => {
+                    if (!Array.isArray(items)) return;
+                    for (const item of items) addField(item);
+                };
+                const addProfile = (profile) => {
+                    if (!profile || typeof profile !== 'object') return;
+                    addFields(profile.candidate_fields);
+                    for (const detail of Array.isArray(profile.field_details) ? profile.field_details : []) {
+                        addField(detail?.field);
+                    }
+                };
+                addFields(payload.candidate_fields);
+                addFields(payload.data_file_candidate_fields);
+                addFields(payload.dataframe_candidate_fields);
+                addFields(payload.data_file_dataframe_candidate_fields);
+                for (const detail of this.parserSourceFieldDetails(payload)) addField(detail?.field);
+                const profiles = Array.isArray(payload.extension_profiles) ? payload.extension_profiles : [];
+                for (const profile of profiles) addProfile(profile);
+                const folderProfiles = Array.isArray(payload.folder_profiles) ? payload.folder_profiles : [];
+                for (const folderProfile of folderProfiles) {
+                    addFields(folderProfile?.candidate_fields);
+                    for (const detail of Array.isArray(folderProfile?.field_details) ? folderProfile.field_details : []) {
+                        addField(detail?.field);
+                    }
+                    const nestedProfiles = Array.isArray(folderProfile?.extension_profiles) ? folderProfile.extension_profiles : [];
+                    for (const profile of nestedProfiles) addProfile(profile);
+                }
+                const defaults = payload.defaults && typeof payload.defaults === 'object' ? payload.defaults : {};
+                for (const key of ['data', 'fs', 'ch_names', 'recording_type', 'subject_id', 'group', 'species', 'condition']) {
+                    addField(defaults[key]);
+                }
+                return out;
             },
             parserFsSourceCandidates() {
                 const base = this.parserCandidateFieldsWithoutFileExtracted()
@@ -1343,9 +1423,7 @@ def custom_feature(sample, params):
                     out.push(field);
                 }
                 const samplingTokenField = this.parserFilenameTokenField('sampling_frequency');
-                const allCandidates = Array.isArray(this.parserInfo?.candidate_fields)
-                    ? this.parserInfo.candidate_fields.map((field) => String(field || '').trim())
-                    : [];
+                const allCandidates = this.parserAllCandidateFields(this.parserInfo, { includeFileExtracted: true });
                 if (
                     samplingTokenField &&
                     allCandidates.includes(samplingTokenField) &&
@@ -1389,9 +1467,7 @@ def custom_feature(sample, params):
             normalizeParserRecordingTypeSource() {
                 const source = String(this.parserRecordingTypeSource || '').trim();
                 const allowedSources = new Set(
-                    (Array.isArray(this.parserInfo?.candidate_fields) ? this.parserInfo.candidate_fields : [])
-                        .map((field) => String(field || '').trim())
-                        .filter((field) => field.length > 0)
+                    this.parserAllCandidateFields(this.parserInfo, { includeFileExtracted: true })
                 );
                 if (source === '__value__' || source === '__none__' || allowedSources.has(source)) return;
                 this.parserRecordingTypeSource = '__value__';
@@ -1554,12 +1630,15 @@ def custom_feature(sample, params):
                         .map((field) => String(field || '').trim())
                         .filter((field) => field.length > 0)
                     : [];
-                if (explicit.length > 0) return explicit;
-                return Array.isArray(this.parserInfo?.candidate_fields)
-                    ? this.parserInfo.candidate_fields
-                        .map((field) => String(field || '').trim())
+                const detailFields = Array.isArray(this.parserInfo?.data_file_field_details)
+                    ? this.parserInfo.data_file_field_details
+                        .map((item) => String(item?.field || '').trim())
                         .filter((field) => field.length > 0)
                     : [];
+                if (explicit.length > 0 || detailFields.length > 0) {
+                    return this.uniqueParserFields([...explicit, ...detailFields]);
+                }
+                return this.parserAllCandidateFields(this.parserInfo, { includeFileExtracted: true });
             },
             parserDataframeCandidateFields() {
                 const dataFileSourceType = String(this.parserInfo?.data_file_source_type || '').trim().toLowerCase();
@@ -1579,7 +1658,7 @@ def custom_feature(sample, params):
                     : [];
                 if (explicit.length > 0) return explicit;
 
-                const details = Array.isArray(this.parserInfo?.field_details) ? this.parserInfo.field_details : [];
+                const details = this.parserSourceFieldDetails(this.parserInfo);
                 const seen = new Set();
                 const fromDetails = [];
                 for (const item of details) {
@@ -2887,11 +2966,7 @@ def custom_feature(sample, params):
                     ? customCandidates
                         .map((field) => String(field || '').trim())
                         .filter((field) => field.length > 0 && !this.parserIsVirtualField(field))
-                    : (Array.isArray(this.parserInfo?.candidate_fields)
-                        ? this.parserInfo.candidate_fields
-                        .map((field) => String(field || '').trim())
-                        .filter((field) => field.length > 0 && !this.parserIsVirtualField(field))
-                        : []);
+                    : this.parserAllCandidateFields(this.parserInfo, { includeFileExtracted: false });
                 const keyList = Array.isArray(keywords)
                     ? keywords.map((value) => String(value || '').trim().toLowerCase()).filter((value) => value.length > 0)
                     : [];
@@ -2916,29 +2991,8 @@ def custom_feature(sample, params):
                 const defaults = payload?.defaults || {};
                 const sampleTableGuesses = this.inferPrimaryFieldsFromSampleTable(payload);
                 const dataCandidates = this.parserDataLocatorCandidates();
-                const collectFieldDetails = (sourcePayload) => {
-                    const rows = [];
-                    const appendRows = (items) => {
-                        if (!Array.isArray(items)) return;
-                        for (const row of items) rows.push(row);
-                    };
-                    appendRows(sourcePayload?.field_details);
-                    const profiles = Array.isArray(sourcePayload?.extension_profiles) ? sourcePayload.extension_profiles : [];
-                    for (const profile of profiles) appendRows(profile?.field_details);
-                    const folderProfiles = Array.isArray(sourcePayload?.folder_profiles) ? sourcePayload.folder_profiles : [];
-                    for (const folderProfile of folderProfiles) {
-                        appendRows(folderProfile?.field_details);
-                        const nestedProfiles = Array.isArray(folderProfile?.extension_profiles) ? folderProfile.extension_profiles : [];
-                        for (const profile of nestedProfiles) appendRows(profile?.field_details);
-                    }
-                    return rows;
-                };
-                const fieldDetails = collectFieldDetails(payload);
-                const candidateSet = new Set(
-                    (Array.isArray(payload?.candidate_fields) ? payload.candidate_fields : [])
-                        .map((field) => String(field || '').trim())
-                        .filter((field) => field.length > 0)
-                );
+                const fieldDetails = this.parserSourceFieldDetails(payload);
+                const candidateSet = new Set(this.parserAllCandidateFields(payload, { includeFileExtracted: true }));
                 const formatTokens = new Set(
                     (Array.isArray(payload?.filename_format_tokens) ? payload.filename_format_tokens : [])
                         .map((token) => String(token || '').trim().toLowerCase())
@@ -3285,7 +3339,8 @@ def custom_feature(sample, params):
                 
                 const channelSourceCandidates = this.parserChannelNameSourceCandidates();
                 const currentChLocator = String(this.parserChNamesLocator || '').trim();
-                const preferredCh = String(sampleTableGuesses.ch_names || '').trim() || String(defaults.ch_names || '').trim() || detailChannels || autoChannels || '';
+                const preferredChRaw = String(sampleTableGuesses.ch_names || '').trim() || String(defaults.ch_names || '').trim() || detailChannels || autoChannels || '';
+                const preferredCh = channelSourceCandidates.includes(preferredChRaw) ? preferredChRaw : '';
                 const chLocatorValid = currentChLocator && channelSourceCandidates.includes(currentChLocator);
                 if (!chLocatorValid) {
                     this.parserChNamesLocator = preferredCh;
@@ -3345,13 +3400,13 @@ def custom_feature(sample, params):
                 }
 
                 if (!this.parserPrimaryFieldsUserEdited) {
-                    if (['pipeline', 'new-simulation'].includes(this.resolvedDataSourceKind())) {
+                    if (String(this.parserChNamesLocator || '').trim()) {
+                        this.parserChNamesSource = this.parserChNamesLocator;
+                        this.parserSensorNames = '';
+                    } else if (['pipeline', 'new-simulation'].includes(this.resolvedDataSourceKind())) {
                         this.parserChNamesSource = '__manual__';
                         this.parserSensorNames = 'ch0';
                         this.parserChNamesLocator = '';
-                    } else if (String(this.parserChNamesLocator || '').trim()) {
-                        this.parserChNamesSource = this.parserChNamesLocator;
-                        this.parserSensorNames = '';
                     } else {
                         this.parserChNamesSource = '__autocomplete__';
                         this.parserChNamesLocator = '';
@@ -5206,7 +5261,7 @@ def custom_feature(sample, params):
                                             <select name="parser_recording_type_source" x-model="parserRecordingTypeSource" @change="onPipelineRecordingTypeSourceChange()"
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                                 <option value="__value__" :style="parserManualOptionStyle()">Custom (Select Recording type value)</option>
-                                                <template x-for="field in parserInfo.candidate_fields || []" :key="'pipeline-rec-type-source-'+field">
+                                                <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'pipeline-rec-type-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>
                                                 <option value="__none__" :style="parserNeutralOptionStyle()">None</option>
@@ -5262,7 +5317,7 @@ def custom_feature(sample, params):
                                                     <option value="__none__" :style="parserNeutralOptionStyle()">None</option>
                                                     <option value="__value__" :style="parserManualOptionStyle()">Custom value</option>
                                                     <option value="__file_id__" :style="parserVirtualOptionStyle()" x-text="parserFileIdOptionLabel()"></option>
-                                                    <template x-for="field in parserInfo.candidate_fields || []" :key="'meta-subject-source-'+field">
+                                                    <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'meta-subject-source-'+field">
                                                         <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                     </template>
                                                 </select>
@@ -5282,7 +5337,7 @@ def custom_feature(sample, params):
                                                     <option value="__none__" :style="parserNeutralOptionStyle()">None</option>
                                                     <option value="__value__" :style="parserManualOptionStyle()">Custom value</option>
                                                     <option value="__file_id__" :style="parserVirtualOptionStyle()" x-text="parserFileIdOptionLabel()"></option>
-                                                    <template x-for="field in parserInfo.candidate_fields || []" :key="'meta-group-source-'+field">
+                                                    <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'meta-group-source-'+field">
                                                         <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                     </template>
                                                 </select>
@@ -5302,7 +5357,7 @@ def custom_feature(sample, params):
                                                     <option value="__none__" :style="parserNeutralOptionStyle()">None</option>
                                                     <option value="__value__" :style="parserManualOptionStyle()">Custom value</option>
                                                     <option value="__file_id__" :style="parserVirtualOptionStyle()" x-text="parserFileIdOptionLabel()"></option>
-                                                    <template x-for="field in parserInfo.candidate_fields || []" :key="'meta-species-source-'+field">
+                                                    <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'meta-species-source-'+field">
                                                         <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                     </template>
                                                 </select>
@@ -5322,7 +5377,7 @@ def custom_feature(sample, params):
                                                     <option value="__none__" :style="parserNeutralOptionStyle()">None</option>
                                                     <option value="__value__" :style="parserManualOptionStyle()">Custom value</option>
                                                     <option value="__file_id__" :style="parserVirtualOptionStyle()" x-text="parserFileIdOptionLabel()"></option>
-                                                    <template x-for="field in parserInfo.candidate_fields || []" :key="'meta-condition-source-'+field">
+                                                    <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'meta-condition-source-'+field">
                                                         <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                     </template>
                                                 </select>
@@ -5516,7 +5571,7 @@ def custom_feature(sample, params):
                                             <select name="parser_recording_type_source" x-model="parserRecordingTypeSource" @change="onPipelineRecordingTypeSourceChange()"
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                                 <option value="__value__" :style="parserManualOptionStyle()">Custom (Select Recording type value)</option>
-                                                <template x-for="field in parserInfo.candidate_fields || []" :key="'rec-source-'+field">
+                                                <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'rec-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>
                                                 <option value="__none__" :style="parserNeutralOptionStyle()">None</option>
@@ -5548,7 +5603,7 @@ def custom_feature(sample, params):
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                                 <option value="" :style="parserNeutralOptionStyle()">None</option>
                                                 <option value="__file_id__" :style="parserVirtualOptionStyle()" x-text="parserFileIdOptionLabel()"></option>
-                                                <template x-for="field in parserInfo.candidate_fields || []" :key="'subject-id-source-'+field">
+                                                <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'subject-id-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>
                                             </select>
@@ -5559,7 +5614,7 @@ def custom_feature(sample, params):
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                                 <option value="" :style="parserNeutralOptionStyle()">None</option>
                                                 <option value="__file_id__" :style="parserVirtualOptionStyle()" x-text="parserFileIdOptionLabel()"></option>
-                                                <template x-for="field in parserInfo.candidate_fields || []" :key="'group-source-'+field">
+                                                <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'group-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>
                                             </select>
@@ -5570,7 +5625,7 @@ def custom_feature(sample, params):
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                                 <option value="" :style="parserNeutralOptionStyle()">None</option>
                                                 <option value="__file_id__" :style="parserVirtualOptionStyle()" x-text="parserFileIdOptionLabel()"></option>
-                                                <template x-for="field in parserInfo.candidate_fields || []" :key="'species-source-'+field">
+                                                <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'species-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>
                                             </select>
@@ -5581,7 +5636,7 @@ def custom_feature(sample, params):
                                                 class="w-full rounded-lg border-gray-300 dark:border-[#323b67] bg-white dark:bg-[#191e33] text-sm">
                                                 <option value="" :style="parserNeutralOptionStyle()">None</option>
                                                 <option value="__file_id__" :style="parserVirtualOptionStyle()" x-text="parserFileIdOptionLabel()"></option>
-                                                <template x-for="field in parserInfo.candidate_fields || []" :key="'condition-source-'+field">
+                                                <template x-for="field in parserAllCandidateFields(parserInfo, { includeFileExtracted: true })" :key="'condition-source-'+field">
                                                     <option :value="field" :style="parserFieldOptionStyle(field)" x-text="parserFieldLabel(field)"></option>
                                                 </template>
                                             </select>


### PR DESCRIPTION
  This PR fixes two WebUI issues in the Features workflow.

  ## Problems and causes

  1. **Features parser autodetection filled `Channel name source` incorrectly**
     - The WebUI only relied on `candidate_fields` in several places.
     - After parser changes, some valid fields, including channel-name fields, were only present
     in `field_details` / nested inspection profiles.
     - As a result, the UI could fall back to `Manual list` / `ch0` instead of selecting the
     detected channel-name field.

  2. **Simulation pipeline exposed array-axis controls in Features**
     - When continuing from Simulation -> Field Potential -> Features, array dimensions should
     already be known by the pipeline.
     - The UI still allowed manual array-axis selection and the backend could consume those
     values.

  ## Changes

  ### `webui/app.py`

  - Adds fields found in `field_details` to backend candidate metadata aggregation.
  - Ignores parser `array_axes` when `data_source_kind == "pipeline"`.
  - Simplifies pipeline channel-name autocomplete validation so it no longer depends on array-
  axis fields.

  ### `webui/templates/3.1.features_methods.html`

  - Adds unified parser candidate helpers that merge `candidate_fields`, `field_details`, nested
  profiles and defaults.
  - Uses the unified candidate list for parser defaults and metadata selectors.
  - Prevents fallback to `Manual list/ch0` when a valid channel-name locator exists.
  - Hides array-axis controls for `Continue simulation pipeline`.
  - Forces `parser_array_axes_enabled=0` for pipeline submissions.
  - Removes `array_axes` from the debug preview for pipeline inputs.

